### PR TITLE
fix: remove FOUNDER_PHONE from Big Ben reservation route

### DIFF
--- a/src/web/app/api/bigben-pub/reserve/route.ts
+++ b/src/web/app/api/bigben-pub/reserve/route.ts
@@ -10,7 +10,6 @@ import { sendSms } from "@/src/lib/sms/sendSms";
  */
 
 const PAUL_PHONE = process.env.BIGBEN_OWNER_PHONE ?? "";
-const FOUNDER_PHONE = process.env.FOUNDER_PHONE ?? "";
 
 export async function POST(req: Request) {
   const base = { _tag: "bigben_reservation", stage: "api" };
@@ -70,11 +69,6 @@ export async function POST(req: Request) {
     if (PAUL_PHONE) {
       await sendSms(PAUL_PHONE, ownerSms, "BigBenPub");
     }
-    // Also notify founder
-    if (FOUNDER_PHONE) {
-      await sendSms(FOUNDER_PHONE, ownerSms, "BigBenPub");
-    }
-
     console.log(
       JSON.stringify({
         ...base,


### PR DESCRIPTION
## Summary
- Remove unnecessary `FOUNDER_PHONE` from `/api/bigben-pub/reserve`
- Only Paul (pub owner) receives booking SMS notifications

Closes no issue — cleanup from PR #62.

## Test plan
- [ ] Submit test reservation on `/bigben-pub` → only Paul gets SMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)