### PR TITLE
fix: silent closing nodes + deterministic ß→ss in webhook

### DIFF
--- a/retell/agent_ids.json
+++ b/retell/agent_ids.json
@@ -4,13 +4,13 @@
     "de_flow_id": "conversation_flow_e2c3a7cec528",
     "intl_agent_id": "agent_01fad4217f8b0697f0c26c69d5",
     "intl_flow_id": "conversation_flow_3c7d423226a9",
-    "last_synced": "2026-03-04T13:42:14.853Z"
+    "last_synced": "2026-03-04T14:12:45.477Z"
   },
   "doerfler": {
     "de_agent_id": "agent_d7dfe45ab444e1370e836c3e0f",
     "de_flow_id": "conversation_flow_8170ad3c2ca9",
     "intl_agent_id": "agent_fb4b956eec31db9c591880fdeb",
     "intl_flow_id": "conversation_flow_608d542979bb",
-    "last_synced": "2026-03-04T13:42:24.393Z"
+    "last_synced": "2026-03-04T14:12:52.997Z"
   }
 }

--- a/retell/exports/brunner_agent.json
+++ b/retell/exports/brunner_agent.json
@@ -236,7 +236,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Sage GENAU EINMAL: 'Vielen Dank, ich habe alles aufgenommen. Sie erhalten gleich eine SMS — dort können Sie die Daten prüfen und Fotos hochladen. Unser Team meldet sich schnellstmöglich. Ich wünsche Ihnen alles Gute, auf Wiederhören!' KEINE Zusammenfassung der Daten. KEINE Rückfragen. Wenn der Anrufer danach antwortet (Tschüss, Danke, etc.): SCHWEIGE KOMPLETT. Sage NICHTS mehr. Das Gespräch ist beendet."
+          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
         },
         "name": "Closing Intake",
         "edges": [],
@@ -258,7 +258,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Sage GENAU EINMAL: 'Sehr gerne! Falls Sie ein Anliegen haben, wir sind jederzeit für Sie da. Schönen Tag noch, auf Wiederhören!' Wenn der Anrufer danach antwortet (Tschüss, Danke, etc.): SCHWEIGE KOMPLETT. Sage NICHTS mehr. Das Gespräch ist beendet."
+          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
         },
         "name": "Closing Info",
         "edges": [],
@@ -280,7 +280,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Sage dem Anrufer auf Hochdeutsch: 'Vielen Dank für Ihren Anruf. Dafür sind wir leider nicht die richtigen Ansprechpartner. Bei Sanitär- oder Heizungsanliegen sind wir aber jederzeit gerne für Sie da. Ich wünsche Ihnen alles Gute. Auf Wiederhören!' Du sprichst ausschliesslich Deutsch."
+          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
         },
         "name": "Out-of-scope Closing",
         "edges": [],

--- a/retell/exports/brunner_agent_intl.json
+++ b/retell/exports/brunner_agent_intl.json
@@ -209,7 +209,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Tell the caller IN THEIR LANGUAGE the following (adapt naturally, do not read word by word): EN: 'Thank you, I've recorded everything. You'll receive an SMS shortly where you can verify the details, make corrections if needed, and upload photos of the damage — this helps our technician prepare. Our team will get back to you as soon as possible. Take care! Goodbye!' / FR: 'Merci, j'ai tout noté. Vous recevrez bientôt un SMS — vous pourrez y vérifier les données, les corriger si nécessaire et envoyer des photos du dégât. Notre équipe vous recontactera rapidement. Bonne journée ! Au revoir !' / IT: 'Grazie, ho registrato tutto. Riceverà presto un SMS — potrà verificare i dati, correggerli se necessario e caricare foto del danno. Il nostro team la ricontatterà al più presto. Buona giornata! Arrivederci!' No summary. No follow-up questions. Say ONLY this closing. If the caller says goodbye (thanks, bye, etc.), do NOT respond again — the call is over."
+          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
         },
         "name": "Closing Intake",
         "edges": [],
@@ -231,7 +231,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Tell the caller IN THEIR LANGUAGE: 'My pleasure! If you ever need anything in the future, we're always here for you. I wish you a wonderful day. Goodbye!' / 'Avec plaisir ! N'hésitez pas à nous rappeler. Bonne journée ! Au revoir !' / 'Con piacere! Non esiti a richiamarci. Buona giornata! Arrivederci!' No follow-up questions. Say ONLY this and NOTHING else. If the caller says goodbye, do NOT respond again — the call is over."
+          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
         },
         "name": "Closing Info",
         "edges": [],
@@ -253,7 +253,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Tell the caller IN THEIR LANGUAGE: 'Thank you, but this is not something we handle. We help with plumbing and heating. Goodbye!' No follow-up questions. Say ONLY this and NOTHING else."
+          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
         },
         "name": "Out-of-scope Closing",
         "edges": [],

--- a/retell/exports/doerfler_agent.json
+++ b/retell/exports/doerfler_agent.json
@@ -214,7 +214,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Sage dem Anrufer auf Hochdeutsch sinngemäss: 'Vielen Dank, ich habe alles aufgenommen. Sie erhalten gleich eine SMS auf Ihr Handy — dort können Sie die erfassten Daten prüfen, bei Bedarf korrigieren und auch Fotos vom Schaden hochladen. Das hilft unserem Techniker, sich optimal vorzubereiten. Die Dörfler AG meldet sich bei Ihnen. Ich wünsche Ihnen alles Gute. Auf Wiederhören!' Keine erneute Zusammenfassung. Keine Rückfragen. Sage NUR diesen Abschluss und NICHTS weiter danach. Wenn der Anrufer sich verabschiedet (Tschüss, Danke, Tschau, Auf Wiederhören), antworte NICHT nochmals — das Gespräch ist beendet."
+          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
         },
         "name": "Closing Node",
         "edges": [],
@@ -236,7 +236,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Sage dem Anrufer auf Hochdeutsch: Danke. Dafür sind wir nicht zuständig. Bei Sanitär- oder Heizungsanliegen helfe ich gerne. Du sprichst ausschliesslich Deutsch."
+          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
         },
         "name": "Out-of-scope Closing",
         "edges": [],

--- a/retell/exports/doerfler_agent_intl.json
+++ b/retell/exports/doerfler_agent_intl.json
@@ -187,7 +187,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Tell the caller IN THEIR LANGUAGE (adapt naturally): EN: 'Thank you, I've recorded everything. You'll receive an SMS shortly where you can verify the details, make corrections if needed, and upload photos of the damage — this helps our technician prepare. Dörfler AG will get back to you soon. Take care! Goodbye!' / FR: 'Merci, j'ai tout noté. Vous recevrez bientôt un SMS — vous pourrez y vérifier les données, les corriger et envoyer des photos du dégât. Dörfler AG vous recontactera rapidement. Bonne journée ! Au revoir !' / IT: 'Grazie, ho registrato tutto. Riceverà presto un SMS — potrà verificare i dati, correggerli e caricare foto del danno. Dörfler AG la ricontatterà presto. Buona giornata! Arrivederci!' No summary. No follow-up questions. Say ONLY this closing. If the caller says goodbye, do NOT respond again — the call is over."
+          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
         },
         "name": "Closing Node",
         "edges": [],
@@ -209,7 +209,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Tell the caller IN THEIR LANGUAGE: 'Thank you, but this is not something we handle. We help with plumbing and heating. Goodbye!' No follow-up questions. Say ONLY this and NOTHING else."
+          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
         },
         "name": "Out-of-scope Closing",
         "edges": [],

--- a/src/web/app/api/retell/webhook/route.ts
+++ b/src/web/app/api/retell/webhook/route.ts
@@ -63,6 +63,11 @@ function nonEmptyStr(v: unknown): string | undefined {
   return undefined;
 }
 
+/** Swiss German: replace ß with ss (e.g. "Straße" → "Strasse"). */
+function deCH(v: string | undefined): string | undefined {
+  return v?.replace(/ß/g, "ss");
+}
+
 /** Extract exactly 4 consecutive digits from any PLZ format (e.g. "PLZ 8800", "8800 Thalwil", "acht-acht-null-null"). */
 function normalizePlz(v: unknown): string | undefined {
   if (typeof v !== "string") return undefined;
@@ -245,17 +250,18 @@ export async function POST(req: Request) {
 
   // Structured fields — read from whichever path had data
   const plz = normalizePlz(extractedData.plz) ?? normalizePlz(extractedData.postal_code) ?? normalizePlz(extractedData.zip);
-  const city = nonEmptyStr(extractedData.city ?? extractedData.ort ?? extractedData.stadt);
-  const street = nonEmptyStr(extractedData.street ?? extractedData.strasse);
+  const city = deCH(nonEmptyStr(extractedData.city ?? extractedData.ort ?? extractedData.stadt));
+  const street = deCH(nonEmptyStr(extractedData.street ?? extractedData.strasse));
   const houseNumber = nonEmptyStr(extractedData.house_number ?? extractedData.hausnummer);
   const category = nonEmptyStr(extractedData.category ?? extractedData.kategorie);
   const urgencyRaw = nonEmptyStr(extractedData.urgency ?? extractedData.dringlichkeit);
   // Priority: custom extracted field (German) → transcript (raw conversation)
   // NOTE: call_analysis.call_summary is SKIPPED — Retell generates it in English
   // regardless of agent language, which produces English text in German emails.
-  const description =
+  const description = deCH(
     nonEmptyStr(extractedData.description ?? extractedData.beschreibung) ??
-    nonEmptyStr(call?.transcript);
+    nonEmptyStr(call?.transcript),
+  );
 
   // ── Strict validation — NO SILENT DEFAULTS ─────────────────────────
   const missing: string[] = [];


### PR DESCRIPTION
## Summary
- **Loop fix v2:** Previous fix (PR #36, `skip_response_edge`) was insufficient — the Main Node speaks the farewell BEFORE transitioning to the Closing Node, which then repeats it. Fix: All closing node instructions changed to "Say NOTHING — goodbye was already spoken." Now: Main Node farewell → silent Closing Node → `skip_response_edge` → end-call.
- **ß→ss fix v2:** GPT-4.1 ignores analysis field description hints. Fix: deterministic `deCH()` helper in `webhook/route.ts` that does `.replace(/ß/g, "ss")` on `street`, `city`, and `description` before Supabase insert. Code doesn't hallucinate.
- All 4 agent pairs synced + published.

## Test plan
- [ ] Call 044 505 30 19, complete intake → Lisa says farewell ONCE, no repeat
- [ ] Say "Danke" after farewell → call should end cleanly
- [ ] Check case in Dashboard → street uses "ss" not "ß"
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)