### PR TITLE
fix: guard SIP TwiML callerId — Twilio Error 13214

### DIFF
--- a/src/web/app/api/demo/sip-twiml/route.ts
+++ b/src/web/app/api/demo/sip-twiml/route.ts
@@ -9,29 +9,43 @@
  * - DEMO_SIP_CALLER_ID (env): Founder's personal number → SMS lands on demo phone.
  *   Must be verified as Twilio Outgoing Caller ID.
  * - Fallback: Twilio number on our account (no SMS on personal phone).
+ *
+ * Twilio Error 13214 = callerId missing or invalid. Guard: E.164 validation + fallback.
  */
 
 const BRUNNER_LISA = "+41445054818"; // Brunner Haustechnik Voice Agent (Retell)
-const TWILIO_FALLBACK = "+41445053019"; // Twilio number on our account
+const TWILIO_FALLBACK = "+41445053019"; // Twilio number on our account (always valid)
 
-function buildTwiml(): string {
-  const callerId = process.env.DEMO_SIP_CALLER_ID || TWILIO_FALLBACK;
-  return `<?xml version="1.0" encoding="UTF-8"?>
+const E164_RE = /^\+[1-9]\d{6,14}$/;
+
+function resolveCallerId(): string {
+  const raw = (process.env.DEMO_SIP_CALLER_ID ?? "").trim();
+  if (raw.length > 0 && E164_RE.test(raw)) return raw;
+  return TWILIO_FALLBACK;
+}
+
+export async function GET() {
+  const callerId = resolveCallerId();
+  const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Dial callerId="${callerId}">
     <Number>${BRUNNER_LISA}</Number>
   </Dial>
 </Response>`;
-}
-
-export async function GET() {
-  return new Response(buildTwiml(), {
+  return new Response(twiml, {
     headers: { "Content-Type": "application/xml" },
   });
 }
 
 export async function POST() {
-  return new Response(buildTwiml(), {
+  const callerId = resolveCallerId();
+  const twiml = `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Dial callerId="${callerId}">
+    <Number>${BRUNNER_LISA}</Number>
+  </Dial>
+</Response>`;
+  return new Response(twiml, {
     headers: { "Content-Type": "application/xml" },
   });
 }


### PR DESCRIPTION
## Summary
- E.164 regex validation on `DEMO_SIP_CALLER_ID` env var
- Guaranteed fallback to `+41445053019` (verified Twilio number) if env var empty/invalid
- Trim whitespace, reject malformed values
- Resolves callerId per-request (not at module init)

## Root cause
Twilio Error 13214 = callerId missing or invalid on `<Dial>`. Previous code used `||` fallback but env var may have been set to whitespace or non-E.164 value.

## Test plan
- [ ] MicroSIP call connects without 13214
- [ ] SMS delivered to +41764458942 (when env var set)
- [ ] Fallback works when env var unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)