### PR TITLE
fix: OpenGraph metadata for customer pages (#69)

### DIFF
--- a/src/web/app/(demos)/bigben-pub/page.tsx
+++ b/src/web/app/(demos)/bigben-pub/page.tsx
@@ -5,6 +5,21 @@ export const metadata: Metadata = {
   title: "Big Ben Pub — Your Local in Oberrieden",
   description:
     "Traditional British pub in Oberrieden. Best Guinness on the lake, live sports, events, and proper pub food. Book your table online.",
+  openGraph: {
+    title: "Big Ben Pub — Your Local in Oberrieden",
+    description:
+      "Best Guinness on the lake, live sports, events & proper pub food. Book your table online.",
+    url: "https://flowsight.ch/bigben-pub",
+    siteName: "Big Ben Pub",
+    locale: "en_GB",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Big Ben Pub — Your Local in Oberrieden",
+    description:
+      "Best Guinness on the lake, live sports, events & proper pub food. Book your table online.",
+  },
 };
 
 export default function BigBenPubPage() {

--- a/src/web/app/kunden/[slug]/page.tsx
+++ b/src/web/app/kunden/[slug]/page.tsx
@@ -21,10 +21,24 @@ export async function generateMetadata({
   const { slug } = await params;
   const c = getCustomer(slug);
   if (!c) return {};
+  const title = `${c.companyName} — ${c.tagline}`;
   return {
-    title: `${c.companyName} — ${c.tagline}`,
+    title,
     description: c.metaDescription,
     keywords: c.seoKeywords,
+    openGraph: {
+      title,
+      description: c.metaDescription,
+      url: `https://flowsight.ch/kunden/${slug}`,
+      siteName: c.companyName,
+      locale: "de_CH",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: c.metaDescription,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- Big Ben Pub: explicit OG metadata (no more "Sanitär & Heizung" in WhatsApp preview)
- `/kunden/[slug]` template: OG from customer config (affects all prospect websites)

Closes #69

## Test plan
- [ ] Share `/bigben-pub` link — preview says "Big Ben Pub", not FlowSight Sanitär
- [ ] Share `/kunden/doerfler-ag` — preview shows Dörfler info

🤖 Generated with [Claude Code](https://claude.com/claude-code)