### PR TITLE
docs: links.md per customer folder — mandatory onboarding step

### DIFF
--- a/docs/customers/bigben-pub/links.md
+++ b/docs/customers/bigben-pub/links.md
@@ -1,0 +1,5 @@
+# BigBen Pub — Links
+
+- **Website:** https://flowsight.ch/kunden/bigben-pub
+- **Links-Seite:** https://flowsight.ch/kunden/bigben-pub/links
+- **Wizard:** https://flowsight.ch/kunden/bigben-pub/meldung

--- a/docs/customers/brunner-haustechnik/links.md
+++ b/docs/customers/brunner-haustechnik/links.md
@@ -1,0 +1,5 @@
+# Brunner Haustechnik AG — Links
+
+- **Website:** https://flowsight.ch/kunden/brunner-haustechnik
+- **Links-Seite:** https://flowsight.ch/kunden/brunner-haustechnik/links
+- **Wizard:** https://flowsight.ch/kunden/brunner-haustechnik/meldung

--- a/docs/customers/doerfler-ag/links.md
+++ b/docs/customers/doerfler-ag/links.md
@@ -1,0 +1,5 @@
+# Dörfler AG — Links
+
+- **Website:** https://flowsight.ch/kunden/doerfler-ag
+- **Links-Seite:** https://flowsight.ch/kunden/doerfler-ag/links
+- **Wizard:** https://flowsight.ch/kunden/doerfler-ag/meldung

--- a/docs/customers/lessons-learned.md
+++ b/docs/customers/lessons-learned.md
@@ -42,6 +42,12 @@
 | 9 | **Text** | Alte Website als Basis + High-End Creative Writing. Keine 1:1-Kopie, kein Erfinden von Fakten. |
 | 10 | **Wizard** | Immer aktiv. Kategorien aus `services[]` ableiten. |
 
+### Pflicht-Output pro Kunde (IMMER):
+- `docs/customers/<slug>/links.md` — Website-URL, Links-Seite, Wizard-URL
+- Config in `src/web/src/lib/customers/<slug>.ts`
+- Bilder in `src/web/public/kunden/<slug>/`
+- Registry-Eintrag in `registry.ts`
+
 ### Zusätzlich wenn vorhanden:
 - Zertifizierungen / Verbandsmitgliedschaften
 - Markenpartner (URLs geprüft!)
@@ -67,7 +73,11 @@
 1. Config erstellen: `src/web/src/lib/customers/<slug>.ts`
 2. Registry ergänzen: 1 import + 1 Zeile in `registry.ts`
 3. Bilder ablegen: `src/web/public/kunden/<slug>/`
-4. Build + Push — fertig
+4. **`docs/customers/<slug>/links.md` anlegen** — Website-URL, Links-Seite, Wizard-URL. **PFLICHT bei jedem neuen Kunden.**
+5. Build + Push — fertig
+
+> **WICHTIG:** Schritt 4 ist nicht optional. `links.md` ist die SSOT für alle Kunden-URLs.
+> Ordnerstruktur pro Kunde: `docs/customers/<slug>/` muss mindestens `links.md` enthalten.
 
 ---
 

--- a/docs/customers/orlandini/links.md
+++ b/docs/customers/orlandini/links.md
@@ -1,0 +1,5 @@
+# Orlandini Sanitär Heizung GmbH — Links
+
+- **Website:** https://flowsight.ch/kunden/orlandini
+- **Links-Seite:** https://flowsight.ch/kunden/orlandini/links
+- **Wizard:** https://flowsight.ch/kunden/orlandini/meldung

--- a/docs/customers/walter-leuthold/links.md
+++ b/docs/customers/walter-leuthold/links.md
@@ -1,0 +1,5 @@
+# Walter Leuthold — Links
+
+- **Website:** https://flowsight.ch/kunden/walter-leuthold
+- **Links-Seite:** https://flowsight.ch/kunden/walter-leuthold/links
+- **Wizard:** https://flowsight.ch/kunden/walter-leuthold/meldung

--- a/docs/customers/widmer/links.md
+++ b/docs/customers/widmer/links.md
@@ -1,0 +1,5 @@
+# Widmer H. & Co. AG — Links
+
+- **Website:** https://flowsight.ch/kunden/widmer-sanitaer
+- **Links-Seite:** https://flowsight.ch/kunden/widmer-sanitaer/links
+- **Wizard:** https://flowsight.ch/kunden/widmer-sanitaer/meldung


### PR DESCRIPTION
## Summary
- Add `links.md` to every customer folder (`docs/customers/<slug>/links.md`)
- Contains website URL, links page URL, wizard URL per customer
- Made mandatory in lessons-learned.md onboarding checklist + intake process

## Customers
- bigben-pub, brunner-haustechnik, doerfler-ag, orlandini, walter-leuthold, widmer

## New rule (lessons-learned.md)
Every new customer MUST get a `links.md` in their `docs/customers/<slug>/` folder as part of onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)