### PR TITLE
feat: reframe pricing + remove buzzwords

### DIFF
--- a/docs/runbooks/twilio_a2p_registration.md
+++ b/docs/runbooks/twilio_a2p_registration.md
@@ -1,0 +1,168 @@
+# Twilio A2P Registration — Step-by-Step
+
+**Ziel:** Alle SMS (Schadensbestätigung, Demo-Booking, Reminder) spam-sicher machen.
+**Dauer:** ~30 Min Setup, 1-5 Werktage Genehmigung durch Twilio/Carrier.
+**Ergebnis:** Alphanumerische Sender ("BrunnerHT", "Doerfler" etc.) werden als verifizierter Business-Traffic zugestellt.
+
+---
+
+## Voraussetzungen
+
+- Twilio Account (haben wir: TWILIO_ACCOUNT_SID in Vercel Env)
+- Firmenadresse (FlowSight, deine Adresse oder GmbH/AG-Adresse)
+- CH-Handynummer als Kontakt
+
+---
+
+## Schritt 1: Messaging Service erstellen
+
+1. Twilio Console > **Messaging** > **Services** > **Create Messaging Service**
+2. Werte eintragen:
+
+| Feld | Wert |
+|------|------|
+| **Friendly Name** | `FlowSight SMS` |
+| **Use case** | "Notifications" (nicht Marketing!) |
+
+3. **Sender Pool** > "Add Senders":
+   - Typ: **Alpha Sender** > Add: `FlowSight` (max 11 Zeichen)
+   - Zusätzlich die bestehende Twilio-Nummer (+41 44 505 48 18) als Fallback hinzufügen
+4. **Integration** > Incoming Messages: "Drop the message" (wir empfangen keine SMS)
+5. **Compliance Info** > ausfüllen (siehe Schritt 2)
+6. **Save** > Messaging Service SID notieren (Format: `MGxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`)
+
+---
+
+## Schritt 2: Brand Registration (Trust Hub)
+
+1. Twilio Console > **Trust Hub** > **Customer Profiles** > **Create new Customer Profile**
+2. **Business Profile** ausfüllen:
+
+| Feld | Wert |
+|------|------|
+| **Business Name** | FlowSight (oder dein eingetragener Firmenname) |
+| **Business Type** | Sole Proprietorship / Private Company (je nach Rechtsform) |
+| **Business Registration Number** | CHE-Nummer falls vorhanden, sonst leer |
+| **Business Industry** | Technology |
+| **Website** | https://flowsight.ch |
+| **Region of Operation** | Europe > Switzerland |
+| **Business Address** | Deine Geschäftsadresse |
+
+3. **Authorized Representative** (= du):
+
+| Feld | Wert |
+|------|------|
+| **First Name** | Gunnar |
+| **Last Name** | Wende |
+| **Email** | deine Business-E-Mail |
+| **Phone** | deine Handynummer (+41...) |
+| **Title** | Founder / CEO |
+
+4. **Submit** > Status wird "Pending Review"
+
+---
+
+## Schritt 3: A2P Campaign Registration
+
+> Erst möglich nachdem Brand genehmigt ist (1-3 Werktage).
+
+1. Twilio Console > **Messaging** > **Services** > **FlowSight SMS** > **Compliance**
+2. Oder: **Trust Hub** > **A2P Messaging** > **Register a Campaign**
+3. Campaign ausfüllen:
+
+| Feld | Wert |
+|------|------|
+| **Campaign Use Case** | **Customer Care** (nicht Marketing!) |
+| **Description** | "Transactional SMS for Swiss plumbing/heating businesses: damage report confirmations, appointment reminders, and service notifications." |
+| **Sample Message 1** | "BrunnerHT: Ihre Meldung (Heizung defekt) wurde aufgenommen. Erfasster Ort: 8800 Thalwil. Ihr Service-Team meldet sich schnellstmöglich." |
+| **Sample Message 2** | "FlowSight: Ihre Demo am 10.03. um 14:00 ist bestätigt. Microsoft Teams-Link: [URL]. Bei Fragen: +41 44 552 09 19" |
+| **Sample Message 3** | "FlowSight: Erinnerung — Ihre Demo ist morgen um 14:00. Link: [URL]. Verschieben? Antworten Sie auf diese Nachricht." |
+| **Message Flow** | "Users initiate contact by submitting a damage report via phone (voice agent) or web form, or by booking a demo. SMS is sent as transactional confirmation only." |
+| **Opt-in** | "Opt-in is collected when the user provides their phone number during damage reporting (voice call or web form) or demo booking." |
+| **Opt-in Keywords** | n/a (transactional, kein Opt-in nötig) |
+| **Opt-out Keywords** | STOP |
+| **Help Keywords** | HELP |
+| **Subscriber Opt-in** | Yes |
+| **Subscriber Opt-out** | Yes |
+| **Embedded Links** | Yes (correction link + Teams link) |
+| **Age-gated Content** | No |
+
+4. **Submit** > Genehmigung dauert 1-5 Werktage
+
+---
+
+## Schritt 4: Alphanumerische Sender pro Tenant registrieren
+
+Nachdem die Campaign genehmigt ist:
+
+1. **Messaging Service** > **Sender Pool** > **Add Alpha Sender**
+2. Pro Tenant einen Sender hinzufügen:
+
+| Tenant | Alpha Sender | Max 11 Zeichen |
+|--------|-------------|----------------|
+| Brunner HT | `BrunnerHT` | 9 Zeichen |
+| Dörfler AG | `Doerfler` | 8 Zeichen |
+| FlowSight | `FlowSight` | 9 Zeichen |
+
+> Wichtig: In der Schweiz sind alphanumerische Sender erlaubt. Kein separates Carrier-Approval nötig — die A2P-Campaign-Genehmigung reicht.
+
+---
+
+## Schritt 5: Code-Änderung (nach Genehmigung)
+
+Aktuell sendet `sendSms()` direkt über die Twilio Messages API mit `From: <alphanumericName>`.
+
+**Änderung:** Statt `From` den `MessagingServiceSid` verwenden. Twilio wählt dann automatisch den richtigen Sender aus dem Pool.
+
+```
+// vorher
+body: new URLSearchParams({ From: from, To: to, Body: body })
+
+// nachher
+body: new URLSearchParams({ MessagingServiceSid: sid, To: to, Body: body })
+```
+
+Neue Env Var: `TWILIO_MESSAGING_SERVICE_SID` (der MG... Wert aus Schritt 1)
+
+Ich mache diese Code-Änderung sobald du die Genehmigung hast.
+
+---
+
+## Schritt 6: Verifizierung
+
+Nach Genehmigung testen:
+
+```bash
+# Twilio CLI oder Console > SMS Log prüfen
+# Status muss "delivered" sein, nicht "undelivered"
+```
+
+Test-SMS an dein Handy senden (Swisscom + Sunrise testen falls möglich).
+
+---
+
+## Zeitplan
+
+| Tag | Aktion |
+|-----|--------|
+| Heute | Schritt 1-2 (Messaging Service + Brand Registration) |
+| Tag 2-4 | Warten auf Brand-Genehmigung |
+| Nach Genehmigung | Schritt 3 (Campaign Registration) |
+| Tag 3-7 | Warten auf Campaign-Genehmigung |
+| Nach Genehmigung | Schritt 4-6 (Sender + Code + Test) |
+
+---
+
+## FAQ
+
+**Was passiert mit bestehenden SMS während der Wartezeit?**
+Nichts ändert sich. Bestehende SMS laufen weiter wie bisher (alphanumerisch, ohne Registration). Das Spam-Risiko bleibt bis zur Genehmigung bestehen, aber bei unserem geringen Volumen (< 10/Tag) ist das vertretbar.
+
+**Brauche ich das pro Tenant neu?**
+Nein. Ein Messaging Service + eine Campaign reicht. Neue Tenants brauchen nur einen neuen Alpha Sender im Pool (30 Sekunden in der Console).
+
+**Was kostet das?**
+$0 extra für die Registration. SMS-Preise bleiben gleich (~CHF 0.07/SMS CH).
+
+**Kann ich den Status prüfen?**
+Trust Hub > Customer Profiles zeigt den aktuellen Status (Pending/Approved/Rejected).

--- a/src/web/app/(marketing)/demo/page.tsx
+++ b/src/web/app/(marketing)/demo/page.tsx
@@ -4,7 +4,7 @@ import { SITE } from "@/src/lib/marketing/constants";
 export const metadata: Metadata = {
   title: "Demo buchen",
   description:
-    "Buchen Sie eine 15-minütige FlowSight-Demo: KI-Telefonassistent, Ops-Dashboard und Website für Sanitär- & Heizungsbetriebe.",
+    "Buchen Sie eine 15-minütige FlowSight-Demo: Telefonassistentin, Fallübersicht und Website für Sanitär- & Heizungsbetriebe.",
 };
 
 function PhoneIcon({ className = "h-6 w-6" }: { className?: string }) {
@@ -51,7 +51,7 @@ export default function DemoPage() {
           {[
             {
               icon: <PhoneIcon className="h-5 w-5" />,
-              title: "KI Voice 24/7",
+              title: "Telefonassistentin 24/7",
               desc: "Anrufe annehmen — auch nachts und am Wochenende.",
             },
             {
@@ -61,8 +61,8 @@ export default function DemoPage() {
             },
             {
               icon: <StarIcon className="h-5 w-5" />,
-              title: "Google Reviews",
-              desc: "5-Sterne-Anfragen per Knopfdruck nach dem Einsatz.",
+              title: "Google-Bewertungen",
+              desc: "Bewertungen gezielt anfragen — nach erledigtem Einsatz.",
             },
           ].map((item) => (
             <div

--- a/src/web/app/(marketing)/page.tsx
+++ b/src/web/app/(marketing)/page.tsx
@@ -8,11 +8,11 @@ import { DemoForm } from "@/src/components/DemoForm";
 export const metadata: Metadata = {
   title: "FlowSight — Jeder Anruf wird zum Auftrag",
   description:
-    "KI-Telefonassistent, Ops-Dashboard und professionelle Website für Sanitär- und Heizungsbetriebe. 24/7 erreichbar, strukturierte Fälle, Google Reviews. Raum Zürich.",
+    "Telefonassistentin, Fallübersicht und professionelle Website für Sanitär- und Heizungsbetriebe. 24/7 erreichbar, strukturierte Fälle, Google-Bewertungen. Raum Zürich.",
   openGraph: {
     title: "FlowSight — Jeder Anruf wird zum Auftrag",
     description:
-      "KI-Telefonassistent, Ops-Dashboard und professionelle Website für Sanitär- und Heizungsbetriebe. 24/7 erreichbar, strukturierte Fälle, Google Reviews. Raum Zürich.",
+      "Telefonassistentin, Fallübersicht und professionelle Website für Sanitär- und Heizungsbetriebe. 24/7 erreichbar, strukturierte Fälle, Google-Bewertungen. Raum Zürich.",
     url: "https://flowsight.ch",
   },
   alternates: {
@@ -90,9 +90,9 @@ export default function HomePage() {
               <span className="text-gold-400">zum Auftrag.</span>
             </h1>
             <p className="mt-6 max-w-lg text-lg leading-relaxed text-navy-200">
-              Website, KI-Telefonassistent und Ops-Dashboard — alles aus einer Hand.
+              Website, Telefonassistentin und Fallübersicht — alles aus einer Hand.
               FlowSight nimmt Schadensmeldungen entgegen, erstellt strukturierte Fälle
-              und liefert Ihnen alles ins Dashboard. 24/7, auch nachts und am Wochenende.
+              und liefert Ihnen alles auf einen Blick. 24/7, auch nachts und am Wochenende.
             </p>
 
             {/* Proof indicators */}
@@ -155,7 +155,7 @@ export default function HomePage() {
               },
               {
                 problem: "Anrufe gehen abends und am Wochenende verloren.",
-                solution: "24/7 erreichbar — der Telefonassistent nimmt jeden Anruf an.",
+                solution: "24/7 erreichbar — die Telefonassistentin nimmt jeden Anruf an.",
               },
               {
                 problem: "Zettelwirtschaft statt strukturierter Dokumentation.",
@@ -224,7 +224,7 @@ export default function HomePage() {
                 {
                   step: "1",
                   title: "Meldung geht ein",
-                  desc: "Per Anruf an Ihren KI-Telefonassistenten oder über das Online-Formular auf Ihrer Website — 24/7, auch nachts und am Wochenende.",
+                  desc: "Per Anruf an Ihre Telefonassistentin oder über das Online-Formular auf Ihrer Website — 24/7, auch nachts und am Wochenende.",
                   icon: (
                     <svg className="h-7 w-7" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
@@ -245,7 +245,7 @@ export default function HomePage() {
                 {
                   step: "3",
                   title: "Sie übernehmen",
-                  desc: "Termin planen, Fotos anhängen, Fall abschliessen — alles im Ops-Dashboard. Kein Zettel, kein Chaos.",
+                  desc: "Termin planen, Fotos anhängen, Fall abschliessen — alles in der Fallübersicht. Kein Zettel, kein Chaos.",
                   icon: (
                     <svg className="h-7 w-7" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
@@ -305,7 +305,7 @@ export default function HomePage() {
               Alles kommt zu Ihnen.
             </h2>
             <p className="mt-4 text-lg text-navy-400">
-              Kein neues System lernen. Fälle kommen automatisch rein — Sie entscheiden, was wann erledigt wird.
+              Kein neues System lernen. Meldungen kommen automatisch rein — Sie entscheiden, was wann erledigt wird.
             </p>
           </div>
 
@@ -372,11 +372,11 @@ export default function HomePage() {
               },
               {
                 title: "Mehrsprachig",
-                desc: "Hochdeutsch, Schweizerdeutsch, Englisch, Französisch und Italienisch — der Telefonassistent versteht Ihre Kunden, egal welche Sprache.",
+                desc: "Hochdeutsch, Schweizerdeutsch, Englisch, Französisch und Italienisch — die Telefonassistentin versteht Ihre Kunden, egal welche Sprache.",
               },
               {
                 title: "Persönliches Onboarding",
-                desc: "Telefonnummer, Telefonassistent, Dashboard — wir richten alles gemeinsam ein. Kein technisches Wissen nötig.",
+                desc: "Telefonnummer, Telefonassistentin, Fallübersicht — wir richten alles gemeinsam ein. Kein technisches Wissen nötig.",
               },
             ].map((item) => (
               <div key={item.title} className="rounded-2xl border border-navy-200/40 bg-navy-50/50 p-8 text-center">
@@ -411,20 +411,19 @@ export default function HomePage() {
                 Starter
               </p>
               <p className="mt-4">
-                <span className="text-3xl font-bold text-navy-900">ab CHF 99</span>
+                <span className="text-3xl font-bold text-navy-900">CHF 199</span>
                 <span className="ml-1 text-base text-navy-400">/ Monat</span>
               </p>
               <p className="mt-2 text-sm text-navy-900/70">
-                Website + Wizard
+                Website + Online-Schadenmeldung
               </p>
               <ul className="mt-6 space-y-3">
                 {[
-                  "Moderne Website im Firmenlook",
-                  "Mobil-optimiert & SEO-ready",
-                  "Online-Schadenmelde-Formular",
-                  "E-Mail-Benachrichtigung",
-                  "Bestätigungs-E-Mail an Melder",
-                  "Persönliches Onboarding",
+                  "Moderne Website im Firmenlook (mobiloptimiert)",
+                  "Online-Schadenmeldung in 3 Schritten",
+                  "Betriebsinfo per E-Mail bei neuer Meldung",
+                  "Kunden-SMS: Bestätigung + Foto-Upload-Link",
+                  "Persönliches Onboarding & Setup inklusive",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2 text-sm text-navy-900/70">
                     <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-gold-500" />
@@ -440,29 +439,28 @@ export default function HomePage() {
               </Link>
             </div>
 
-            {/* Professional — highlighted */}
+            {/* Alltag — highlighted */}
             <div className="relative rounded-2xl border-2 border-gold-500 bg-white p-8 shadow-md">
               <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-gold-500 px-4 py-1 text-xs font-bold uppercase tracking-wider text-navy-950">
                 Beliebt
               </span>
               <p className="text-sm font-semibold uppercase tracking-wider text-gold-600">
-                Professional
+                Alltag
               </p>
               <p className="mt-4">
-                <span className="text-3xl font-bold text-navy-900">ab CHF 249</span>
+                <span className="text-3xl font-bold text-navy-900">CHF 299</span>
                 <span className="ml-1 text-base text-navy-400">/ Monat</span>
               </p>
               <p className="mt-2 text-sm text-navy-900/70">
-                Website + Telefonassistent + Dashboard
+                Telefonassistentin + Fallübersicht
               </p>
               <ul className="mt-6 space-y-3">
                 {[
                   "Alles aus Starter, plus:",
-                  "KI-Telefonassistent (24/7, mehrsprachig)",
-                  "Schweizer Telefonnummer inklusive",
-                  "Ops-Dashboard mit Fall-Übersicht",
-                  "Terminplanung mit ICS-Einladung",
-                  "Foto-Anhänge pro Fall",
+                  "Digitale Telefonassistentin (24/7, nach Wunsch konfigurierbar)",
+                  "Fallübersicht: alle Meldungen an einem Ort",
+                  "Bestätigungs-SMS + Foto-Upload (weniger Rückfragen)",
+                  "Mehrsprachig (DE/EN/FR/IT)",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2 text-sm text-navy-900/70">
                     <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-gold-500" />
@@ -478,24 +476,25 @@ export default function HomePage() {
               </Link>
             </div>
 
-            {/* Premium */}
+            {/* Wachstum */}
             <div className="rounded-2xl border border-navy-200 bg-white p-8 shadow-sm transition-shadow hover:shadow-md">
               <p className="text-sm font-semibold uppercase tracking-wider text-navy-400">
-                Premium
+                Wachstum
               </p>
               <p className="mt-4">
-                <span className="text-3xl font-bold text-navy-900">ab CHF 349</span>
+                <span className="text-3xl font-bold text-navy-900">CHF 399</span>
                 <span className="ml-1 text-base text-navy-400">/ Monat</span>
               </p>
               <p className="mt-2 text-sm text-navy-900/70">
-                + Reviews + Morning Report
+                Alltag + Bewertungen & Priorität
               </p>
               <ul className="mt-6 space-y-3">
                 {[
-                  "Alles aus Professional, plus:",
-                  "Google-Review-Anfragen per Knopfdruck",
-                  "Täglicher Statusbericht (Morning Report)",
-                  "Prioritäts-Support",
+                  "Alles aus Alltag, plus:",
+                  "Google-Bewertungen gezielt anfragen",
+                  "Prioritäts-Support (schnellere Reaktion)",
+                  "Bewertungen zum richtigen Zeitpunkt auslösen",
+                  "Stärkeres Google-Profil — mehr Anfragen aus der Region",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2 text-sm text-navy-900/70">
                     <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-gold-500" />
@@ -564,7 +563,7 @@ export default function HomePage() {
               },
               {
                 q: "Brauche ich technisches Wissen?",
-                a: "Nein. Wir richten alles für Sie ein — Website, Telefonnummer, Telefonassistent, Dashboard, E-Mail-Vorlagen. Sie brauchen nur einen Browser.",
+                a: "Nein. Wir richten alles für Sie ein — Website, Telefonnummer, Telefonassistentin, Fallübersicht. Sie brauchen nur einen Browser.",
               },
               {
                 q: "Funktioniert das mit meiner bestehenden Nummer?",
@@ -572,11 +571,11 @@ export default function HomePage() {
               },
               {
                 q: "Was passiert bei einem Notfall?",
-                a: "Der Telefonassistent erkennt die Dringlichkeit und markiert den Fall als Notfall. Sie erhalten sofort eine E-Mail mit allen Details.",
+                a: "Die Telefonassistentin erkennt die Dringlichkeit und markiert den Fall als Notfall. Sie erhalten sofort eine E-Mail mit allen Details.",
               },
               {
-                q: "Können mehrere Mitarbeiter das Dashboard nutzen?",
-                a: "Ja. Sie können beliebig viele Benutzer anlegen. Jeder sieht die gleichen Fälle und kann Termine planen, Fotos anhängen und Reviews anfragen.",
+                q: "Können mehrere Mitarbeiter die Fallübersicht nutzen?",
+                a: "Ja. Sie können beliebig viele Benutzer anlegen. Jeder sieht die gleichen Fälle und kann Termine planen, Fotos anhängen und Bewertungen anfragen.",
               },
               {
                 q: "Wie sicher sind meine Daten?",
@@ -584,11 +583,11 @@ export default function HomePage() {
               },
               {
                 q: "Wie schnell bin ich einsatzbereit?",
-                a: "Website in einer Woche. Telefonassistent und Dashboard ebenfalls — wir übernehmen die komplette Einrichtung, persönlich und in Ihrem Tempo.",
+                a: "Website in einer Woche. Telefonassistentin und Fallübersicht ebenfalls — wir übernehmen die komplette Einrichtung, persönlich und in Ihrem Tempo.",
               },
               {
                 q: "Kann ich FlowSight risikofrei testen?",
-                a: "Ja. Setup ist kostenfrei, der erste Monat gratis. Unser 30-Tage-Versprechen: Wenn Sie nicht mindestens 10 Fälle strukturiert im Dashboard haben und Ihre erste 5-Sterne-Bewertung erhalten haben — zahlen Sie nichts.",
+                a: "Ja. Setup ist kostenfrei, der erste Monat gratis. Unser 30-Tage-Versprechen: Wenn Sie nicht mindestens 10 Fälle strukturiert in der Fallübersicht haben und Ihre erste 5-Sterne-Bewertung erhalten haben — zahlen Sie nichts.",
               },
             ].map((item) => (
               <details key={item.q} className="group py-6">

--- a/src/web/app/(marketing)/pricing/page.tsx
+++ b/src/web/app/(marketing)/pricing/page.tsx
@@ -17,42 +17,41 @@ function CheckIcon({ className = "h-5 w-5" }: { className?: string }) {
 const TIERS = [
   {
     name: "Starter",
-    price: "ab CHF 99",
-    subtitle: "Website + Wizard",
+    price: "CHF 199",
+    subtitle: "Website + Online-Schadenmeldung",
     highlighted: false,
     features: [
-      "Moderne Website im Firmenlook",
-      "Mobil-optimiert & SEO-ready",
-      "Online-Schadenmelde-Formular (Wizard)",
-      "E-Mail-Benachrichtigung bei Meldung",
-      "Bestätigungs-E-Mail an Melder",
-      "Persönliches Onboarding",
+      "Moderne Website im Firmenlook (mobiloptimiert)",
+      "Online-Schadenmeldung in 3 Schritten",
+      "Betriebsinfo per E-Mail bei neuer Meldung",
+      "Kunden-SMS: Bestätigung + Foto-Upload-Link",
+      "Persönliches Onboarding & Setup inklusive",
     ],
   },
   {
-    name: "Professional",
-    price: "ab CHF 249",
-    subtitle: "Website + Voice + Dashboard",
+    name: "Alltag",
+    price: "CHF 299",
+    subtitle: "Telefonassistentin + Fallübersicht",
     highlighted: true,
     features: [
       "Alles aus Starter, plus:",
-      "KI-Telefonassistent (24/7, mehrsprachig)",
-      "Schweizer Telefonnummer inklusive",
-      "Ops-Dashboard mit Fall-Übersicht",
-      "Terminplanung mit ICS-Einladung",
-      "Foto-Anhänge pro Fall",
+      "Digitale Telefonassistentin (24/7, nach Wunsch konfigurierbar)",
+      "Fallübersicht: alle Meldungen an einem Ort",
+      "Bestätigungs-SMS + Foto-Upload (weniger Rückfragen)",
+      "Mehrsprachig (DE/EN/FR/IT)",
     ],
   },
   {
-    name: "Premium",
-    price: "ab CHF 349",
-    subtitle: "Das Komplettpaket",
+    name: "Wachstum",
+    price: "CHF 399",
+    subtitle: "Alltag + Bewertungen & Priorität",
     highlighted: false,
     features: [
-      "Alles aus Professional, plus:",
-      "Google-Review-Anfragen per Knopfdruck",
-      "Täglicher Statusbericht (Morning Report)",
-      "Prioritäts-Support",
+      "Alles aus Alltag, plus:",
+      "Google-Bewertungen gezielt anfragen",
+      "Prioritäts-Support (schnellere Reaktion)",
+      "Bewertungen zum richtigen Zeitpunkt auslösen",
+      "Stärkeres Google-Profil — mehr Anfragen aus der Region",
     ],
   },
 ] as const;
@@ -141,15 +140,15 @@ export default function PricingPage() {
           <div className="grid gap-8 sm:grid-cols-2">
             <div className="rounded-2xl border border-navy-200/60 bg-white p-8">
               <p className="text-sm font-semibold uppercase tracking-wider text-navy-400">
-                Voice-Minuten
+                Telefonminuten
               </p>
               <p className="mt-3 text-lg font-semibold text-navy-900">
                 Abrechnung nach Verbrauch
               </p>
               <p className="mt-2 text-sm leading-relaxed text-navy-900/70">
-                Nur bei Nutzung — keine Grundgebühr. Ein typischer Intake-Call
-                dauert 2–4 Minuten. Der genaue Minutenpreis wird im persönlichen
-                Gespräch besprochen.
+                Nur bei Nutzung — keine Grundgebühr. Ein typisches Gespräch
+                dauert 2–4 Minuten. Den genauen Minutenpreis besprechen wir
+                persönlich.
               </p>
             </div>
 
@@ -161,7 +160,7 @@ export default function PricingPage() {
                 Gemeinsam in einer Woche
               </p>
               <p className="mt-2 text-sm leading-relaxed text-navy-900/70">
-                Website, Telefonnummer, Telefonassistent, Dashboard-Zugang —
+                Website, Telefonnummer, Telefonassistentin, Fallübersicht —
                 persönlich eingerichtet. Keine Setup-Kosten in der Pilotphase.
               </p>
             </div>
@@ -188,11 +187,11 @@ export default function PricingPage() {
               },
               {
                 q: "Was kostet die Einrichtung?",
-                a: "In der Pilotphase: nichts. Wir richten alles gemeinsam ein — Website, Telefonassistent und Dashboard.",
+                a: "In der Pilotphase: nichts. Wir richten alles gemeinsam ein — Website, Telefonassistentin und Fallübersicht.",
               },
               {
-                q: "Wie werden Voice-Minuten abgerechnet?",
-                a: "Nur bei Nutzung. Ein typischer Intake-Call dauert 2–4 Minuten. Den genauen Minutenpreis besprechen wir persönlich.",
+                q: "Wie werden Telefonminuten abgerechnet?",
+                a: "Nur bei Nutzung. Ein typisches Gespräch dauert 2–4 Minuten. Den genauen Minutenpreis besprechen wir persönlich.",
               },
             ].map((item) => (
               <details key={item.q} className="group py-5">

--- a/src/web/src/components/HeroVisual.tsx
+++ b/src/web/src/components/HeroVisual.tsx
@@ -78,7 +78,7 @@ export function HeroVisual({ className = "" }: { className?: string }) {
             <polygon points="64,12 80,20 64,28" fill="currentColor" />
           </svg>
           <span className="mt-1 text-[10px] font-medium tracking-wide text-gold-400/70">
-            KI verarbeitet…
+            wird erfasst…
           </span>
         </div>
         {/* Mobile: vertical arrow */}
@@ -88,7 +88,7 @@ export function HeroVisual({ className = "" }: { className?: string }) {
             <polygon points="12,34 20,48 28,34" fill="currentColor" />
           </svg>
           <span className="mt-1 text-[10px] font-medium tracking-wide text-gold-400/70">
-            KI verarbeitet…
+            wird erfasst…
           </span>
         </div>
 


### PR DESCRIPTION
## Summary
- **Pricing reframed:** Starter (CHF 199) / Alltag (CHF 299) / Wachstum (CHF 399) — 5 Bullets pro Kachel, Betriebssprache statt SaaS-Sprache
- **Buzzwords entfernt:** "KI-Telefonassistent" → "Telefonassistentin", "Ops-Dashboard" → "Fallübersicht", "KI verarbeitet" → "wird erfasst"
- **Morning Report** aus Pricing entfernt (nicht live)
- **Twilio A2P Runbook** hinzugefügt (docs/runbooks/twilio_a2p_registration.md)

Closes #49, Closes #50, Closes #42

## Changed files
- `app/(marketing)/page.tsx` — Homepage: Hero, Pricing teaser, FAQ, Trust section
- `app/(marketing)/pricing/page.tsx` — Full pricing page
- `app/(marketing)/demo/page.tsx` — Demo page bullets
- `components/HeroVisual.tsx` — "wird erfasst" statt "KI verarbeitet"
- `docs/runbooks/twilio_a2p_registration.md` — SMS spam solution

## Test plan
- [ ] Homepage: Hero text, Pricing cards, FAQ buzzword-frei
- [ ] /pricing: 3 Kacheln (Starter/Alltag/Wachstum), korrekte Preise, 5 Bullets
- [ ] /demo: Bullets ohne "KI"
- [ ] Mobile responsive check

Generated with [Claude Code](https://claude.com/claude-code)