### PR TITLE
fix: SIP TwiML dial target + SMS override in webhook

### DIFF
--- a/src/web/app/api/demo/sip-twiml/route.ts
+++ b/src/web/app/api/demo/sip-twiml/route.ts
@@ -2,50 +2,33 @@
  * GET/POST /api/demo/sip-twiml — Returns TwiML for SIP-originated demo calls.
  *
  * Used as Voice URL on the Twilio SIP Domain "flowsight-demo.sip.twilio.com".
- * When MicroSIP makes an outbound call, Twilio hits this URL and connects
- * the call to the Brunner Voice Agent (Lisa).
+ * MicroSIP → SIP Domain → this route → TwiML → Dial Twilio number →
+ * Twilio number's own voice config routes to Retell.
  *
- * callerId controls what Retell sees as from_number → where the post-call SMS goes.
- * - DEMO_SIP_CALLER_ID (env): Founder's personal number → SMS lands on demo phone.
- *   Must be verified as Twilio Outgoing Caller ID.
- * - Fallback: Twilio number on our account (no SMS on personal phone).
+ * callerId = TWILIO_NUMBER (voice-safe, verified, always valid).
+ * Number   = TWILIO_NUMBER (routes through Twilio number config → Retell).
  *
- * Twilio Error 13214 = callerId missing or invalid. Guard: E.164 validation + fallback.
+ * SMS target override is handled in the webhook via DEMO_SIP_CALLER_ID,
+ * NOT here. This route never uses DEMO_SIP_CALLER_ID.
  */
 
-const BRUNNER_LISA = "+41445054818"; // Brunner Haustechnik Voice Agent (Retell)
-const TWILIO_FALLBACK = "+41445053019"; // Twilio number on our account (always valid)
+const TWILIO_NUMBER = "+41445053019"; // Verified Twilio number (website number)
 
-const E164_RE = /^\+[1-9]\d{6,14}$/;
-
-function resolveCallerId(): string {
-  const raw = (process.env.DEMO_SIP_CALLER_ID ?? "").trim();
-  if (raw.length > 0 && E164_RE.test(raw)) return raw;
-  return TWILIO_FALLBACK;
-}
-
-export async function GET() {
-  const callerId = resolveCallerId();
-  const twiml = `<?xml version="1.0" encoding="UTF-8"?>
+const TWIML = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-  <Dial callerId="${callerId}">
-    <Number>${BRUNNER_LISA}</Number>
+  <Dial callerId="${TWILIO_NUMBER}">
+    <Number>${TWILIO_NUMBER}</Number>
   </Dial>
 </Response>`;
-  return new Response(twiml, {
+
+export async function GET() {
+  return new Response(TWIML, {
     headers: { "Content-Type": "application/xml" },
   });
 }
 
 export async function POST() {
-  const callerId = resolveCallerId();
-  const twiml = `<?xml version="1.0" encoding="UTF-8"?>
-<Response>
-  <Dial callerId="${callerId}">
-    <Number>${BRUNNER_LISA}</Number>
-  </Dial>
-</Response>`;
-  return new Response(twiml, {
+  return new Response(TWIML, {
     headers: { "Content-Type": "application/xml" },
   });
 }

--- a/src/web/app/api/retell/webhook/route.ts
+++ b/src/web/app/api/retell/webhook/route.ts
@@ -70,6 +70,19 @@ function normalizePlz(v: unknown): string | undefined {
   return match ? match[0] : undefined;
 }
 
+/**
+ * SIP demo calls arrive with from_number = Twilio number (+41445053019).
+ * If DEMO_SIP_CALLER_ID is set, redirect SMS to founder's personal phone.
+ */
+const TWILIO_SIP_NUMBER = "+41445053019";
+
+function resolveSmsTarget(callerPhone: string | undefined): string | undefined {
+  if (!callerPhone) return undefined;
+  const override = (process.env.DEMO_SIP_CALLER_ID ?? "").trim();
+  if (callerPhone === TWILIO_SIP_NUMBER && override.length > 0) return override;
+  return callerPhone;
+}
+
 /** Structured log line for Vercel Function Logs (no PII, machine-parseable). */
 function logDecision(fields: Record<string, unknown>) {
   console.log(JSON.stringify({ _tag: "retell_webhook", ...fields }));
@@ -426,10 +439,14 @@ export async function POST(req: Request) {
     }
 
     // ── Post-call SMS ─────────────────────────────────────────────
+    // SMS target override: SIP demo calls arrive with from_number = Twilio number.
+    // DEMO_SIP_CALLER_ID env var redirects SMS to founder's personal phone.
+    const smsTarget = resolveSmsTarget(callerPhone);
+
     let smsSent = false;
     let smsSid: string | undefined;
     let smsSkipReason: string | undefined;
-    if (!callerPhone) {
+    if (!smsTarget) {
       smsSkipReason = "no_caller_phone";
     } else {
       const smsConfig = await getTenantSmsConfig(tenantId);
@@ -445,7 +462,7 @@ export async function POST(req: Request) {
         const smsResult = await sendPostCallSms({
           caseId,
           createdAt: row.created_at,
-          callerPhone: callerPhone!,
+          callerPhone: smsTarget,
           smsSenderName: smsConfig.senderName,
           plz: plz!,
           city: city!,


### PR DESCRIPTION
## Summary
- **sip-twiml**: `<Dial callerId="+41445053019"><Number>+41445053019</Number></Dial>` — both Twilio number, voice-safe
- **webhook**: `resolveSmsTarget()` detects SIP demo calls (from_number = Twilio number) and redirects SMS to `DEMO_SIP_CALLER_ID` (founder phone)

## What changed
- `DEMO_SIP_CALLER_ID` removed from TwiML route entirely — personal number must NOT be Dial callerId
- SMS override logic moved to webhook where it belongs

## Test plan
- [ ] Twilio Request Inspector shows `<Number>+41445053019</Number>` + `callerId="+41445053019"`
- [ ] MicroSIP call connects to Lisa
- [ ] SMS arrives at +41764458942

🤖 Generated with [Claude Code](https://claude.com/claude-code)