### PR TITLE
fix: voice closing loop + dynamic SIP routing (#46)

### DIFF
--- a/retell/agent_ids.json
+++ b/retell/agent_ids.json
@@ -4,14 +4,14 @@
     "de_flow_id": "conversation_flow_e2c3a7cec528",
     "intl_agent_id": "agent_01fad4217f8b0697f0c26c69d5",
     "intl_flow_id": "conversation_flow_3c7d423226a9",
-    "last_synced": "2026-03-05T13:57:28.821Z"
+    "last_synced": "2026-03-05T16:21:49.895Z"
   },
   "doerfler": {
     "de_agent_id": "agent_d7dfe45ab444e1370e836c3e0f",
     "de_flow_id": "conversation_flow_8170ad3c2ca9",
     "intl_agent_id": "agent_fb4b956eec31db9c591880fdeb",
     "intl_flow_id": "conversation_flow_608d542979bb",
-    "last_synced": "2026-03-05T13:57:31.514Z"
+    "last_synced": "2026-03-05T16:21:58.080Z"
   },
   "flowsight_sales": {
     "de_agent_id": "agent_6515d8d1f23072ce61db806901",

--- a/src/web/app/api/demo/sip-twiml/route.ts
+++ b/src/web/app/api/demo/sip-twiml/route.ts
@@ -1,37 +1,60 @@
+import { NextRequest } from "next/server";
+
 /**
  * GET/POST /api/demo/sip-twiml — Returns TwiML for SIP-originated demo calls.
  *
  * Used as Voice URL on the Twilio SIP Domain "flowsight-demo.sip.twilio.com".
- * MicroSIP → SIP Domain → this route → TwiML → Dial Brunner Retell agent.
+ * MicroSIP → SIP Domain → this route → TwiML → Dial target Retell agent.
+ *
+ * Routes based on dialed number (SIP To header):
+ * - +41445054818 or +41447203142 (Brunner numbers) → Brunner Retell agent
+ * - +41445520919 or +41445053019 (FlowSight numbers) → FlowSight Sales Retell agent
+ * - Default → Brunner (demo fallback)
  *
  * callerId = TWILIO_NUMBER (voice-safe, verified on our account).
- * Number   = BRUNNER_RETELL (Retell phone number assigned to Brunner Lisa).
- *
- * These are two DIFFERENT numbers:
- * - +41445053019 = Twilio number (callerId, also Dörfler entry point — NOT Brunner)
- * - +41445054818 = Retell number (Brunner Haustechnik Lisa DE agent)
- *
- * SMS target override is handled in the webhook via DEMO_SIP_CALLER_ID.
  */
 
-const CALLER_ID = "+41445053019"; // Twilio number on our account (voice-safe)
-const BRUNNER_RETELL = "+41445054818"; // Brunner Haustechnik Voice Agent (Retell)
+const CALLER_ID = "+41445053019";
+const BRUNNER_RETELL = "+41445054818";
 
-const TWIML = `<?xml version="1.0" encoding="UTF-8"?>
+// FlowSight Sales agent is registered in Retell on +41445053019.
+// SIP calls route via Retell SIP endpoint directly.
+const FLOWSIGHT_SALES_RETELL = "+41445053019";
+
+// Numbers that should route to FlowSight Sales (Lisa von FlowSight)
+const SALES_NUMBERS = new Set(["+41445520919", "+41445053019", "41445520919", "41445053019"]);
+
+function extractDialedNumber(request: NextRequest): string | null {
+  const url = new URL(request.url);
+  // Twilio sends the dialed SIP URI as "To" parameter
+  const to = url.searchParams.get("To") || "";
+  // Extract number from sip:+41445520919@flowsight-demo.sip.twilio.com
+  const match = to.match(/sip:\+?(\d+)@/);
+  return match ? match[1] : null;
+}
+
+function buildTwiml(target: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Dial callerId="${CALLER_ID}">
-    <Number>${BRUNNER_RETELL}</Number>
+    <Number>${target}</Number>
   </Dial>
 </Response>`;
+}
 
-export async function GET() {
-  return new Response(TWIML, {
+function routeCall(request: NextRequest): Response {
+  const dialed = extractDialedNumber(request);
+  const target = dialed && SALES_NUMBERS.has(dialed) ? FLOWSIGHT_SALES_RETELL : BRUNNER_RETELL;
+
+  return new Response(buildTwiml(target), {
     headers: { "Content-Type": "application/xml" },
   });
 }
 
-export async function POST() {
-  return new Response(TWIML, {
-    headers: { "Content-Type": "application/xml" },
-  });
+export async function GET(request: NextRequest) {
+  return routeCall(request);
+}
+
+export async function POST(request: NextRequest) {
+  return routeCall(request);
 }


### PR DESCRIPTION
## Summary
- **#46 Voice Closing Loop:** Deployed POST-FAREWELL fix for Brunner + Dörfler via retell_sync (all 4 agents updated + published)
- **SIP TwiML:** Dynamic routing based on dialed number — FlowSight numbers (044 552 09 19, 044 505 30 19) → Sales agent, Brunner numbers → Brunner agent

## Test plan
- [x] `npm run build` PASS
- [x] retell_sync brunner: 4 steps PASS, published
- [x] retell_sync doerfler: 4 steps PASS, published
- [ ] MicroSIP: dial 044 552 09 19 → Sales Lisa answers
- [ ] MicroSIP: dial 044 505 48 18 → Brunner Lisa answers
- [ ] Voice call: no closing loop after farewell

Closes #46

Generated with [Claude Code](https://claude.com/claude-code)