### PR TITLE
feat: scout v2 — ICP scoring, multi-query, municipality scouting

### DIFF
--- a/docs/architecture/env_vars.md
+++ b/docs/architecture/env_vars.md
@@ -52,6 +52,9 @@ Diese Datei ist eine Liste aller benötigten Env Vars + Herkunft. Keine Werte ei
 ## Demo (SIP/MicroSIP)
 - DEMO_SIP_CALLER_ID -> Founder-Handynummer E.164 (z.B. +41791234567). Muss als Twilio Outgoing Caller ID verifiziert sein. Retell sieht diese Nummer als from_number → SMS landet auf dem Demo-Handy.
 
+## Scout (Prospect Discovery)
+- GOOGLE_SCOUT_KEY -> Google Cloud Console (Places API New). Used by scripts/_ops/scout.mjs for prospect discovery. $200/month free credit.
+
 ## App / Routing
 - APP_URL -> Canonical app URL (server-side, z.B. https://flowsight-mvp.vercel.app)
 - NEXT_PUBLIC_APP_URL -> Same, but client-accessible (NEXT_PUBLIC_ prefix)

--- a/docs/sales/pipeline.csv
+++ b/docs/sales/pipeline.csv
@@ -1,13 +1,4 @@
-firma,ort,website,google_rating,google_reviews,score,grund_pro,grund_contra,status,email_gesendet,demo_url,notizen
-Sanitherm Sanitär Heizung GmbH,Adliswil,https://www.sanitherm.ch/,3.7,6,6,Wenig aussagende Website; 6 GR,GRE Schnitt 3.7; nur eine 5-Sterne mit Text,OFFEN,,,
-Wacker+Scavezzon Sanitär GmbH,Kilchberg,https://www.1a-sanitaer.ch/,4.6,9,4,9 GR; 4.6 Schnitt; einige gute Texte,Könnten mit Website schon zufrieden sein,OFFEN,,,
-Simson Sanitär & Heizung GmbH,Wollishofen,,3.0,2,3,Keine Website; 2 GR; eine 5-Sterne,Keine E-Mail auffindbar; keine Bilder; nur 2 GR,OFFEN,,,
-Vedovati Sanitäre-Anlagen,Adliswil,https://www.vedovati.ch/,3.6,16,1,16 GR,GRE Schnitt 3.6; moderne Website,SKIP,,,
-Rohner Peter Sanitär + Heizung,Wollishofen,https://rohner-peter-sanitaer-heizung.digitalone.site/,0,0,1,Keine richtige Website,Keine GR,SKIP,,,
-Bühlmann Heizungen,Wollishofen,https://www.bmh-ag.ch/,0,0,0,,Starke Website,SKIP,,,
-Fruet Sanitär AG,Wollishofen,https://www.fruet.ch/,0,0,0,,Starke Website,SKIP,,,
-Sani Work,Wollishofen,https://saniwork.ch/,0,0,0,,Starke Website,SKIP,,,
-Reno Group GmbH,Kilchberg,https://renogroup.ch/,0,0,0,,,SKIP,,,
-Stark Haustechnik GmbH,Adliswil,https://stark-haustechnik.ch/,0,0,0,,,SKIP,,,
-Hoppler Heizung Sanitär Service GmbH,Adliswil,https://hoppler.ch/,0,0,2,Gute Google Reviews,Starke Website,SKIP,,,
-Remer Heizungen & Sanitär,Adliswil,,0,0,1,Keine Website,Keine GR; nichts,SKIP,,,
+firma,ort,website,google_rating,google_reviews,score,kontakt,telefon,email,status,demo_url,email_gesendet,anruf_1,notizen
+Sanitherm Sanitär Heizung GmbH,Adliswil,https://www.sanitherm.ch/,3.7,6,6,,,OFFEN,,,,"Wenig aussagende Website; 6 GR; GRE Schnitt 3.7"
+Wacker+Scavezzon Sanitär GmbH,Kilchberg,https://www.1a-sanitaer.ch/,4.6,9,4,,,OFFEN,,,,"9 GR; 4.6 Schnitt; einige gute Review-Texte"
+Simson Sanitär & Heizung GmbH,Wollishofen,,3.0,2,3,,,OFFEN,,,,"Keine Website; keine E-Mail auffindbar"

--- a/docs/sales/scout_raw.csv
+++ b/docs/sales/scout_raw.csv
@@ -1,0 +1,1 @@
+place_id,firma,ort,adresse,telefon,website,google_rating,google_reviews,maps_url,score,tier,trust,gap,reasons,query,discovered

--- a/scripts/_ops/scout.mjs
+++ b/scripts/_ops/scout.mjs
@@ -2,25 +2,32 @@
 /**
  * scout.mjs — Google Places Prospect Finder for FlowSight
  *
- * Searches Google Maps for businesses matching a query + location,
- * scores them for FlowSight relevance, and appends to pipeline.csv.
+ * Discovers sanitär/heizung businesses per municipality, scores them
+ * for FlowSight ICP fit, and writes to scout_raw.csv.
  *
  * Usage:
- *   node scripts/_ops/scout.mjs --query "Sanitär Heizung" --location "Adliswil, Zürich"
- *   node scripts/_ops/scout.mjs --query "Sanitär" --location "47.2727,8.5835" --radius 5000
- *   node scripts/_ops/scout.mjs --query "Sanitär Heizung" --location "Thalwil" --dry-run
+ *   # Scout a single municipality
+ *   node scripts/_ops/scout.mjs --gemeinde Thalwil
  *
- * Requires: GOOGLE_PLACES_API_KEY env var (or --api-key flag)
- * Google Cloud: Enable "Places API (New)" — $200/month free credit covers ~1000 searches
+ *   # Scout all linker Zürichsee municipalities
+ *   node scripts/_ops/scout.mjs --region zuerichsee-links
  *
- * Scoring (0-10):
- *   +3  no website or very basic website
- *   +2  few Google reviews (< 10)
- *   +2  high Google rating (>= 4.0) with reviews (happy customers = upsell potential)
- *   +1  low rating (< 4.0) = pain = opportunity
- *   +1  has phone number (contactable)
- *   +1  small business signals (no chain/franchise indicators)
- *   -5  already in pipeline.csv (skip duplicates)
+ *   # Dry run (no file writes)
+ *   node scripts/_ops/scout.mjs --gemeinde Kilchberg --dry-run
+ *
+ *   # Custom query (override defaults)
+ *   node scripts/_ops/scout.mjs --gemeinde Horgen --queries "Sanitär,Heizung,Badumbau"
+ *
+ * Env: GOOGLE_SCOUT_KEY (Vercel SSOT + .env.local)
+ *
+ * Scoring model — "Digital Gap" (see docs below for reasoning):
+ *   Score = Local Trust (0-5) + Digital Gap (0-5) + Contactable (0-1) - Disqualifiers
+ *   Perfect ICP: strong reviews + no/weak website = high score
+ *   Bad lead: no reviews + strong website = low score
+ *
+ * Files:
+ *   docs/sales/scout_raw.csv   ← all discovered candidates (this script writes here)
+ *   docs/sales/pipeline.csv    ← founder-curated qualified prospects (manual promotion)
  */
 
 import fs from "fs";
@@ -28,7 +35,22 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RAW_CSV = path.resolve(__dirname, "../../docs/sales/scout_raw.csv");
 const PIPELINE_CSV = path.resolve(__dirname, "../../docs/sales/pipeline.csv");
+
+// ── Env ─────────────────────────────────────────────────────────────
+// Load .env.local if present (check multiple locations)
+for (const rel of ["../../.env.local", "../../src/web/.env.local"]) {
+  const envPath = path.resolve(__dirname, rel);
+  if (!fs.existsSync(envPath)) continue;
+  const envContent = fs.readFileSync(envPath, "utf-8");
+  for (const line of envContent.split("\n")) {
+    const match = line.match(/^([A-Z_][A-Z0-9_]*)=(.+)$/);
+    if (match && !process.env[match[1]]) {
+      process.env[match[1]] = match[2].replace(/^["']|["']$/g, "").trim();
+    }
+  }
+}
 
 // ── Args ────────────────────────────────────────────────────────────
 const args = process.argv.slice(2);
@@ -37,65 +59,118 @@ function getArg(name) {
   return i !== -1 && args[i + 1] ? args[i + 1] : null;
 }
 const dryRun = args.includes("--dry-run");
-const query = getArg("query") || "Sanitär Heizung";
-const location = getArg("location") || "Zürichsee";
-const radius = getArg("radius") || "8000";
-const apiKey = getArg("api-key") || process.env.GOOGLE_PLACES_API_KEY || "";
+const gemeinde = getArg("gemeinde");
+const region = getArg("region");
+const customQueries = getArg("queries");
+const apiKey = getArg("api-key") || process.env.GOOGLE_SCOUT_KEY || "";
 
 if (!apiKey) {
   console.error(`
-╔══════════════════════════════════════════════════════════════╗
-║  GOOGLE_PLACES_API_KEY not set.                              ║
-║                                                              ║
-║  Setup (5 min):                                              ║
-║  1. Go to console.cloud.google.com                           ║
-║  2. Create project "FlowSight Scout"                         ║
-║  3. Enable "Places API (New)"                                ║
-║  4. Create API Key (restrict to Places API)                  ║
-║  5. Set: export GOOGLE_PLACES_API_KEY=AIza...                ║
-║                                                              ║
-║  Free tier: $200/month = ~1000 searches. More than enough.   ║
-╚══════════════════════════════════════════════════════════════╝
+  GOOGLE_SCOUT_KEY not set.
+
+  Setup (5 min):
+  1. console.cloud.google.com → project "FlowSight Scout"
+  2. Enable "Places API (New)"
+  3. Create API Key (restrict to Places API)
+  4. Vercel: set GOOGLE_SCOUT_KEY
+  5. Local: add to src/web/.env.local
+
+  Free tier: $200/month = ~1000+ searches.
 `);
   process.exit(1);
 }
 
-// ── Load existing pipeline to skip duplicates ───────────────────────
-function loadExistingFirms() {
-  if (!fs.existsSync(PIPELINE_CSV)) return new Set();
-  const csv = fs.readFileSync(PIPELINE_CSV, "utf-8");
-  const lines = csv.split("\n").slice(1); // skip header
-  const firms = new Set();
-  for (const line of lines) {
-    const name = line.split(",")[0]?.trim().toLowerCase();
-    if (name) firms.add(name);
+if (!gemeinde && !region) {
+  console.error(`
+  Usage:
+    node scripts/_ops/scout.mjs --gemeinde Thalwil
+    node scripts/_ops/scout.mjs --region zuerichsee-links
+    node scripts/_ops/scout.mjs --gemeinde Horgen --dry-run
+
+  Available regions:
+    zuerichsee-links    Thalwil → Horgen (10 Gemeinden)
+`);
+  process.exit(1);
+}
+
+// ── Regions ─────────────────────────────────────────────────────────
+const REGIONS = {
+  "zuerichsee-links": [
+    "Thalwil",
+    "Oberrieden",
+    "Horgen",
+    "Au ZH",
+    "Wädenswil",
+    "Richterswil",
+    "Kilchberg ZH",
+    "Rüschlikon",
+    "Adliswil",
+    "Langnau am Albis",
+  ],
+};
+
+// ── Query patterns ──────────────────────────────────────────────────
+// Multiple patterns to catch firms that don't have "Sanitär" in their name
+// (e.g. "Dörfler AG" is a sanitär business but name doesn't say so)
+const DEFAULT_QUERIES = [
+  "Sanitär",
+  "Sanitärinstallateur",
+  "Heizungsinstallateur",
+  "Haustechnik",
+  "Badumbau",
+  "Sanitär Heizung",
+];
+
+// ── Load existing IDs to skip duplicates ────────────────────────────
+function loadExistingPlaceIds() {
+  const ids = new Set();
+  const names = new Set();
+
+  for (const csvPath of [RAW_CSV, PIPELINE_CSV]) {
+    if (!fs.existsSync(csvPath)) continue;
+    const csv = fs.readFileSync(csvPath, "utf-8");
+    for (const line of csv.split("\n").slice(1)) {
+      if (!line.trim()) continue;
+      // Parse first field (place_id or firma) for dedup
+      const fields = parseCSVLine(line);
+      const id = fields[0]?.trim();
+      const name = (csvPath === RAW_CSV ? fields[1] : fields[0])?.trim().toLowerCase();
+      if (id) ids.add(id);
+      if (name) names.add(name);
+    }
   }
-  return firms;
+  return { ids, names };
+}
+
+// Simple CSV line parser (handles quoted fields)
+function parseCSVLine(line) {
+  const fields = [];
+  let current = "";
+  let inQuotes = false;
+  for (const ch of line) {
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === "," && !inQuotes) {
+      fields.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  fields.push(current);
+  return fields;
 }
 
 // ── Google Places Text Search ───────────────────────────────────────
-async function searchPlaces(textQuery, locationBias) {
-  // Use Places API (New) — Text Search
+async function searchPlaces(textQuery) {
   const url = "https://places.googleapis.com/v1/places:searchText";
 
   const body = {
-    textQuery: `${textQuery} in ${locationBias}`,
+    textQuery,
     languageCode: "de",
     regionCode: "CH",
     maxResultCount: 20,
   };
-
-  // If location looks like coordinates, add locationBias
-  const coordMatch = locationBias.match(/^(-?\d+\.?\d*),\s*(-?\d+\.?\d*)$/);
-  if (coordMatch) {
-    body.locationBias = {
-      circle: {
-        center: { latitude: parseFloat(coordMatch[1]), longitude: parseFloat(coordMatch[2]) },
-        radius: parseFloat(radius),
-      },
-    };
-    body.textQuery = textQuery;
-  }
 
   const res = await fetch(url, {
     method: "POST",
@@ -103,6 +178,7 @@ async function searchPlaces(textQuery, locationBias) {
       "Content-Type": "application/json",
       "X-Goog-Api-Key": apiKey,
       "X-Goog-FieldMask": [
+        "places.id",
         "places.displayName",
         "places.formattedAddress",
         "places.websiteUri",
@@ -120,176 +196,323 @@ async function searchPlaces(textQuery, locationBias) {
 
   if (!res.ok) {
     const err = await res.text();
-    console.error(`Google API error (${res.status}):`, err);
-    process.exit(1);
+    console.error(`  API error (${res.status}) for "${textQuery}":`, err.slice(0, 200));
+    return [];
   }
 
   const data = await res.json();
   return data.places || [];
 }
 
-// ── Score a place ───────────────────────────────────────────────────
-function scorePlaceForFlowSight(place) {
-  let score = 0;
-  const pros = [];
-  const cons = [];
-
+// ── Scoring ─────────────────────────────────────────────────────────
+/**
+ * ICP Scoring Model — "Digital Gap"
+ *
+ * We're looking for: strong local business + weak digital presence = leverage.
+ * NOT: weak everything (might be dead) or strong everything (no gap).
+ *
+ * Score = Local Trust (0-5) + Digital Gap (0-5) + Contactable (0/1) - Disqualifiers
+ *
+ * LOCAL TRUST (0-5) — deterministic from rating × reviews
+ *   5: rating ≥ 4.5 AND reviews ≥ 10    (strong proof)
+ *   4: rating ≥ 4.0 AND reviews ≥ 5     (solid proof)
+ *   3: rating ≥ 3.5 AND reviews ≥ 3     (some proof)
+ *   2: reviews ≥ 1 (has presence)
+ *   1: on Google Maps but 0 reviews      (exists)
+ *   0: not applicable
+ *
+ * DIGITAL GAP (0-5) — heuristic from website presence + type
+ *   5: no website at all                 (maximum gap)
+ *   4: directory-only (local.ch, search.ch link)
+ *   3: builder website (wix, jimdo, one.com, digitalone, squarespace)
+ *   2: has website but basic domain (manual check needed)
+ *   0: has professional-looking website   (low gap — but can't verify quality)
+ *
+ *   Limitation: we can only assess website existence and URL pattern.
+ *   Actual quality (modern? fast? conversion-optimized?) requires founder review.
+ *
+ * CONTACTABLE (0-1) — deterministic
+ *   1: has phone number
+ *   0: no phone
+ *
+ * DISQUALIFIERS — heuristic
+ *   -3: business types suggest chain/franchise/enterprise
+ *   -2: name contains AG/SA + multiple location indicators
+ *
+ * Assumptions:
+ *   - Google Places API returns accurate rating/review data
+ *   - "No website" from API means truly no website (not just missing from API)
+ *   - Builder URL patterns are reliable indicators
+ *   - We cannot determine employee count from API data (proxy: review count as rough scale)
+ */
+function scorePlace(place) {
+  const reasons = [];
   const website = place.websiteUri || "";
   const rating = place.rating || 0;
   const reviews = place.userRatingCount || 0;
   const phone = place.nationalPhoneNumber || place.internationalPhoneNumber || "";
+  const types = place.types || [];
 
-  // No or basic website = big opportunity
-  if (!website) {
-    score += 3;
-    pros.push("Keine Website");
-  } else if (website.includes("digitalone") || website.includes("wix") || website.includes("jimdo") || website.includes("one.com")) {
-    score += 2;
-    pros.push("Baukasten-Website");
-  }
-
-  // Few reviews = not yet tapping digital potential
-  if (reviews > 0 && reviews < 10) {
-    score += 2;
-    pros.push(`Nur ${reviews} GR`);
-  } else if (reviews >= 10 && reviews < 30) {
-    score += 1;
-    pros.push(`${reviews} GR`);
-  } else if (reviews >= 30) {
-    cons.push(`${reviews} GR (gut aufgestellt)`);
-  }
-
-  // High rating with reviews = happy customers, upsell potential
-  if (rating >= 4.0 && reviews >= 3) {
-    score += 2;
-    pros.push(`${rating} Sterne`);
-  } else if (rating > 0 && rating < 4.0) {
-    score += 1;
-    pros.push(`${rating} Sterne (Verbesserungspotential)`);
-  }
-
-  // Has phone = contactable
-  if (phone) {
-    score += 1;
+  // ── Local Trust (0-5) ──
+  let localTrust = 0;
+  if (rating >= 4.5 && reviews >= 10) {
+    localTrust = 5;
+    reasons.push(`Trust 5: ${rating}★ × ${reviews} Reviews — starker Proof`);
+  } else if (rating >= 4.0 && reviews >= 5) {
+    localTrust = 4;
+    reasons.push(`Trust 4: ${rating}★ × ${reviews} Reviews — solider Proof`);
+  } else if (rating >= 3.5 && reviews >= 3) {
+    localTrust = 3;
+    reasons.push(`Trust 3: ${rating}★ × ${reviews} Reviews — etwas Proof`);
+  } else if (reviews >= 1) {
+    localTrust = 2;
+    reasons.push(`Trust 2: ${reviews} Reviews — existiert digital`);
   } else {
-    cons.push("Kein Telefon");
+    localTrust = 1;
+    reasons.push("Trust 1: auf Maps, aber 0 Reviews");
   }
 
-  // Strong website = less need
-  if (website && !website.includes("digitalone") && !website.includes("wix") && !website.includes("jimdo")) {
-    // Check if it's a real company site (not a directory)
-    if (!website.includes("local.ch") && !website.includes("search.ch")) {
-      cons.push("Hat Website");
-    }
+  // ── Digital Gap (0-5) ──
+  let digitalGap = 0;
+  const BUILDERS = ["wix", "jimdo", "one.com", "digitalone", "squarespace", "weebly", "webnode", "site123"];
+  const DIRECTORIES = ["local.ch", "search.ch", "tel.search.ch", "yellow.ch"];
+  const websiteLower = website.toLowerCase();
+
+  if (!website) {
+    digitalGap = 5;
+    reasons.push("Gap 5: keine Website");
+  } else if (DIRECTORIES.some((d) => websiteLower.includes(d))) {
+    digitalGap = 4;
+    reasons.push("Gap 4: nur Verzeichnis-Link");
+  } else if (BUILDERS.some((b) => websiteLower.includes(b))) {
+    digitalGap = 3;
+    reasons.push(`Gap 3: Baukasten-Website`);
+  } else {
+    digitalGap = 2;
+    reasons.push("Gap 2: hat Website (Qualität manuell prüfen)");
   }
 
-  return { score: Math.min(score, 10), pros, cons };
+  // ── Contactable (0-1) ──
+  let contactable = 0;
+  if (phone) {
+    contactable = 1;
+  } else {
+    reasons.push("Kein Telefon gefunden");
+  }
+
+  // ── Disqualifiers ──
+  let penalty = 0;
+  const CHAIN_TYPES = ["department_store", "shopping_mall", "supermarket", "bank"];
+  if (types.some((t) => CHAIN_TYPES.includes(t))) {
+    penalty += 3;
+    reasons.push("Disq: Kette/Grossbetrieb");
+  }
+  // Very high review count suggests larger operation
+  if (reviews > 80) {
+    penalty += 2;
+    reasons.push(`Disq: ${reviews} Reviews — vermutlich Grossbetrieb`);
+  }
+  // Known enterprise/chain names (not our ICP)
+  const nameLower = (place.displayName?.text || "").toLowerCase();
+  const ENTERPRISE_NAMES = ["fust", "meier tobler", "coop", "migros", "jumbo", "hornbach", "bauhaus", "sanitas troesch"];
+  if (ENTERPRISE_NAMES.some((e) => nameLower.includes(e))) {
+    penalty += 5;
+    reasons.push("Disq: Enterprise/Kette");
+  }
+
+  const score = Math.max(0, Math.min(10, localTrust + digitalGap + contactable - penalty));
+  const tier = score >= 7 ? "HOT" : score >= 4 ? "WARM" : "COLD";
+
+  return { score, tier, localTrust, digitalGap, contactable, penalty, reasons };
 }
 
-// ── CSV escape ──────────────────────────────────────────────────────
+// ── CSV helpers ─────────────────────────────────────────────────────
 function csvEscape(val) {
-  const s = String(val || "");
-  if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+  const s = String(val ?? "");
+  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes(";")) {
     return `"${s.replace(/"/g, '""')}"`;
   }
   return s;
 }
 
+const RAW_HEADER = "place_id,firma,ort,adresse,telefon,website,google_rating,google_reviews,maps_url,score,tier,trust,gap,reasons,query,discovered";
+
+function ensureRawCSV() {
+  if (!fs.existsSync(RAW_CSV)) {
+    fs.writeFileSync(RAW_CSV, RAW_HEADER + "\n");
+  }
+}
+
+// ── Extract municipality from address ───────────────────────────────
+function extractOrt(address) {
+  // Swiss addresses: "Street, PLZ Ort, Schweiz" or "Street, Ort, Schweiz"
+  const parts = address.split(",").map((s) => s.trim());
+  if (parts.length >= 2) {
+    // Second-to-last part usually has PLZ + Ort
+    const plzOrt = parts[parts.length - 2];
+    // Remove PLZ (4 digits)
+    return plzOrt.replace(/^\d{4}\s*/, "").trim();
+  }
+  return "";
+}
+
 // ── Main ────────────────────────────────────────────────────────────
 async function main() {
-  console.log(`\n🔍 Searching: "${query}" in ${location} (radius ${radius}m)\n`);
+  const gemeinden = region
+    ? REGIONS[region] || (() => { console.error(`Unknown region: ${region}`); process.exit(1); })()
+    : [gemeinde];
 
-  const places = await searchPlaces(query, location);
-  console.log(`Found ${places.length} results from Google Places.\n`);
+  const queries = customQueries
+    ? customQueries.split(",").map((q) => q.trim())
+    : DEFAULT_QUERIES;
 
-  if (places.length === 0) {
-    console.log("No results. Try a broader search query or different location.");
-    return;
-  }
+  console.log(`\n  Scout: ${gemeinden.length} Gemeinde(n), ${queries.length} Queries each`);
+  console.log(`  Gemeinden: ${gemeinden.join(", ")}`);
+  console.log(`  Queries: ${queries.join(", ")}`);
+  console.log(`  Mode: ${dryRun ? "DRY RUN" : "WRITE to scout_raw.csv"}\n`);
 
-  const existing = loadExistingFirms();
-  const results = [];
+  const { ids: existingIds, names: existingNames } = loadExistingPlaceIds();
+  const allResults = new Map(); // place_id → result object (dedupe across queries)
+  let apiCalls = 0;
 
-  for (const p of places) {
-    const name = p.displayName?.text || "Unknown";
-    const address = p.formattedAddress || "";
-    const ort = address.split(",").slice(-2, -1)[0]?.trim() || "";
+  for (const gem of gemeinden) {
+    console.log(`  --- ${gem} ---`);
 
-    // Skip if already in pipeline
-    if (existing.has(name.toLowerCase())) {
-      console.log(`  ⏭  ${name} — already in pipeline`);
-      continue;
+    for (const q of queries) {
+      const textQuery = `${q} ${gem}`;
+      const places = await searchPlaces(textQuery);
+      apiCalls++;
+
+      for (const p of places) {
+        const placeId = p.id;
+        if (!placeId) continue;
+
+        // Skip if already known (in raw or pipeline)
+        if (existingIds.has(placeId)) continue;
+
+        // Skip if already found in this run
+        if (allResults.has(placeId)) continue;
+
+        // Name-based dedupe fallback
+        const name = p.displayName?.text || "";
+        if (existingNames.has(name.toLowerCase())) continue;
+
+        const address = p.formattedAddress || "";
+        const ort = extractOrt(address);
+        const phone = p.nationalPhoneNumber || p.internationalPhoneNumber || "";
+        const { score, tier, localTrust, digitalGap, contactable, penalty, reasons } = scorePlace(p);
+
+        allResults.set(placeId, {
+          placeId,
+          name,
+          ort,
+          address,
+          phone,
+          website: p.websiteUri || "",
+          rating: p.rating || 0,
+          reviews: p.userRatingCount || 0,
+          mapsUrl: p.googleMapsUri || "",
+          score,
+          tier,
+          localTrust,
+          digitalGap,
+          contactable,
+          penalty,
+          reasons,
+          query: textQuery,
+        });
+      }
+
+      // Small delay to be nice to the API
+      await new Promise((r) => setTimeout(r, 200));
     }
-
-    const { score, pros, cons } = scorePlaceForFlowSight(p);
-
-    results.push({
-      name,
-      ort,
-      website: p.websiteUri || "",
-      rating: p.rating || 0,
-      reviews: p.userRatingCount || 0,
-      phone: p.nationalPhoneNumber || p.internationalPhoneNumber || "",
-      score,
-      pros: pros.join("; "),
-      cons: cons.join("; "),
-      mapsUrl: p.googleMapsUri || "",
-    });
   }
 
   // Sort by score descending
-  results.sort((a, b) => b.score - a.score);
+  const results = [...allResults.values()].sort((a, b) => b.score - a.score);
 
-  // Display results
-  console.log("─".repeat(80));
-  console.log("  Score │ Firma                              │ Ort           │ ★    │ GR  │ Website");
-  console.log("─".repeat(80));
+  // ── Display ─────────────────────────────────────────────────────
+  console.log("\n" + "=".repeat(90));
+  console.log("  SCOUT RESULTS");
+  console.log("=".repeat(90));
 
-  for (const r of results) {
-    const websiteShort = r.website ? "✓" : "✗";
-    const scoreColor = r.score >= 5 ? "🟢" : r.score >= 3 ? "🟡" : "⚪";
-    console.log(
-      `  ${scoreColor} ${String(r.score).padStart(2)}  │ ${r.name.padEnd(35).slice(0, 35)}│ ${r.ort.padEnd(14).slice(0, 14)}│ ${String(r.rating || "-").padStart(4)} │ ${String(r.reviews).padStart(3)} │ ${websiteShort}`
-    );
-    if (r.pros) console.log(`        │   ✅ ${r.pros}`);
-    if (r.cons) console.log(`        │   ❌ ${r.cons}`);
-  }
-
-  console.log("─".repeat(80));
-
-  const hot = results.filter((r) => r.score >= 4);
-  const warm = results.filter((r) => r.score >= 2 && r.score < 4);
-  console.log(`\n📊 ${results.length} results: ${hot.length} hot (≥4), ${warm.length} warm (2-3), ${results.length - hot.length - warm.length} cold (<2)\n`);
-
-  if (dryRun) {
-    console.log("🏁 Dry run — not writing to pipeline.csv\n");
+  if (results.length === 0) {
+    console.log("\n  No new prospects found. All already known or no results.\n");
     return;
   }
 
-  // Append to pipeline.csv
-  const newLines = results.map((r) =>
+  const tiers = { HOT: [], WARM: [], COLD: [] };
+  for (const r of results) tiers[r.tier].push(r);
+
+  for (const [tierName, tierResults] of Object.entries(tiers)) {
+    if (tierResults.length === 0) continue;
+    const icon = tierName === "HOT" ? "🔴" : tierName === "WARM" ? "🟡" : "⚪";
+    console.log(`\n  ${icon} ${tierName} (${tierResults.length})`);
+    console.log("  " + "-".repeat(86));
+
+    for (const r of tierResults) {
+      const web = r.website ? "🌐" : "❌";
+      console.log(
+        `  [${r.score}/10] ${r.name}` +
+        `  |  ${r.ort}  |  ${r.rating || "-"}★ ${r.reviews}R  |  ${web} Website  |  ${r.phone || "kein Tel"}`
+      );
+      // Show scoring breakdown
+      console.log(
+        `          Trust:${r.localTrust} + Gap:${r.digitalGap} + Tel:${r.contactable}` +
+        (r.penalty ? ` - Penalty:${r.penalty}` : "")
+      );
+      // Show top reasons (max 2 for readability)
+      const topReasons = r.reasons.slice(0, 2).join(" | ");
+      console.log(`          ${topReasons}`);
+      if (r.website) console.log(`          ${r.website}`);
+    }
+  }
+
+  console.log("\n" + "=".repeat(90));
+  console.log(`  Total: ${results.length} new  |  ${tiers.HOT.length} HOT  |  ${tiers.WARM.length} WARM  |  ${tiers.COLD.length} COLD`);
+  console.log(`  API calls: ${apiCalls}  |  Gemeinden: ${gemeinden.length}  |  Queries: ${queries.length}`);
+  console.log("=".repeat(90));
+
+  if (dryRun) {
+    console.log("\n  DRY RUN — nothing written.\n");
+    return;
+  }
+
+  // ── Write to scout_raw.csv ──────────────────────────────────────
+  ensureRawCSV();
+  const today = new Date().toISOString().split("T")[0];
+  const lines = results.map((r) =>
     [
+      csvEscape(r.placeId),
       csvEscape(r.name),
       csvEscape(r.ort),
+      csvEscape(r.address),
+      csvEscape(r.phone),
       csvEscape(r.website),
       r.rating || "",
       r.reviews || "",
+      csvEscape(r.mapsUrl),
       r.score,
-      csvEscape(r.pros),
-      csvEscape(r.cons),
-      r.score >= 4 ? "OFFEN" : "SKIP",
-      "", // email_gesendet
-      "", // demo_url
-      csvEscape(r.phone ? `Tel: ${r.phone}` : ""),
+      r.tier,
+      r.localTrust,
+      r.digitalGap,
+      csvEscape(r.reasons.join("; ")),
+      csvEscape(r.query),
+      today,
     ].join(",")
   );
 
-  fs.appendFileSync(PIPELINE_CSV, "\n" + newLines.join("\n"));
-  console.log(`✅ ${results.length} entries appended to pipeline.csv\n`);
-  console.log(`Next steps for hot prospects (score ≥ 4):`);
-  console.log(`  1. Review pipeline.csv — confirm relevance`);
-  console.log(`  2. Run: node scripts/_ops/prospect_pipeline.mjs --url <website> --slug <slug>`);
-  console.log(`  3. Send email with demo link\n`);
+  fs.appendFileSync(RAW_CSV, lines.join("\n") + "\n");
+  console.log(`\n  ✅ ${results.length} entries written to scout_raw.csv`);
+
+  // Show next steps for HOT
+  if (tiers.HOT.length > 0) {
+    console.log(`\n  Next steps for ${tiers.HOT.length} HOT prospects:`);
+    console.log("  1. Review scout_raw.csv — confirm ICP fit");
+    console.log("  2. Add best ones to pipeline.csv (manual)");
+    console.log("  3. Build demo website: node scripts/_ops/prospect_pipeline.mjs --url <url> --slug <slug>");
+    console.log("  4. Send email\n");
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
Complete scout rewrite for founder-led sales discovery:

- **Scoring**: "Digital Gap" model — Local Trust (0-5) + Digital Gap (0-5) + Contactable - Disqualifiers
- **Multi-query**: 6 patterns per municipality (catches firms without "Sanitär" in name)
- **Regions**: `--region zuerichsee-links` = 10 Gemeinden
- **Two-file flow**: scout_raw.csv (all finds) → pipeline.csv (curated)
- **Enterprise filter**: Fust, Meier Tobler, chains auto-penalized
- **Env**: GOOGLE_SCOUT_KEY (Vercel SSOT)
- **pipeline.csv**: cleaned, only 3 real prospects remain

## Test plan
- [ ] `node scripts/_ops/scout.mjs --gemeinde Thalwil --dry-run` → shows scored results
- [ ] Enterprise names (Fust, Meier Tobler) get penalized
- [ ] Dörfler AG found via "Haustechnik" query
- [ ] Dedupe works across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)