### PR TITLE
fix: P0 demo — SMS token + PKCE magic link (Closes #28)

### DIFF
--- a/src/web/app/api/verify/[caseId]/attachments/route.ts
+++ b/src/web/app/api/verify/[caseId]/attachments/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { getServiceClient } from "@/src/lib/supabase/server";
-import { validateVerifyToken } from "@/src/lib/sms/verifySmsToken";
+import { validateVerifyToken, validateShortVerifyToken } from "@/src/lib/sms/verifySmsToken";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -36,8 +36,12 @@ async function validateHmac(
     .single();
 
   if (error || !row) return { valid: false, caseExists: false };
+  // Accept both full (64 hex) and short (16 hex) tokens — SMS sends short tokens
+  const isFullToken = token.length === 64;
   return {
-    valid: validateVerifyToken(caseId, row.created_at, token),
+    valid: isFullToken
+      ? validateVerifyToken(caseId, row.created_at, token)
+      : validateShortVerifyToken(caseId, row.created_at, token),
     caseExists: true,
   };
 }

--- a/src/web/app/auth/confirm/ConfirmAuth.tsx
+++ b/src/web/app/auth/confirm/ConfirmAuth.tsx
@@ -45,7 +45,15 @@ export function ConfirmAuth() {
       } else if (code) {
         const { error } = await supabase.auth.exchangeCodeForSession(code);
         success = !error;
-        if (error) setErrorMsg(error.message);
+        if (error) {
+          // PKCE verifier missing = link opened in different browser (in-app, etc.)
+          const isPkce = error.message?.toLowerCase().includes("code verifier");
+          setErrorMsg(
+            isPkce
+              ? "Link wurde in einem anderen Browser ge\u00f6ffnet. Bitte im selben Browser \u00f6ffnen, in dem der Login angefordert wurde \u2014 oder neuen Link anfordern."
+              : error.message,
+          );
+        }
       }
 
       if (success) {

--- a/src/web/src/lib/supabase/browser.ts
+++ b/src/web/src/lib/supabase/browser.ts
@@ -4,6 +4,10 @@ import { createBrowserClient } from "@supabase/ssr";
  * Browser Supabase client with cookie-based auth.
  * Use in Client Components for auth flows (login, session check).
  * NOT the same as getServiceClient() (server-only, bypasses RLS).
+ *
+ * flowType "implicit" sends token_hash in magic link emails instead of PKCE
+ * code. This avoids "PKCE code verifier not found" when the magic link is
+ * opened in a different browser / in-app browser (common on mobile).
  */
 export function getBrowserClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -15,5 +19,7 @@ export function getBrowserClient() {
     );
   }
 
-  return createBrowserClient(url, key);
+  return createBrowserClient(url, key, {
+    auth: { flowType: "implicit" },
+  });
 }


### PR DESCRIPTION
## Summary
Two P0 demo-killer bugs fixed. Both are minimal, surgical changes.

### Bug 1: SMS Link → "Invalid token" on photo upload
**Root cause:** `api/verify/[caseId]/attachments/route.ts` only called `validateVerifyToken()` (64-hex full token), but SMS sends **short 16-hex tokens** via `/v/[caseId]?t=<short>`. The main verify route already handled both — the attachments route didn't.

**Fix:** `validateHmac()` now checks token length and dispatches to the correct validator:
```typescript
const isFullToken = token.length === 64;
valid: isFullToken
  ? validateVerifyToken(caseId, row.created_at, token)
  : validateShortVerifyToken(caseId, row.created_at, token)
```

### Bug 2: Ops Magic Link → "PKCE code verifier not found"
**Root cause:** `createBrowserClient` from `@supabase/ssr` defaults to `flowType: 'pkce'`, which stores a code_verifier in the originating browser's cookies. When the magic link opens in a different browser (mobile email in-app browser, etc.), the verifier is missing → crash.

**Fix:** Set `flowType: 'implicit'` on the browser client. Magic links now use `token_hash` (verified server-side) instead of PKCE `code` (requires stored verifier). No cross-browser dependency.

**UX:** ConfirmAuth detects PKCE-specific errors and shows: "Link wurde in einem anderen Browser geoeffnet" + "Neuen Link anfordern" CTA (for any residual old-format PKCE links).

## Files changed (3)
- `src/web/app/api/verify/[caseId]/attachments/route.ts` — accept short tokens
- `src/web/src/lib/supabase/browser.ts` — `flowType: 'implicit'`
- `src/web/app/auth/confirm/ConfirmAuth.tsx` — PKCE error UX

## Test plan
- [ ] SMS link → photo upload → no "Invalid token", upload succeeds (3/3)
- [ ] Magic link login → works in same browser (3/3)
- [ ] Magic link login → opened in different browser → clear error + "Neuen Link anfordern"
- [ ] Full dry-run: Voice → SMS → Link → Photo → Ops Login → Case visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)