### PR TITLE
docs: update SSOT after PR #32 (voice STT, CoreBot verified)

### DIFF
--- a/docs/OPS_BOARD.md
+++ b/docs/OPS_BOARD.md
@@ -1,6 +1,6 @@
 # OPS Board — FlowSight Roadmap (SSOT)
 
-**Updated:** 2026-03-04 (PR #29: P0 Demo Fix — SMS Token + PKCE Magic Link)
+**Updated:** 2026-03-04 (PR #32: Voice STT Hardening — Closes #31)
 **Rule:** CC updates with every deliverable. Founder reviews weekly.
 **Einziger Task-Tracker.** Alle offenen Tasks leben hier.
 
@@ -8,15 +8,15 @@
 
 ## Snapshot
 
-- **Produkt:** 14 Module LIVE (Website, Voice, Wizard, Ops, Reviews, Morning Report, Entitlements, Email, Peoplefone, Sales Agent, Demo Booking, Demo-Strang, SMS Channel, **CoreBot** incl. Voice→STT)
+- **Produkt:** 14 Module LIVE (Website, Voice, Wizard, Ops, Reviews, Morning Report, Entitlements, Email, Peoplefone, Sales Agent, Demo Booking, Demo-Strang, SMS Channel, **CoreBot** incl. Voice→STT + Photo/Doc Attachments)
 - **Kunden:** Dörfler AG (Go-Live PARTIAL), Brunner HT (Demo-Tenant + SMS live)
 - **BLOCKER:** 0. Alle gelöst. ✅
-- **Shipped:** N17 ✅ N18 ✅ N19 ✅ N20 ✅ N21 ✅ N26 ✅ N27 ✅ N28 ✅ N30 ✅ N31 ✅ N32 ✅ PR#23 ✅ PR#27 ✅ PR#29 ✅
+- **Shipped:** N17 ✅ N18 ✅ N19 ✅ N20 ✅ N21 ✅ N26 ✅ N27 ✅ N28 ✅ N30 ✅ N31 ✅ N32 ✅ PR#23 ✅ PR#27 ✅ PR#29 ✅ PR#32 ✅
 - **Bugs gesamt:** 20+ Findings → alle Demo-kritischen fixed, 6 Backlog (N22/N23/N24/N29/N33)
 - **Ops Tooling:** `retell_sync.mjs` (API-Sync) + `onboard_tenant.mjs` (Tenant-Setup) + `prospect_pipeline.mjs` (Full-Stack Prospect Onboarding)
 - **CI/CD:** GitHub Actions (lint + build + Telegram notify). Branch Protection: PR required, 1 approval.
 - **Vercel Region:** Frankfurt (fra1)
-- **Phase:** Repo-Cleanup abgeschlossen. Kundenakquise-Phase. CoreBot live. Prospect Pipeline ready.
+- **Phase:** Repo-Cleanup abgeschlossen. Kundenakquise-Phase. CoreBot fully operational (STT + Attachments verified). Prospect Pipeline ready.
 
 ### How to Operate (Founder via Handy)
 
@@ -157,6 +157,7 @@
 | 2026-03-03 | **Demo-Kit + SIP Fix:** Complete demo toolkit (MicroSIP setup, audio proof, reset SQL, cheat sheet, Twilio diagnose+fix scripts). Fixed SIP auth mismatch (Error 32202) + missing callerId (Error 13214). Created `/api/demo/sip-twiml` route. Verified: Call connected, Lisa answers, 0 errors. | demo-kit/*, src/web/app/api/demo/sip-twiml/route.ts |
 | 2026-03-04 | **CoreBot Attachments (PR #27):** Photo/Document support in Telegram → GitHub Issue flow. Session persistence via Supabase Storage (L1 in-memory + L2 cross-instance). /ticket command, 5 attachments/ticket, 25MB limit, inline images in GitHub comments. | /api/telegram/webhook |
 | 2026-03-04 | **P0 Demo Fix (PR #29, Closes #28):** (1) SMS verify attachments route accepted only full 64-hex tokens, but SMS sends short 16-hex → "Invalid token". Fix: accept both. (2) PKCE magic link fails cross-browser (in-app browser). Fix: flowType: implicit → token_hash (no stored verifier needed). | attachments/route.ts, browser.ts, ConfirmAuth.tsx |
+| 2026-03-04 | **Voice STT Hardening (PR #32, Closes #31):** Discriminated union return type (TranscribeOk/TranscribeFail), 30s AbortController timeout, error categories (auth/quota/timeout/format/network/empty), OPENAI_API_KEY len+prefix logging, voice OGG fallback upload to corebot-files when STT fails, STT error reason in Telegram ACK. Root cause: wrong API key in Vercel env. | /api/telegram/webhook |
 
 **Erledigte Founder Blocks:** B (LinkedIn ✅), C (GBP ✅), F2 (Email Deliverability ✅), F5 (Voice Regression ✅), F6 (2FA Audit ✅), F10 (Billing Guard ✅)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # FlowSight — STATUS (Company SSOT)
 
-**Datum:** 2026-03-04 (PR #29: P0 Demo Fix — SMS Token + PKCE Magic Link)
+**Datum:** 2026-03-04 (PR #32: Voice STT Hardening + CoreBot Attachments verified)
 **Owner:** Founder + CC (Head Ops)
 
 ## Was ist FlowSight?
@@ -35,7 +35,7 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 | **Customer Websites** | LIVE ✅ | /kunden/[slug] — SSG template (12 sections, lightbox) |
 | **Review Engine** | LIVE ✅ | Manual button, review_sent_at, GOOGLE_REVIEW_URL |
 | **Entitlements** | LIVE ✅ | hasModule() — per-tenant module gating |
-| **CoreBot** | LIVE ✅ | Telegram → GitHub Issues (auto-classify, /status, ACK, **Voice→STT→Issue**, **Photo/Doc Attachments** via Supabase Storage) |
+| **CoreBot** | LIVE ✅ | Telegram → GitHub Issues (auto-classify, /status, ACK, **Voice→STT→Issue** with hardened error reporting, **Photo/Doc Attachments** via Supabase Storage, **/ticket** command, cross-instance sessions) |
 | **Demo-Strang** | LIVE ✅ | /brunner-haustechnik — High-End Demo (6-Service Grid, 30 Bilder, KI-Teamfoto, Voice Agent Intake+Info) |
 
 ## Kunden
@@ -47,11 +47,12 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 
 ## Aktueller Stand
 
-- **14 Module LIVE.** CoreBot now with Voice→STT→Issue + Photo/Doc Attachments (Supabase Storage cross-instance sessions).
-- **P0 Demo-Fixes (04.03.):** SMS Verify Token (Attachments-Route akzeptierte nur Full-Token, SMS sendet Short-Token) + PKCE Magic Link (flowType: implicit, cross-browser). PR #27 + #29.
+- **14 Module LIVE.** CoreBot now with Voice→STT→Issue (hardened: 30s timeout, error categories, voice fallback) + Photo/Doc Attachments (Supabase Storage cross-instance sessions) + /ticket command.
+- **Voice STT Fix (04.03.):** OpenAI API Key issue diagnosed via new error reporting (PR #32). Hardened: discriminated union return type, AbortController timeout, error categories (auth/quota/timeout/format/network/empty), voice OGG fallback upload when STT fails. Founder-confirmed working.
+- **CoreBot Attachments (04.03.):** Photo/Doc upload + session persistence (L1 in-memory + L2 Supabase Storage) verified end-to-end. PR #27.
+- **P0 Demo-Fixes (04.03.):** SMS Verify Token (short 16-hex accepted) + PKCE Magic Link (flowType: implicit). PR #29.
 - **E2E Test 02.03.:** Voice ✅, E-Mail ✅, SMS ✅ (Twilio delivered, BrunnerHT Sender).
-- **Demo-Feedback 02.03.:** Erste Demo mit Peter. Website/Wizard/Dashboard/Reviews top. Voice-Audio-Routing + SMS-UX + Mobile-Login als Bugs erfasst (N30-N32).
-- **Erledigt:** N17-N21 ✅, N26-N28 ✅, N30-N32 ✅, Issue #28 ✅ — 20+ Bugs fixed
+- **Erledigt:** N17-N21 ✅, N26-N28 ✅, N30-N32 ✅, Issue #28 ✅, Issue #31 ✅ — 20+ Bugs fixed
 - **BLOCKER:** Keine. Go-Live möglich.
 - **Vercel Region:** Frankfurt (fra1) — näher an Supabase + CH-Usern.
 - **Ops Tooling:** `retell_sync.mjs` (Retell API Sync), `onboard_tenant.mjs` (Tenant Setup), `prospect_pipeline.mjs` (Full-Stack Prospect Onboarding, ~15min/prospect)

--- a/docs/business_briefing.md
+++ b/docs/business_briefing.md
@@ -2,7 +2,7 @@
 
 > Dieses Dokument ist der komplette Kontext für ChatGPT, Claude und externe Partner.
 > Copy-paste als System-Prompt oder ersten Message. Deckt Business, Produkt, Technik und Strategie ab.
-> Letzte Aktualisierung: 2026-03-01
+> Letzte Aktualisierung: 2026-03-04
 
 ---
 
@@ -107,9 +107,24 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 - **Sales Lead:** Voice Agent Lead → E-Mail an Founder
 - Provider: Resend (Transaktional, SPF/DKIM/DMARC verifiziert)
 
-### 3.8 Entitlements
+### 3.8 SMS Channel
+- Post-call SMS mit Korrekturlink an Melder (Twilio alphanumeric sender, z.B. "BrunnerHT")
+- Kurzlink `/v/[caseId]?t=<16hex>` (~85 Zeichen), HMAC-gesichert
+- Foto-Upload via Verify-Seite (Supabase Storage)
+- Akzeptiert sowohl Full-Token (64-hex) als auch Short-Token (16-hex)
+
+### 3.9 CoreBot (Ops-Assistent)
+- Telegram Bot → GitHub Issues (automatische Klassifizierung: type + domain Labels)
+- **Voice→STT→Issue:** Sprachnachricht → OpenAI Whisper Transkription → GitHub Issue
+- **Photo/Doc Attachments:** Fotos + Dokumente an Tickets anhängen (Supabase Storage, inline in GitHub)
+- **/ticket Befehl:** Ticket ohne Sprachnachricht erstellen + Anhänge innerhalb 120s
+- **/status Befehl:** Übersicht offener GitHub Issues
+- Session-Persistenz: L1 In-Memory + L2 Supabase Storage (cross-instance, serverless-safe)
+- Limiten: max 5 Anhänge/Ticket, 25MB total, 120s Session-Fenster
+
+### 3.10 Entitlements
 - Per-Tenant Module Gating via hasModule() Funktion
-- Module: voice, wizard, ops, reviews, morning_report
+- Module: voice, wizard, ops, reviews, morning_report, sms
 - Konfiguration in Supabase tenants-Tabelle (modules JSONB Array)
 
 ---
@@ -185,7 +200,7 @@ NACH ERLEDIGUNG:
 | Kunde | Status | Module | URL |
 |-------|--------|--------|-----|
 | **Dörfler AG** (Oberrieden) | Go-Live PARTIAL (3/4 PASS) | voice, wizard, ops, reviews | flowsight.ch/kunden/doerfler-ag |
-| **Brunner Haustechnik AG** (Thalwil) | DEMO (fiktiv) | voice, wizard, ops, reviews | flowsight.ch/brunner-haustechnik |
+| **Brunner Haustechnik AG** (Thalwil) | DEMO (fiktiv) | voice, wizard, ops, reviews, sms | flowsight.ch/brunner-haustechnik |
 
 ### Dörfler AG — Erster Referenzkunde
 - Sanitär/Heizung seit 1926, Oberrieden ZH
@@ -261,12 +276,10 @@ NACH ERLEDIGUNG:
 
 ## 10. Bekannte Limitationen & offene Punkte
 
-- **Kein Kalender-Sync** — Termine werden manuell im Dashboard eingetragen
+- **Kein Kalender-Sync** — Termine werden manuell im Dashboard eingetragen (N3)
 - **Review-Anfrage manuell** — kein Auto-Trigger nach Fall-Abschluss
 - **Terminerinnerung fehlt** — 24h-Reminder an Melder geplant (N15)
 - **Kunden-Historie fehlt** — kein Matching bei wiederholtem Kontakt (N16)
-- **Voice E-Mail auf Englisch** — Retell Analysis Output noch nicht auf Deutsch (N10)
-- **Aktionen im Dashboard umständlich** — Save→Close→Reopen nötig für Termin/Review (Bug N12)
 - **Vercel Hobby-Limits** — 1 Log pro Invocation, keine Cron-Jobs
 - **Supabase Free** — keine automatischen Backups
 


### PR DESCRIPTION
## Summary
- **STATUS.md:** Updated date, CoreBot description (STT hardening + /ticket), Aktueller Stand reflects PR #32 + founder-verified STT + attachments
- **OPS_BOARD.md:** Added PR #32 to Shipped list + Completed archive, updated snapshot (CoreBot fully operational)
- **business_briefing.md:** Added SMS Channel (3.8) + CoreBot (3.9) module sections, renumbered Entitlements to 3.10, cleaned up Section 10 (removed fixed bugs N10/N12), updated Brunner modules, date bump to 03-04

## Test plan
- [ ] Docs-only change, no code impact
- [ ] CI passes (lint + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)