### PR TITLE
fix: SMS alpha sender + phone routing audit (#47, #54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 - Deploy: Vercel, Root Directory = src/web
 - Secrets: Vercel Env = SSOT (runtime). Local .env.local via temp-dir pull sync only. Never commit to repo.
 - Voice: intake-only, max 7 questions, sanitär-spezifisch, Recording OFF
+- Retell: EVERY agent change MUST end with publish. Unpublished agents cause silent routing failures. Use retell_sync.mjs (auto-publishes) or manually publish in Dashboard after JSON import. Verify: is_published=true via API.
 
 ## SSOT Paths
 - Company status + document map: docs/STATUS.md

--- a/docs/architecture/env_vars.md
+++ b/docs/architecture/env_vars.md
@@ -47,6 +47,7 @@ Diese Datei ist eine Liste aller benötigten Env Vars + Herkunft. Keine Werte ei
 
 ## SMS (Post-Call Verification)
 - SMS_HMAC_SECRET -> selbst generiert (Bitwarden), für HMAC-SHA256 Token in Korrektur-Links
+- SMS_ALLOWED_NUMBERS -> (optional) Komma-separierte E.164 Whitelist. Wenn gesetzt, gehen SMS nur an diese Nummern. Leer/fehlend = senden an alle. Testphase: nur Founder-Handy.
 
 ## Demo (SIP/MicroSIP)
 - DEMO_SIP_CALLER_ID -> Founder-Handynummer E.164 (z.B. +41791234567). Muss als Twilio Outgoing Caller ID verifiziert sein. Retell sieht diese Nummer als from_number → SMS landet auf dem Demo-Handy.

--- a/docs/runbooks/phone_routing_registry.md
+++ b/docs/runbooks/phone_routing_registry.md
@@ -1,0 +1,98 @@
+# Phone Routing Registry — SSOT
+
+**Owner:** Founder
+**Last updated:** 2026-03-05
+**Rule:** Before ANY phone number assignment change in Retell, update this file FIRST.
+
+## Phone Number Registry
+
+| Number | Provider | Purpose | Published Where | Retell Agent | Retell Agent ID |
+|--------|----------|---------|-----------------|--------------|-----------------|
+| +41 44 552 09 19 | Peoplefone | FlowSight Sales | flowsight.ch, LinkedIn, Pitch Deck | **FlowSight Sales DE (Lisa)** | (see Retell Dashboard) |
+| +41 44 505 30 19 | Twilio | Peoplefone forward target | NOWHERE (internal) | **FlowSight Sales DE (Lisa)** | (same as above) |
+| +41 44 505 48 18 | Twilio | Brunner Demo Voice | NOWHERE (demo-kit intern) | **Brunner Intake DE** | agent_47deec4bdc891126de71dd42be |
+| +41 44 505 74 20 | Twilio | Doerfler Testing/Legacy | NOWHERE (internal) | **Doerfler Intake DE** | agent_d7dfe45ab444e1370e836c3e0f |
+
+## Routing Chains (PSTN)
+
+### FlowSight Sales (044 552 09 19)
+```
+Caller dials 044 552 09 19
+  -> Peoplefone Line 1 Forward -> +41 44 505 30 19 (Twilio)
+  -> SIP Trunk "flowsight-retell-ch" -> Retell
+  -> Agent: FlowSight Sales DE (Lisa)
+  -> Webhook: POST /api/retell/sales
+  -> Result: Lead email to Founder
+```
+
+### Brunner Demo (044 505 48 18)
+```
+Caller dials 044 505 48 18
+  -> Twilio -> SIP Trunk -> Retell
+  -> Agent: Brunner Intake DE
+  -> Webhook: POST /api/retell/webhook
+  -> resolveTenant(+41445054818) -> Brunner tenant
+  -> Result: Case created + email
+```
+
+### Doerfler Testing (044 505 74 20)
+```
+Caller dials 044 505 74 20
+  -> Twilio -> SIP Trunk -> Retell
+  -> Agent: Doerfler Intake DE
+  -> Webhook: POST /api/retell/webhook
+  -> resolveTenant(+41445057420) -> Doerfler tenant
+  -> Result: Case created + email
+```
+
+### Demo-Kit SIP (MicroSIP, separate path)
+```
+MicroSIP -> flowsight-demo.sip.twilio.com
+  -> TwiML (/api/demo/sip-twiml) -> Dial +41445054818
+  -> Retell Agent: Brunner Intake DE
+  -> Webhook caller override via DEMO_SIP_CALLER_ID
+```
+
+## Supabase tenant_numbers Mapping
+
+| phone_number | tenant | purpose |
+|---|---|---|
+| +41445520919 | Doerfler (48cae49e) | Peoplefone brand — for webhook tenant resolution |
+| +41445053019 | Doerfler (48cae49e) | Twilio entry — for webhook tenant resolution |
+| +41445057420 | Doerfler (48cae49e) | Legacy Twilio — for webhook tenant resolution |
+| +41445054818 | Brunner (d0000000) | Brunner voice number |
+
+**Note:** The tenant_numbers mapping for +41445520919 and +41445053019 still points to Doerfler.
+This is CORRECT for the intake webhook, but irrelevant for Sales calls (Sales webhook doesn't do tenant lookup).
+
+## Change Log
+
+| Date | Change | Reason |
+|------|--------|--------|
+| 2026-02-25 | +41445053019 assigned to Doerfler Intake DE | Peoplefone front door PoC |
+| 2026-03-01 | +41445053019 reassigned to Brunner Intake DE | Demo-kit setup (broke Sales path) |
+| 2026-03-05 | +41445053019 reassigned to FlowSight Sales DE (Lisa) | Fix #47 — restore correct routing |
+| 2026-03-05 | Sales DE + INTL agents published, phone version updated to v7 | Root cause: agents were NEVER published after creation. Retell fallback behavior routed to Brunner. |
+
+## Root Cause Analysis (#47)
+
+The FlowSight Sales agents were imported via Retell Dashboard JSON upload but **never published**.
+Retell's behavior when inbound_agent is not published: falls back to unknown/default agent (Brunner answered).
+Additionally, the phone number was pinned to agent version 4 while the agent was at version 7.
+
+**Fix:** Published both Sales agents + updated phone number to latest version.
+**Prevention:** The `retell_sync.mjs` script always publishes after sync. Sales agents are now tracked in `retell/agent_ids.json` under `flowsight_sales`.
+
+## Verification Checklist (run after ANY change)
+
+- [ ] Call 044 552 09 19 -> Lisa answers ("digitale Assistentin von FlowSight")
+- [ ] Call 044 505 48 18 -> Brunner Intake answers
+- [ ] Call 044 505 74 20 -> Doerfler Intake answers
+- [ ] MicroSIP SIP call -> Brunner Intake answers (demo-kit path unaffected)
+
+## Anti-Drift Rules
+
+1. **Never** reassign +41 44 505 30 19 in Retell without updating this file
+2. **Never** change Peoplefone forward target without updating this file
+3. After any Retell phone number change: run ALL 4 verification tests
+4. This file is the SSOT for phone routing — not peoplefone_front_door.md (which is now outdated for agent assignment)

--- a/retell/agent_ids.json
+++ b/retell/agent_ids.json
@@ -4,13 +4,21 @@
     "de_flow_id": "conversation_flow_e2c3a7cec528",
     "intl_agent_id": "agent_01fad4217f8b0697f0c26c69d5",
     "intl_flow_id": "conversation_flow_3c7d423226a9",
-    "last_synced": "2026-03-04T15:20:13.479Z"
+    "last_synced": "2026-03-05T13:57:28.821Z"
   },
   "doerfler": {
     "de_agent_id": "agent_d7dfe45ab444e1370e836c3e0f",
     "de_flow_id": "conversation_flow_8170ad3c2ca9",
     "intl_agent_id": "agent_fb4b956eec31db9c591880fdeb",
     "intl_flow_id": "conversation_flow_608d542979bb",
-    "last_synced": "2026-03-04T15:20:16.344Z"
+    "last_synced": "2026-03-05T13:57:31.514Z"
+  },
+  "flowsight_sales": {
+    "de_agent_id": "agent_6515d8d1f23072ce61db806901",
+    "de_flow_id": "conversation_flow_1f30bf247bf3",
+    "intl_agent_id": "agent_e03666c402209716fb2c5b41d6",
+    "intl_flow_id": null,
+    "last_synced": "2026-03-05T16:00:00.000Z",
+    "note": "Sales agents — phone +41445053019. Must be published after any change."
   }
 }

--- a/scripts/_ops/retell_phone_audit.mjs
+++ b/scripts/_ops/retell_phone_audit.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Retell Phone Number Audit & Fix
+ *
+ * Lists all phone numbers + agents in Retell, shows current assignments,
+ * and can reassign a phone number to a different agent.
+ *
+ * Usage:
+ *   # Audit only (show current state):
+ *   node --env-file=src/web/.env.local scripts/_ops/retell_phone_audit.mjs
+ *
+ *   # Fix: reassign a phone number to an agent:
+ *   node --env-file=src/web/.env.local scripts/_ops/retell_phone_audit.mjs \
+ *     --fix <phone_number_id> --agent <agent_id>
+ */
+
+const RETELL_BASE = "https://api.retellai.com";
+
+const apiKey = process.env.RETELL_API_KEY;
+if (!apiKey) {
+  console.error("FATAL: RETELL_API_KEY not set.");
+  console.error("Run with: node --env-file=src/web/.env.local scripts/_ops/retell_phone_audit.mjs");
+  process.exit(1);
+}
+
+const hdrs = {
+  Authorization: `Bearer ${apiKey}`,
+  "Content-Type": "application/json",
+};
+
+async function retellGet(path) {
+  const res = await fetch(`${RETELL_BASE}${path}`, { headers: hdrs });
+  if (!res.ok) throw new Error(`GET ${path} → ${res.status}`);
+  return res.json();
+}
+
+async function retellPatch(path, body) {
+  const res = await fetch(`${RETELL_BASE}${path}`, {
+    method: "PATCH",
+    headers: hdrs,
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => null);
+  if (!res.ok) throw new Error(`PATCH ${path} → ${res.status}: ${JSON.stringify(data)}`);
+  return data;
+}
+
+// ── CLI args ────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+function getArg(flag) {
+  const idx = args.indexOf(flag);
+  return idx >= 0 && args[idx + 1] ? args[idx + 1] : null;
+}
+const fixNumberId = getArg("--fix");
+const fixAgentId = getArg("--agent");
+
+try {
+  // ── Fetch all data ──────────────────────────────────────────────────
+  const [phones, agents] = await Promise.all([
+    retellGet("/list-phone-numbers"),
+    retellGet("/list-agents"),
+  ]);
+
+  // Build agent lookup
+  const agentMap = {};
+  for (const a of agents) {
+    agentMap[a.agent_id] = a.agent_name;
+  }
+
+  // ── Display current state ───────────────────────────────────────────
+  console.log("\n╔════════════════════════════════════════════════════════════╗");
+  console.log("║           Retell Phone Number Audit                      ║");
+  console.log("╚════════════════════════════════════════════════════════════╝\n");
+
+  console.log("━━━ Phone Numbers ━━━\n");
+  console.log("  ID                          | Number              | Agent Assigned");
+  console.log("  ----------------------------|---------------------|----------------------------------");
+  for (const p of phones) {
+    const agentName = p.inbound_agent_id ? (agentMap[p.inbound_agent_id] || "UNKNOWN") : "(none)";
+    const num = p.phone_number || p.phone_number_pretty || "?";
+    console.log(`  ${(p.phone_number_id || "").padEnd(28)} | ${num.padEnd(19)} | ${agentName} [${p.inbound_agent_id || "none"}]`);
+  }
+
+  console.log("\n━━━ All Agents ━━━\n");
+  for (const a of agents) {
+    console.log(`  ${a.agent_id}  ${a.agent_name}`);
+  }
+
+  // ── Fix mode ────────────────────────────────────────────────────────
+  if (fixNumberId && fixAgentId) {
+    const targetPhone = phones.find(p => p.phone_number_id === fixNumberId || p.phone_number === fixNumberId);
+    if (!targetPhone) {
+      console.error(`\nERROR: Phone number '${fixNumberId}' not found. Use an ID or E.164 number from the list above.`);
+      process.exit(1);
+    }
+
+    const agentName = agentMap[fixAgentId] || "UNKNOWN";
+    const phoneId = targetPhone.phone_number_id;
+
+    console.log(`\n━━━ Reassigning ━━━\n`);
+    console.log(`  Phone: ${targetPhone.phone_number} (${phoneId})`);
+    console.log(`  From:  ${agentMap[targetPhone.inbound_agent_id] || "none"} [${targetPhone.inbound_agent_id || "none"}]`);
+    console.log(`  To:    ${agentName} [${fixAgentId}]`);
+
+    await retellPatch(`/update-phone-number/${phoneId}`, {
+      inbound_agent_id: fixAgentId,
+    });
+
+    console.log(`\n  ✓ DONE — ${targetPhone.phone_number} now routes to ${agentName}\n`);
+  } else if (fixNumberId || fixAgentId) {
+    console.error("\nERROR: Both --fix <phone_id> and --agent <agent_id> are required.");
+    process.exit(1);
+  } else {
+    console.log("\n  To reassign: --fix <phone_number_id> --agent <agent_id>\n");
+  }
+
+} catch (err) {
+  console.error(`\nFATAL: ${err.message}\n`);
+  process.exit(1);
+}

--- a/scripts/_ops/twilio_phone_audit.mjs
+++ b/scripts/_ops/twilio_phone_audit.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Twilio Phone Number Audit — check Voice URL config for all numbers.
+ *
+ * Usage:
+ *   node --env-file=src/web/.env.local scripts/_ops/twilio_phone_audit.mjs
+ */
+
+const SID = process.env.TWILIO_ACCOUNT_SID;
+const TOKEN = process.env.TWILIO_AUTH_TOKEN;
+
+if (!SID || !TOKEN) {
+  console.error("FATAL: TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN required.");
+  process.exit(1);
+}
+
+const AUTH = "Basic " + Buffer.from(`${SID}:${TOKEN}`).toString("base64");
+const API = `https://api.twilio.com/2010-04-01/Accounts/${SID}`;
+
+async function get(url) {
+  const res = await fetch(url, { headers: { Authorization: AUTH } });
+  if (!res.ok) throw new Error(`GET ${url} → ${res.status}`);
+  return res.json();
+}
+
+try {
+  const data = await get(`${API}/IncomingPhoneNumbers.json?PageSize=50`);
+  const numbers = data.incoming_phone_numbers || [];
+
+  console.log("\n╔════════════════════════════════════════════════════════════╗");
+  console.log("║           Twilio Phone Number Audit                      ║");
+  console.log("╚════════════════════════════════════════════════════════════╝\n");
+
+  for (const n of numbers) {
+    console.log(`  ── ${n.phone_number} (${n.friendly_name}) ──`);
+    console.log(`     SID:           ${n.sid}`);
+    console.log(`     Voice URL:     ${n.voice_url || "(none)"}`);
+    console.log(`     Voice Method:  ${n.voice_method || "(none)"}`);
+    console.log(`     Voice App SID: ${n.voice_application_sid || "(none)"}`);
+    console.log(`     SMS URL:       ${n.sms_url || "(none)"}`);
+    console.log(`     Status CB:     ${n.status_callback || "(none)"}`);
+    console.log(`     Trunk SID:     ${n.trunk_sid || "(none)"}`);
+    console.log("");
+  }
+
+  // Also check SIP domains
+  console.log("━━━ SIP Domains ━━━\n");
+  const sipData = await get(`${API}/SIP/Domains.json`);
+  for (const d of sipData.sip_domains || []) {
+    console.log(`  ── ${d.domain_name} ──`);
+    console.log(`     SID:        ${d.sid}`);
+    console.log(`     Voice URL:  ${d.voice_url || "(none)"}`);
+    console.log(`     Voice Method: ${d.voice_method || "(none)"}`);
+    console.log("");
+  }
+
+} catch (err) {
+  console.error(`\nFATAL: ${err.message}\n`);
+  process.exit(1);
+}

--- a/src/web/src/lib/sms/sendSms.ts
+++ b/src/web/src/lib/sms/sendSms.ts
@@ -1,13 +1,17 @@
 import "server-only";
 
 /**
- * Send an SMS via Twilio REST API.
+ * Send an SMS via Twilio REST API using Alphanumeric Sender ID.
  * Zero dependencies — uses native fetch + Basic auth.
- * Follows the same pattern as whatsapp.ts.
+ *
+ * Sender: Alphanumeric (e.g. "BrunnerHT", "FlowSight") — no SMS-capable
+ * phone number needed. CH carriers support this without registration.
  *
  * Env vars:
  * - TWILIO_ACCOUNT_SID
  * - TWILIO_AUTH_TOKEN
+ * - SMS_ALLOWED_NUMBERS (optional) — comma-separated E.164 whitelist.
+ *   When set, only these numbers receive SMS. Empty/unset = send to all.
  *
  * Never throws — returns result with sent:false on any error.
  * No console.log — caller owns the log line.
@@ -17,6 +21,11 @@ export interface SendSmsResult {
   sent: boolean;
   messageSid?: string;
   reason?: string;
+}
+
+/** Twilio alphanumeric sender: 3-11 chars, [A-Za-z0-9 ], min 1 letter. */
+function isValidAlphaSender(from: string): boolean {
+  return /^[A-Za-z0-9 ]{3,11}$/.test(from) && /[A-Za-z]/.test(from);
 }
 
 export async function sendSms(
@@ -29,6 +38,19 @@ export async function sendSms(
 
   if (!accountSid || !authToken) {
     return { sent: false, reason: "missing_env" };
+  }
+
+  if (!isValidAlphaSender(from)) {
+    return { sent: false, reason: `invalid_alpha_sender: "${from}"` };
+  }
+
+  // Whitelist guard: when SMS_ALLOWED_NUMBERS is set, only send to listed numbers.
+  const allowList = process.env.SMS_ALLOWED_NUMBERS;
+  if (allowList) {
+    const allowed = allowList.split(",").map((n) => n.trim());
+    if (!allowed.includes(to)) {
+      return { sent: false, reason: `not_in_allowlist: ${to}` };
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary
- **SMS Alpha Sender:** Validation (3-11 chars, min 1 letter) + `SMS_ALLOWED_NUMBERS` whitelist guard for test phase. Verified: FlowSight, BrunnerHT, Doerfler all deliver to CH mobile.
- **Phone Routing (#47):** Root cause found — Sales agent was never published. Fixed via API. New audit scripts (`retell_phone_audit.mjs`, `twilio_phone_audit.mjs`) and phone routing registry runbook as SSOT.
- **Retell publish rule:** Added to CLAUDE.md — every agent change MUST end with publish.

## Test plan
- [x] `npm run build` PASS
- [x] SMS test: FlowSight → delivered, BrunnerHT → delivered, Doerfler → delivered
- [x] Retell audit: all 3 numbers correctly assigned
- [x] Sales agent published and verified
- [ ] Call 044 552 09 19 → Lisa von FlowSight answers

Closes #47, Closes #54

Generated with [Claude Code](https://claude.com/claude-code)