### PR TITLE
fix: mobile nav overlay fully opaque

### DIFF
--- a/src/web/src/components/MobileNav.tsx
+++ b/src/web/src/components/MobileNav.tsx
@@ -32,7 +32,7 @@ export function MobileNav() {
 
       {/* Fullscreen overlay */}
       {open && (
-        <div className="fixed inset-0 z-40 flex flex-col bg-navy-950/95 backdrop-blur-sm">
+        <div className="fixed inset-0 z-40 flex flex-col bg-navy-950">
           {/* Close area — top right */}
           <div className="flex justify-end px-6 py-4">
             <button


### PR DESCRIPTION
## Summary
- Mobile burger menu overlay was semi-transparent (`bg-navy-950/95 backdrop-blur-sm`)
- iOS Safari rendering bug: backdrop-blur + opacity combo sometimes fails to render the background, leaving white text invisible on light sections
- Fix: fully opaque `bg-navy-950` — no blur needed at 95% opacity anyway

## Test plan
- [ ] Mobile: tap burger → menu items visible on ALL page sections (light + dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)