### PR TITLE
fix: consistent Leitsystem node styling

### DIFF
--- a/src/web/app/handout/[id]/page.tsx
+++ b/src/web/app/handout/[id]/page.tsx
@@ -124,7 +124,7 @@ export default async function HandoutPage({
 
             {/* Ticket */}
             <div className="flex flex-col items-center">
-              <FlowNode icon="ticket" label="Fall" highlighted />
+              <FlowNode icon="ticket" label="Fall" />
               <p className="mt-2 max-w-[120px] text-center text-[10px] leading-tight text-navy-300">
                 Strukturierter Fall mit SMS-Bestätigung + Foto-Upload
               </p>


### PR DESCRIPTION
Remove highlighted prop from Fall node — all 5 nodes now have uniform navy bg + gold icon.