### PR TITLE
fix: wizard SMS + clickable step nav (#45, #43)

### DIFF
--- a/src/web/app/(demos)/brunner-haustechnik/meldung/BrunnerWizardForm.tsx
+++ b/src/web/app/(demos)/brunner-haustechnik/meldung/BrunnerWizardForm.tsx
@@ -125,7 +125,7 @@ function Spinner() {
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-function StepIndicator({ current, total }: { current: number; total: number }) {
+function StepIndicator({ current, total, onStepClick }: { current: number; total: number; onStepClick?: (step: number) => void }) {
   const labels = ["Problem", "Adresse", "Kontakt"];
   return (
     <div className="mb-8 flex items-center justify-center gap-1 sm:gap-2">
@@ -133,9 +133,15 @@ function StepIndicator({ current, total }: { current: number; total: number }) {
         const step = i + 1;
         const done = step < current;
         const active = step === current;
+        const canClick = done && onStepClick;
         return (
           <div key={step} className="flex items-center gap-1 sm:gap-2">
-            <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              disabled={!canClick}
+              onClick={() => canClick && onStepClick(step)}
+              className={`flex items-center gap-1.5 ${canClick ? "cursor-pointer" : "cursor-default"}`}
+            >
               <div
                 className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold transition-all ${
                   active
@@ -148,10 +154,10 @@ function StepIndicator({ current, total }: { current: number; total: number }) {
               >
                 {done ? <IconCheck /> : step}
               </div>
-              <span className={`hidden text-xs font-medium sm:block ${active ? "text-gray-900" : "text-gray-400"}`}>
+              <span className={`hidden text-xs font-medium sm:block ${active ? "text-gray-900" : done ? "text-emerald-600" : "text-gray-400"}`}>
                 {labels[i]}
               </span>
-            </div>
+            </button>
             {step < total && (
               <div className={`h-px w-6 sm:w-10 ${done ? "bg-emerald-500" : "bg-gray-200"}`} />
             )}
@@ -339,7 +345,7 @@ export default function BrunnerWizardForm({ initialCategory }: { initialCategory
         </p>
       </div>
 
-      <StepIndicator current={step} total={3} />
+      <StepIndicator current={step} total={3} onStepClick={(s) => setStep(s)} />
 
       <form onSubmit={handleSubmit}>
         {/* ── Step 1: Problem ──────────────────────────────────── */}

--- a/src/web/app/api/cases/route.ts
+++ b/src/web/app/api/cases/route.ts
@@ -4,6 +4,8 @@ import { getServiceClient } from "@/src/lib/supabase/server";
 import { sendCaseNotification, sendReporterConfirmation } from "@/src/lib/email/resend";
 import { notify } from "@/src/lib/notify/router";
 import { hasModule } from "@/src/lib/tenants/hasModule";
+import { getTenantSmsConfig } from "@/src/lib/tenants/getTenantSmsConfig";
+import { sendPostCallSms } from "@/src/lib/sms/postCallSms";
 
 // ---------------------------------------------------------------------------
 // Validation helpers (aligned with case_contract.md)
@@ -296,6 +298,39 @@ export async function POST(request: NextRequest) {
         event_type: "reporter_confirmation_sent",
         title: "Bestätigung an Melder gesendet",
       }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
+    }
+
+    // SMS confirmation to reporter (wizard + voice share the same SMS logic)
+    if (data.contact_phone) {
+      const smsConfig = await getTenantSmsConfig(tenantId);
+      if (smsConfig) {
+        const smsResult = await sendPostCallSms({
+          caseId: row.id,
+          createdAt: row.created_at,
+          callerPhone: data.contact_phone,
+          smsSenderName: smsConfig.senderName,
+          plz: data.plz,
+          city: data.city,
+          category: data.category,
+          street: data.street,
+          houseNumber: data.house_number,
+        });
+        if (smsResult.sent) {
+          await supabase.from("case_events").insert({
+            case_id: row.id,
+            event_type: "sms_sent",
+            title: "Bestätigungs-SMS an Melder gesendet",
+            metadata: { to: data.contact_phone, message_sid: smsResult.messageSid },
+          }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
+        }
+        console.log(JSON.stringify({
+          _tag: "cases_api",
+          category: "sms",
+          level: "info",
+          message: smsResult.sent ? "SMS sent" : `SMS skipped: ${smsResult.reason}`,
+          data: { case_id: row.id, source: data.source, sent: smsResult.sent },
+        }));
+      }
     }
 
     // Notify: system failures only (email dispatch fail → RED alert)

--- a/src/web/app/wizard/WizardForm.tsx
+++ b/src/web/app/wizard/WizardForm.tsx
@@ -117,26 +117,34 @@ function Spinner() {
 // Sub-components
 // ---------------------------------------------------------------------------
 
-function StepIndicator({ current, total }: { current: number; total: number }) {
+function StepIndicator({ current, total, onStepClick }: { current: number; total: number; onStepClick?: (step: number) => void }) {
   return (
     <div className="mb-8 flex items-center justify-center gap-2">
       {Array.from({ length: total }, (_, i) => {
         const step = i + 1;
         const done = step < current;
         const active = step === current;
+        const canClick = done && onStepClick;
         return (
           <div key={step} className="flex items-center gap-2">
-            <div
-              className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold transition-all ${
-                active
-                  ? "bg-white text-slate-900 shadow-lg shadow-white/20"
-                  : done
-                    ? "bg-emerald-500/80 text-white"
-                    : "bg-white/10 text-white/40"
-              }`}
+            <button
+              type="button"
+              disabled={!canClick}
+              onClick={() => canClick && onStepClick(step)}
+              className={canClick ? "cursor-pointer" : "cursor-default"}
             >
-              {done ? <IconCheck /> : step}
-            </div>
+              <div
+                className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold transition-all ${
+                  active
+                    ? "bg-white text-slate-900 shadow-lg shadow-white/20"
+                    : done
+                      ? "bg-emerald-500/80 text-white"
+                      : "bg-white/10 text-white/40"
+                }`}
+              >
+                {done ? <IconCheck /> : step}
+              </div>
+            </button>
             {step < total && (
               <div className={`h-px w-8 ${done ? "bg-emerald-500/60" : "bg-white/10"}`} />
             )}
@@ -316,7 +324,7 @@ export default function WizardForm({ initialCategory, tenantSlug }: { initialCat
         Beschreiben Sie Ihr Anliegen in 3 kurzen Schritten.
       </p>
 
-      <StepIndicator current={step} total={3} />
+      <StepIndicator current={step} total={3} onStepClick={(s) => setStep(s)} />
 
       <form onSubmit={handleSubmit}>
         {/* ── Step 1: Problem ──────────────────────────────────── */}


### PR DESCRIPTION
## Summary
- **#45 Wizard SMS:** `/api/cases` sendet jetzt SMS-Bestätigung nach Wizard-Submission (gleicher Flow wie Voice: Korrektur-Link + Foto-Upload). Bedingung: Telefonnummer angegeben + Tenant hat SMS-Modul aktiviert.
- **#43 Step-Navigation:** Abgeschlossene Steps im Wizard sind jetzt klickbar — Benutzer können direkt zu Step 1 oder 2 zurückspringen, ohne mehrfach "Zurück" zu drücken.

Closes #45, Closes #43

## Changed files
- `app/api/cases/route.ts` — SMS nach case creation (getTenantSmsConfig + sendPostCallSms)
- `app/(demos)/brunner-haustechnik/meldung/BrunnerWizardForm.tsx` — Clickable StepIndicator
- `app/wizard/WizardForm.tsx` — Clickable StepIndicator (generic template)

## Test plan
- [ ] Wizard-Meldung mit Telefonnummer absenden → SMS muss ankommen
- [ ] Wizard-Meldung ohne Telefonnummer → keine SMS, kein Fehler
- [ ] Step 1 ausfüllen → Step 2 → auf Step 1 Indikator klicken → zurück zu Step 1, Daten erhalten
- [ ] Step 3: Zurück-Button funktioniert weiterhin

Generated with [Claude Code](https://claude.com/claude-code)