### PR TITLE
fix: configurable SIP callerId for demo SMS

### DIFF
--- a/docs/architecture/env_vars.md
+++ b/docs/architecture/env_vars.md
@@ -48,6 +48,9 @@ Diese Datei ist eine Liste aller benötigten Env Vars + Herkunft. Keine Werte ei
 ## SMS (Post-Call Verification)
 - SMS_HMAC_SECRET -> selbst generiert (Bitwarden), für HMAC-SHA256 Token in Korrektur-Links
 
+## Demo (SIP/MicroSIP)
+- DEMO_SIP_CALLER_ID -> Founder-Handynummer E.164 (z.B. +41791234567). Muss als Twilio Outgoing Caller ID verifiziert sein. Retell sieht diese Nummer als from_number → SMS landet auf dem Demo-Handy.
+
 ## App / Routing
 - APP_URL -> Canonical app URL (server-side, z.B. https://flowsight-mvp.vercel.app)
 - NEXT_PUBLIC_APP_URL -> Same, but client-accessible (NEXT_PUBLIC_ prefix)

--- a/src/web/app/api/demo/sip-twiml/route.ts
+++ b/src/web/app/api/demo/sip-twiml/route.ts
@@ -5,27 +5,33 @@
  * When MicroSIP makes an outbound call, Twilio hits this URL and connects
  * the call to the Brunner Voice Agent (Lisa).
  *
- * The callerId MUST be a Twilio number we own — required for SIP/Client calls.
+ * callerId controls what Retell sees as from_number → where the post-call SMS goes.
+ * - DEMO_SIP_CALLER_ID (env): Founder's personal number → SMS lands on demo phone.
+ *   Must be verified as Twilio Outgoing Caller ID.
+ * - Fallback: Twilio number on our account (no SMS on personal phone).
  */
 
-const CALLER_ID = "+41445053019"; // Twilio number on our account
-const BRUNNER_LISA = "+41445054818"; // Brunner Haustechnik Voice Agent
+const BRUNNER_LISA = "+41445054818"; // Brunner Haustechnik Voice Agent (Retell)
+const TWILIO_FALLBACK = "+41445053019"; // Twilio number on our account
 
-const twiml = `<?xml version="1.0" encoding="UTF-8"?>
+function buildTwiml(): string {
+  const callerId = process.env.DEMO_SIP_CALLER_ID || TWILIO_FALLBACK;
+  return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-  <Dial callerId="${CALLER_ID}">
+  <Dial callerId="${callerId}">
     <Number>${BRUNNER_LISA}</Number>
   </Dial>
 </Response>`;
+}
 
 export async function GET() {
-  return new Response(twiml, {
+  return new Response(buildTwiml(), {
     headers: { "Content-Type": "application/xml" },
   });
 }
 
 export async function POST() {
-  return new Response(twiml, {
+  return new Response(buildTwiml(), {
     headers: { "Content-Type": "application/xml" },
   });
 }


### PR DESCRIPTION
## Summary
- SIP TwiML route now reads `DEMO_SIP_CALLER_ID` env var as callerId
- Retell sees this number as `from_number` → post-call SMS lands on founder's demo phone
- Falls back to Twilio number `+41445053019` if env var not set

## Why
MicroSIP calls via SIP → Twilio sets callerId → Retell captures as `from_number` → SMS goes there. Previously hardcoded to Twilio number (can't receive SMS on a phone). Now configurable to founder's personal number for live demo screen-mirroring.

## Manual steps after merge
1. **Twilio Console**: Verify founder number as Outgoing Caller ID (Phone Numbers → Verified Caller IDs → Add)
2. **Vercel**: Set `DEMO_SIP_CALLER_ID=+41764458942` (Production + Preview)
3. Test: MicroSIP call → Lisa → SMS arrives on personal phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)