### PR TITLE
fix: mobile nav z-index above sticky header

### DIFF
--- a/src/web/src/components/MobileNav.tsx
+++ b/src/web/src/components/MobileNav.tsx
@@ -13,7 +13,7 @@ export function MobileNav() {
       <button
         onClick={() => setOpen((v) => !v)}
         aria-label={open ? "Menü schliessen" : "Menü öffnen"}
-        className="relative z-50 flex h-10 w-10 items-center justify-center rounded-lg text-navy-900 transition-colors hover:bg-navy-100"
+        className="relative z-[110] flex h-10 w-10 items-center justify-center rounded-lg text-navy-900 transition-colors hover:bg-navy-100"
       >
         <svg
           className="h-6 w-6 transition-transform duration-200"
@@ -32,7 +32,7 @@ export function MobileNav() {
 
       {/* Fullscreen overlay */}
       {open && (
-        <div className="fixed inset-0 z-40 flex flex-col bg-navy-950">
+        <div className="fixed inset-0 z-[100] flex flex-col bg-navy-950">
           {/* Close area — top right */}
           <div className="flex justify-end px-6 py-4">
             <button


### PR DESCRIPTION
## Summary
- Root cause: overlay `z-40` was behind sticky header `z-50` — page content covered menu text
- Fix: overlay `z-[100]`, hamburger button `z-[110]`

## Test plan
- [ ] Mobile: burger menu → Funktionen/Preise/Kontakt/Telefon all visible on every section

🤖 Generated with [Claude Code](https://claude.com/claude-code)