### PR TITLE
docs: SSOT update — STATUS, OPS_BOARD, business_briefing to 2026-03-08

### DIFF
--- a/docs/OPS_BOARD.md
+++ b/docs/OPS_BOARD.md
@@ -1,6 +1,6 @@
 # OPS Board — FlowSight Roadmap (SSOT)
 
-**Updated:** 2026-03-04 (PR #32: Voice STT Hardening — Closes #31)
+**Updated:** 2026-03-08 (PR #97: Customer Links Docs)
 **Rule:** CC updates with every deliverable. Founder reviews weekly.
 **Einziger Task-Tracker.** Alle offenen Tasks leben hier.
 
@@ -8,15 +8,14 @@
 
 ## Snapshot
 
-- **Produkt:** 14 Module LIVE (Website, Voice, Wizard, Ops, Reviews, Morning Report, Entitlements, Email, Peoplefone, Sales Agent, Demo Booking, Demo-Strang, SMS Channel, **CoreBot** incl. Voice→STT + Photo/Doc Attachments)
-- **Kunden:** Dörfler AG (Go-Live PARTIAL), Brunner HT (Demo-Tenant + SMS live)
-- **BLOCKER:** 0. Alle gelöst. ✅
-- **Shipped:** N17 ✅ N18 ✅ N19 ✅ N20 ✅ N21 ✅ N26 ✅ N27 ✅ N28 ✅ N30 ✅ N31 ✅ N32 ✅ PR#23 ✅ PR#27 ✅ PR#29 ✅ PR#32 ✅
-- **Bugs gesamt:** 20+ Findings → alle Demo-kritischen fixed, 6 Backlog (N22/N23/N24/N29/N33)
-- **Ops Tooling:** `retell_sync.mjs` (API-Sync) + `onboard_tenant.mjs` (Tenant-Setup) + `prospect_pipeline.mjs` (Full-Stack Prospect Onboarding)
-- **CI/CD:** GitHub Actions (lint + build + Telegram notify). Branch Protection: PR required, 1 approval.
+- **Produkt:** 16 Module LIVE (Website, Voice, Wizard, Ops, Reviews, Morning Report, Entitlements, Email, Peoplefone, Sales Agent, Demo Booking, Demo-Strang, SMS Channel, CoreBot, Customer Links Page, BigBen Pub)
+- **Kunden:** 6 Websites live (Dörfler, Brunner HT, Walter Leuthold, Orlandini, Widmer, BigBen Pub)
+- **BLOCKER:** 0 ✅
+- **Shipped seit 04.03.:** 37 Commits, PRs #53–#97
+- **Ops Tooling:** `retell_sync.mjs` + `onboard_tenant.mjs` + `prospect_pipeline.mjs` + `scout.mjs` (ICP Scoring)
+- **CI/CD:** GitHub Actions (lint + build + Telegram notify). Branch Protection: PR required.
 - **Vercel Region:** Frankfurt (fra1)
-- **Phase:** Repo-Cleanup abgeschlossen. Kundenakquise-Phase. CoreBot fully operational (STT + Attachments verified). Prospect Pipeline ready.
+- **Phase:** Kundenakquise + Website-Qualitätsoffensive. 10-Regeln Intake-Prozess etabliert.
 
 ### How to Operate (Founder via Handy)
 
@@ -30,80 +29,67 @@
 
 ---
 
+## OFFEN — GitHub Issues
+
+| # | Titel | Labels | Status |
+|---|-------|--------|--------|
+| #93 | Ticket betrifft Widmer | ticket, voice, website | OFFEN — Klärung nötig |
+| #92 | Ticket betrifft Website Wittmar | decision, voice, website | OFFEN — Klärung nötig |
+| #90 | Voice Ticket 2026-03-08 12:32 | ticket, ops, voice | OFFEN |
+| #89 | Orlandini Partner nicht aufgenommen | ticket, voice, website | OFFEN — Prüfen ob Partner auf alter Website |
+| #81 | Voice von Handy funktioniert nicht | ticket, voice, website | UNTERSUCHT — Retell Logs zeigen Calls gehen durch, Founder hat nach 2-7s aufgelegt. Kein technischer Blocker. |
+| #80 | BigBen Pub — Rücksprache Paul erfolgt | ticket, telephony, voice | OFFEN — Paul interessiert |
+| #79 | BigBen Pub — Paul zeigt sich interessiert | decision, voice, website | OFFEN — Follow-up nötig |
+
+---
+
 ## OFFEN — Founder Blocks (Go-Live Dörfler)
 
 | # | Task | Status | Details |
 |---|------|--------|---------|
-| A | **E2E Go-Live Checklist** | **DONE** ✅ | Durchgeführt 01.03. — 17 Findings. PDF: `docs/evidence/Getestet wurde jetzt sehr spezifisch.pdf` |
 | D | Dörfler Input — Logo, fehlende Texte | PARTIAL | Brand Color + Google Reviews geliefert. Logo offen. |
-| E | Mobile QA — iPhone | OFFEN | N19 fixed ✅ — Founder kann Mobile re-testen. |
-| F | **Go/No-Go Entscheid** | OFFEN | Keine Blocker mehr. Founder: `retell_sync.mjs --prefix brunner` + E2E Re-Test → Entscheid. |
+| E | Mobile QA — iPhone | OFFEN | Founder kann Mobile re-testen. |
+| F | **Go/No-Go Entscheid** | OFFEN | Keine Blocker. Founder: Entscheid. |
 | G | **Kommunikation an Dörfler** | OFFEN | Blocked by: F |
-| F9 | Google Review Link (Dörfler) | BLOCKED | Nachrüsten wenn Link da. Nicht Go-Live-kritisch. |
-| F11 | Customer Go-Live Sign-off | PARTIAL | 3/4 PASS. Reviews blocked by F9. |
-| N21 | **Retell 188 Telefonnummer-Bug** | **DONE** ✅ | Fehler gefunden, richtige Nummer hinterlegt (01.03.). |
-| N25 | **MS Bookings UX** (Bug 17) | OFFEN | Kumpel-Feedback: Button sagt nur "Termin", Kalender-Add fehlt. Founder prüft MS Bookings Config. |
+| F9 | Google Review Link (Dörfler) | BLOCKED | Nachrüsten wenn Link da. |
+| N25 | **MS Bookings UX** (Bug 17) | OFFEN | Kumpel-Feedback. Founder prüft Config. |
 
 ---
 
 ## OFFEN — Produkt-Backlog
 
-### BLOCKER (vor Go-Live)
-
-| # | Deliverable | Bugs | Owner | Status |
-|---|-------------|------|-------|--------|
-| N19 | **Mobile Auth Fix** — Magic Link "ungültig/abgelaufen" auf Mobile. Converted /auth/confirm to client-side page with button (prevents email client prefetch). | 5 | CC | **DONE** ✅ |
-| N20 | **Voice PLZ Overhaul** — City-only confirmation (no digit readback). TTS garbled digits → new approach: confirm only city name. normalizePlz() in webhook as safety net. Founder must re-import agents. | 4 | CC | **DONE** ✅ |
-
-### Go-Live kritisch
-
-| # | Deliverable | Bugs | Owner | Status |
-|---|-------------|------|-------|--------|
-| N17 | **OPS Case Detail Redesign** — All fields always editable, compact 2-col layout, contact/timeline sidebar, simplified timeline, notes inline, API extended. | 1,2,3,13,14 | CC | **DONE** ✅ |
-| N18 | **OPS Case List UX** — Clickable rows, text search, server-side pagination (15/page), filter-clearing bug fixed. Bug 7 (tenant name in header) skipped — FlowSight branding correct for platform. | 8,9,10,11 | CC | **DONE** ✅ |
-
 ### Backlog (trigger-basiert)
 
 | # | Deliverable | Owner | Trigger | Status |
 |---|-------------|-------|---------|--------|
-| N2 | **E-Mail-First Workflow** — HTML Ops-Notification + Reporter-Bestätigung | CC | Voice Agent live ✅ | **DONE** ✅ |
-| N3 | **Kalender-Sync** — Google/Outlook CalDAV | CC | E-Mail-First shipped + Kundenfeedback | OFFEN |
+| N3 | **Kalender-Sync** — Google/Outlook CalDAV | CC | Kundenfeedback | OFFEN |
 | N4 | **Morning Report (Cron)** — tägliche Zusammenfassung per E-Mail | CC | Vercel Pro upgrade | OFFEN |
-| N5 | **MS Bookings Integration** | F + CC | Go-Live done | **DONE** ✅ |
-| N6 | **Pitch-Deck** (HTML → PDF, 7 Slides) | CC + F | Go-Live done | **DONE** ✅ |
 | N7 | Ops-light UI (reviews-only mode) | CC | Reviews-only Kunde signed | OFFEN |
-| N10 | **Voice E-Mail → Deutsch** | CC | Kundenfeedback | **DONE** ✅ |
 | N11 | **Adress-Autocomplete** — Swiss Post API / Google Places | CC | Post-MVP | OFFEN |
-| N12 | **BUG: Aktionen ohne Speichern-Zwang** | CC | E2E 2026-02-27 | **DONE** ✅ (subsumiert in N17) |
-| N13 | **BUG: Kachelhöhe** | CC | E2E 2026-02-27 | **DONE** ✅ (subsumiert in N17) |
-| N14 | **OPS Timeline: Nächster Schritt** | CC | Demo-Strang Review | **DONE** ✅ (subsumiert in N17) |
 | N15 | **Terminerinnerung 24h vorher** | CC | Post-Go-Live | OFFEN |
 | N16 | **Kunden-Historie** | CC | Post-Go-Live, Kundenfeedback | OFFEN |
-| N22 | **Tenant Brand Color → OPS** — Kunden-Hauptfarbe als Akzent im OPS Dashboard (Buttons, Cards). Roter Faden Website → OPS. | CC | Demo-relevant | OFFEN |
-| N23 | **Analytics Dashboard** — Separate Seite mit KPIs + 2 Diagrammen (Fallvolumen, Bearbeitungszeiten). Neben bestehenden KPI-Cards. | CC | Post-Go-Live | OFFEN |
-| N26 | **SMS Channel** — Post-call SMS with correction link + photo upload. Twilio alphanumeric sender (BrunnerHT). HMAC-secured public pages `/verify/[caseId]`. Webhook SMS logging. | CC | Voice Agent live ✅ | **DONE** ✅ |
-| N27 | **Case Detail UX v2** — Description full-width, Termin links (8/11/15 Uhr) + Notizen rechts, "Termin senden" prominent inline, Action bar: Speichern/Erledigt/Review. | CC | Founder Feedback 02.03. | **DONE** ✅ |
-| N28 | **KPI Dashboard Cards** — 4 KPI-Cards mit Click-to-filter (Total→all, Neu→new, In Bearbeitung→default, Erledigt→done). | CC | Founder Feedback 02.03. | **DONE** ✅ |
-| N29 | **PLZ/Ort Smart Verification** — Voice Agent + Webhook: PLZ gegen Tenant-Einzugsgebiet prüfen. Service-Area als Datenbank pro Tenant. Falsche PLZ → Rückfrage oder Warnung. | CC | Post-Go-Live, Kundenfeedback | OFFEN |
-| N30 | **BUG: SMS Link zu lang** — Short route `/v/[caseId]?t=<16hex>` (HMAC first 8 bytes). ~85 chars statt ~150. API accepts both full+short tokens. | CC | Demo-Feedback 02.03. | **DONE** ✅ |
-| N32 | **BUG: OPS Mobile Login** — Root cause: missing `middleware.ts` for Supabase session refresh. Created middleware matching `/ops/*` + `/auth/*`. | CC | Demo-Feedback 02.03. | **DONE** ✅ |
-| N31 | **BUG: Voice Closing repeat** — Closing nodes had language-trigger edges catching background noise → loop. Fix: emptied edges on all closing/out-of-scope nodes in all 4 agent JSONs. | CC + Founder | Demo-Feedback 02.03. | **DONE** ✅ |
-| N33 | **Demo-Booking SMS (Bestätigung + 24h Reminder)** — Prospect bucht Demo via Website → SMS 1: Sofort-Bestätigung (Datum, Uhrzeit, Kontakt). SMS 2: 24h-Reminder (freundlich, Verschieben möglich). Doppelter Nutzen: (1) Sales-Professionalisierung, (2) Showcase für Sanitär-Kunden ("Leerfahrten vermeiden — genau wie Sie es gerade erlebt haben"). **⚠️ SMS-Spam-Risiko:** Erste Tests zeigten SMS im Spam-Ordner. Vor Umsetzung Lösung finden (Twilio Branded Sender / 10DLC Registration / CH-spezifische Carrier-Regeln). | CC | Sales-Phase | OFFEN |
+| N22 | **Tenant Brand Color → OPS** | CC | Demo-relevant | OFFEN |
+| N23 | **Analytics Dashboard** | CC | Post-Go-Live | OFFEN |
+| N29 | **PLZ/Ort Smart Verification** | CC | Post-Go-Live | OFFEN |
+| N33 | **Demo-Booking SMS** | CC | SMS-Spam-Risiko klären | OFFEN |
 
 ---
 
-## SALES — Aktive Kundenakquise (ab 02.03.2026)
+## SALES — Aktive Kundenakquise
 
 **Tracker:** `docs/sales/pipeline.md`
 **Rhythmus:** Täglich 4-5h, 5 neue Prospects/Woche
 **Methode:** Demo-Website für Prospect bauen → E-Mail → Anruf nach 2 Tagen
+**Tooling:** `scout.mjs` (ICP Scoring, Multi-Query, Municipality Scouting) + `prospect_pipeline.mjs`
 
 | # | Task | Owner | Status |
 |---|------|-------|--------|
 | S1 | Sales Pipeline Tracker eingerichtet | CC | **DONE** ✅ |
-| S2 | Erste 5 Prospects identifizieren + Demo-Websites bauen | Founder + CC | OFFEN — Start 02.03. |
+| S2 | Scout v2 — ICP Scoring + Multi-Query | CC | **DONE** ✅ |
 | S3 | E-Mail-Vorlage + Anruf-Skript ready | CC | **DONE** ✅ |
-| S4 | Wöchentliche Pipeline-Review (jeden Freitag) | Founder | OFFEN |
+| S4 | Wöchentliche Pipeline-Review | Founder | OFFEN |
+| S5 | BigBen Pub — Paul Follow-up | Founder | OFFEN — Paul interessiert (#79/#80) |
+| S6 | Sales Agent Pricing aktualisiert (199/299/399) | CC | **DONE** ✅ (PR #94) |
 
 ---
 
@@ -122,43 +108,30 @@
 | L11 | WhatsApp Sandbox → Prod | Founder | Ops Alerts need SLA |
 | L12 | Data protection statements | Founder | Voice disclosure + Wizard checkbox + DPA |
 | L13 | **Demo-Video aufnehmen** | Founder + CC | Go-Live + Demo-Strang shipped |
-| N24 | **Mobile App / PWA** — Fälle auf Handy verfolgen, Routen planen, Kunden anrufen, Kalender-Sync. Killer-Feature für Handwerker auf der Baustelle. (Bug 6) | CC | Erste zahlende Kunden + Feedback |
+| N24 | **Mobile App / PWA** | CC | Erste zahlende Kunden + Feedback |
 
 ---
 
-## Completed (Archiv — kondensiert)
+## Completed (Archiv — kondensiert, seit 04.03.)
 
 | Datum | Deliverable | Evidence |
 |-------|-------------|----------|
-| 2026-02-25 | Strang A-E: Entitlements, Peoplefone, WhatsApp, Morning Report, Security | Welle 23-25, migrations applied |
-| 2026-02-26 | DemoForm, Dörfler Website, Sales Voice Agent "Lisa", Pricing, Business Briefing | /kunden/doerfler-ag, /api/retell/sales, /pricing |
-| 2026-02-27 | GBP + LinkedIn, Website-Optimierung (SEO/Kontakt/Demo/Keywords), OPS Dashboard Redesign, Website Process Flow | W1-W4, OpsShell, CaseTimeline, 3 migrations |
-| 2026-02-28 | Demo-Strang Brunner HT (v1→v4): Tenant, Seed Data, Custom Demo Page, BrunnerWizardForm, 6-Service Card Grid, lokale Bilder, Team Split-Layout | /brunner-haustechnik, 10 seed cases, 31 images |
-| 2026-02-28 | Sales Pipeline Tracker, N15 Terminerinnerung, SSOT-Konsolidierung | docs/sales/pipeline.md |
-| 2026-03-01 | Brunner Voice Agent v2 (DE+INTL, Intake+Info Dual-Mode, Firmen-Wissen), Template-System, Setup-Runbook, Twilio +41 44 505 48 18 | retell/exports/brunner_agent*.json, retell/templates/README.md |
-| 2026-03-01 | **7-Task Sprint:** N12 fix (auto-save actions), N13 fix (grid alignment), N10 fix (German voice email), N14 (Timeline next step), N5 (MS Bookings), N6 (Pitch Deck), Onboarding Script | CaseDetailForm, CaseTimeline, webhook, DemoForm, pitch_deck.html, onboard_tenant.mjs |
-| 2026-03-01 | **N2 E-Mail-First Workflow:** HTML Ops-Notification (Navy/Gold, Urgency-Header rot/amber/slate, CTA-Button), HTML Reporter-Bestätigung, Adresse+Melder in Payload | resend.ts, cases/route.ts, retell/webhook/route.ts |
-| 2026-03-01 | **N17 Case Detail Redesign:** No edit toggle, all fields editable, compact 2-col layout, contact/timeline sidebar, simplified timeline (gray dots, amber next-step), API extended (urgency/category/plz/city/description) | CaseDetailForm.tsx, page.tsx, CaseTimeline.tsx, route.ts |
-| 2026-03-01 | **N18 Case List UX:** Clickable rows, text search (6 columns), server-side pagination (15/page), filterHref bug fix | CaseListClient.tsx, cases/page.tsx |
-| 2026-03-01 | **N19 Mobile Auth Fix:** /auth/confirm converted from server GET to client page with "Login bestätigen" button (prevents email prefetch consuming OTP) | ConfirmAuth.tsx, auth/confirm/page.tsx |
-| 2026-03-02 | **N20 Voice PLZ Overhaul:** City-only confirmation (no digit readback), normalizePlz() webhook safety net, DE+INTL agent configs updated | webhook/route.ts, brunner_agent*.json |
-| 2026-03-02 | **Retell Sync Script:** Automated agent deployment (create/update flows+agents, cross-link swap tools, publish). Idempotent, --dry-run support. | scripts/_ops/retell_sync.mjs |
-| 2026-03-02 | **N26 SMS Channel:** Post-call SMS (Twilio alphanumeric), HMAC-secured verify page, address correction API, photo upload (signed URLs → Supabase Storage), CorrectionForm (mobile-first). Webhook SMS logging (sms_sent/sms_skip). | sendSms.ts, postCallSms.ts, verifySmsToken.ts, /verify/[caseId], /api/verify/[caseId] |
-| 2026-03-02 | **Voice Agent v3:** SMS+photo mention in closing text, no repeat after goodbye, Dörfler PLZ city-only fix, Dörfler voice_id fix (ElevenLabs→Retell). All 4 agents synced via retell_sync.mjs. | brunner_agent*.json, doerfler_agent*.json |
-| 2026-03-02 | **Vercel Region → Frankfurt (fra1):** Bessere Latenz zu CH-Usern + Supabase (auch Frankfurt). | Vercel Dashboard |
-| 2026-03-03 | **CoreBot (Telegram → GitHub Issues):** Single Vercel API route, auto-classification (type+domain labels), /status command, Telegram ACK, user whitelist, shared secret auth, dedupe. Runbook: `docs/runbooks/corebot_setup.md` | /api/telegram/webhook |
-| 2026-03-03 | **Prospect Pipeline:** Full-stack onboarding script. Quick mode (--url + --slug: Puppeteer crawl → auto-config) + Config mode (--config). Generates: website TS config + images + registry update + Supabase tenant + Voice agent JSONs (DE+INTL). ~15min/prospect vs ~70min manual. | scripts/_ops/prospect_pipeline.mjs |
-| 2026-03-03 | **N32 Mobile Login Fix:** Created missing Supabase auth middleware for session refresh. Root cause: server-auth.ts referenced middleware that didn't exist. | src/web/middleware.ts |
-| 2026-03-03 | **N31 Voice Closing Fix:** Removed language-trigger edges from closing/out-of-scope nodes in all 4 agent JSONs (brunner+doerfler, DE+INTL). Also fixed doerfler duplicate edges key. | retell/exports/*.json |
-| 2026-03-03 | **N30 SMS Short Link:** Short verify route `/v/[caseId]?t=<16hex>` using first 8 bytes of HMAC. URL ~85 chars (was ~150). API accepts both full and short tokens. | verifySmsToken.ts, postCallSms.ts, /v/[caseId] |
-| 2026-03-03 | **N28 KPI Cards Click-to-Filter:** 4 existing KPI cards now link to filtered views (Total→all, Neu→new, In Bearbeitung→default, Erledigt→done). | CaseListClient.tsx |
-| 2026-03-03 | **N27 Case Detail UX v2:** Description full-width, Termin left (8/11/15h) + Notes right, "Termin senden" inline prominent, simplified action bar. | CaseDetailForm.tsx |
-| 2026-03-03 | **Dashboard Showcase:** Replaced single-case mockup in "Alles kommt zu Ihnen" section with full dashboard mockup (KPI cards + 10 realistic cases in table, sidebar hint, search bar). Full-width layout with features below. | DashboardMockup.tsx, (marketing)/page.tsx |
-| 2026-03-03 | **Demo-Kit + SIP Fix:** Complete demo toolkit (MicroSIP setup, audio proof, reset SQL, cheat sheet, Twilio diagnose+fix scripts). Fixed SIP auth mismatch (Error 32202) + missing callerId (Error 13214). Created `/api/demo/sip-twiml` route. Verified: Call connected, Lisa answers, 0 errors. | demo-kit/*, src/web/app/api/demo/sip-twiml/route.ts |
-| 2026-03-04 | **CoreBot Attachments (PR #27):** Photo/Document support in Telegram → GitHub Issue flow. Session persistence via Supabase Storage (L1 in-memory + L2 cross-instance). /ticket command, 5 attachments/ticket, 25MB limit, inline images in GitHub comments. | /api/telegram/webhook |
-| 2026-03-04 | **P0 Demo Fix (PR #29, Closes #28):** (1) SMS verify attachments route accepted only full 64-hex tokens, but SMS sends short 16-hex → "Invalid token". Fix: accept both. (2) PKCE magic link fails cross-browser (in-app browser). Fix: flowType: implicit → token_hash (no stored verifier needed). | attachments/route.ts, browser.ts, ConfirmAuth.tsx |
-| 2026-03-04 | **Voice STT Hardening (PR #32, Closes #31):** Discriminated union return type (TranscribeOk/TranscribeFail), 30s AbortController timeout, error categories (auth/quota/timeout/format/network/empty), OPENAI_API_KEY len+prefix logging, voice OGG fallback upload to corebot-files when STT fails, STT error reason in Telegram ACK. Root cause: wrong API key in Vercel env. | /api/telegram/webhook |
+| 2026-03-04 | CoreBot Attachments, P0 Demo Fix, Voice STT Hardening | PRs #27, #29, #32 |
+| 2026-03-05 | Voice Closing Loop Fix (dynamic SIP routing), SMS Alpha Sender Fix | PRs #46, #47, #54, #55, #56 |
+| 2026-03-05 | Demo Booking SMS Confirmation + Wizard Photo Upload | PRs #53, #57 |
+| 2026-03-05 | SIP TwiML POST body fix, Handout Premium Redesign | PRs #58, #59, #60 |
+| 2026-03-06 | BigBen Pub Custom Demo (Reservierung, Events, Galerie, Reviews) | PRs #62–#66, #69–#72 |
+| 2026-03-06 | Scout v2 (ICP Scoring, Multi-Query), 3 Prospect Demo-Websites | PRs #73–#75 |
+| 2026-03-07 | Customer Template Redesign (ServiceDetailOverlay, Galleries) | PRs #76–#77 |
+| 2026-03-07 | Walter Leuthold v3 (Founder Feedback), Customer Wizard (branded, service-based) | PRs #83–#85 |
+| 2026-03-07 | reporter_name Feature (Wizard + Voice + Webhook + Verify) | PR #86 |
+| 2026-03-08 | Orlandini + Widmer Website Rebuild (high-end, real data) | PR #88 |
+| 2026-03-08 | Customer Links Page + LinkedIn Company URL Fix | PR #91 |
+| 2026-03-08 | Sales Agent Pricing Update (199/299/399) | PR #94 |
+| 2026-03-08 | Lightbox z-index Fix + Mobile Gallery Arrows | PR #95 |
+| 2026-03-08 | Widmer Spenglerei + Intake Process Standardization | PR #96 |
+| 2026-03-08 | Customer Links Docs (links.md pro Kunde, PFLICHT) | PR #97 |
+
+**Ältere Completed (vor 04.03.):** Siehe `docs/archive/wave_log.md`
 
 **Erledigte Founder Blocks:** B (LinkedIn ✅), C (GBP ✅), F2 (Email Deliverability ✅), F5 (Voice Regression ✅), F6 (2FA Audit ✅), F10 (Billing Guard ✅)
-
-**Vollständiges Wave-Log:** `docs/archive/wave_log.md`

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # FlowSight — STATUS (Company SSOT)
 
-**Datum:** 2026-03-04 (PR #32: Voice STT Hardening + CoreBot Attachments verified)
+**Datum:** 2026-03-08 (PR #97: Customer Links Docs + Widmer Spenglerei)
 **Owner:** Founder + CC (Head Ops)
 
 ## Was ist FlowSight?
@@ -23,42 +23,47 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 
 | Modul | Status | Evidence |
 |-------|--------|----------|
-| **Wizard** (Website Intake) | LIVE ✅ | /wizard + /doerfler-ag/meldung → case → email |
-| **Voice** (Telefon Intake) | LIVE ✅ | Dual-Agent DE/INTL, City-only PLZ confirmation, Language Gate, SMS+Photo mention in closing |
+| **Wizard** (Website Intake) | LIVE ✅ | /kunden/[slug]/meldung — service-based categories, branded per customer, photo upload, reporter_name |
+| **Voice** (Telefon Intake) | LIVE ✅ | Dual-Agent DE/INTL, City-only PLZ, Language Gate, SMS+Photo mention, reporter_name, deterministic closing |
 | **SMS Channel** | LIVE ✅ | Post-call SMS with short correction link `/v/[id]?t=<16hex>` (~85 chars) + photo upload. Twilio alphanumeric sender. HMAC-secured. |
-| **Ops Dashboard** | LIVE ✅ | /ops — Case Detail (UX v2: full-width desc, inline Termin+Senden, 3 quick times), Case List (search, pagination, clickable rows, KPI click-to-filter), CSV-Export, Timeline |
-| **Email Notifications** | LIVE ✅ | HTML Ops-Notification (urgency colors, CTA) + HTML Melder-Bestätigung + Review-Anfrage + Demo + Sales Lead |
+| **Ops Dashboard** | LIVE ✅ | /ops — Case Detail (UX v2), Case List (search, pagination, KPI click-to-filter), CSV-Export, Timeline |
+| **Email Notifications** | LIVE ✅ | HTML Ops-Notification + Melder-Bestätigung + Review-Anfrage + Demo + Sales Lead |
 | **Peoplefone Front Door** | LIVE ✅ | Brand-Nr → Twilio → SIP → Retell |
 | **Morning Report** | LIVE ✅ | 10 KPIs, severity ampel, WhatsApp --send |
 | **Marketing Website** | LIVE ✅ | flowsight.ch (homepage, pricing, legal, demo booking) |
-| **Sales Voice Agent** | LIVE ✅ | "Lisa" auf 044 552 09 19, Lead-E-Mail an Founder |
-| **Customer Websites** | LIVE ✅ | /kunden/[slug] — SSG template (12 sections, lightbox) |
+| **Sales Voice Agent** | LIVE ✅ | "Lisa" auf 044 552 09 19, Pricing aktualisiert (Starter 199/Alltag 299/Wachstum 399) |
+| **Customer Websites** | LIVE ✅ | /kunden/[slug] — SSG template (12 sections, ServiceDetailOverlay, lightbox, galleries) |
+| **Customer Links Page** | LIVE ✅ | /kunden/[slug]/links — SSG, alle Kunden-URLs auf einen Blick, noindex |
 | **Review Engine** | LIVE ✅ | Manual button, review_sent_at, GOOGLE_REVIEW_URL |
 | **Entitlements** | LIVE ✅ | hasModule() — per-tenant module gating |
-| **CoreBot** | LIVE ✅ | Telegram → GitHub Issues (auto-classify, /status, ACK, **Voice→STT→Issue** with hardened error reporting, **Photo/Doc Attachments** via Supabase Storage, **/ticket** command, cross-instance sessions) |
-| **Demo-Strang** | LIVE ✅ | /brunner-haustechnik — High-End Demo (6-Service Grid, 30 Bilder, KI-Teamfoto, Voice Agent Intake+Info) |
+| **CoreBot** | LIVE ✅ | Telegram → GitHub Issues (Voice→STT, Photo/Doc Attachments, /ticket, /status) |
+| **Demo-Strang** | LIVE ✅ | /brunner-haustechnik — High-End Demo + Voice Agent Intake+Info |
+| **BigBen Pub** | LIVE ✅ | /bigben-pub — Custom Demo (Reservierungen, Events, Galerie, Google Reviews) |
 
-## Kunden
+## Kunden (6 Websites live)
 
-| Kunde | Slug | Module | Go-Live |
-|-------|------|--------|---------|
-| Dörfler AG (Oberrieden) | doerfler-ag | voice, wizard, ops, reviews | PARTIAL — 3/4 PASS, Reviews blocked (F9) |
-| Brunner Haustechnik AG (Thalwil) | brunner-haustechnik | voice, wizard, ops, reviews, sms | DEMO — Showroom-Tenant, Voice +41 44 505 48 18, SMS "BrunnerHT" |
+| Kunde | Slug | Module | Status |
+|-------|------|--------|--------|
+| Dörfler AG (Oberrieden) | doerfler-ag | voice, wizard, ops, reviews | PARTIAL — 3/4 PASS |
+| Brunner Haustechnik AG (Thalwil) | brunner-haustechnik | voice, wizard, ops, reviews, sms | DEMO-Tenant |
+| Walter Leuthold (Oberrieden) | walter-leuthold | wizard | Website LIVE |
+| Orlandini Sanitär (Horgen) | orlandini | wizard | Website LIVE |
+| Widmer H. & Co. AG (Horgen) | widmer-sanitaer | wizard | Website LIVE |
+| BigBen Pub (Zürich) | bigben-pub | — | Custom Demo |
 
 ## Aktueller Stand
 
-- **14 Module LIVE.** CoreBot now with Voice→STT→Issue (hardened: 30s timeout, error categories, voice fallback) + Photo/Doc Attachments (Supabase Storage cross-instance sessions) + /ticket command.
-- **Voice STT Fix (04.03.):** OpenAI API Key issue diagnosed via new error reporting (PR #32). Hardened: discriminated union return type, AbortController timeout, error categories (auth/quota/timeout/format/network/empty), voice OGG fallback upload when STT fails. Founder-confirmed working.
-- **CoreBot Attachments (04.03.):** Photo/Doc upload + session persistence (L1 in-memory + L2 Supabase Storage) verified end-to-end. PR #27.
-- **P0 Demo-Fixes (04.03.):** SMS Verify Token (short 16-hex accepted) + PKCE Magic Link (flowType: implicit). PR #29.
-- **E2E Test 02.03.:** Voice ✅, E-Mail ✅, SMS ✅ (Twilio delivered, BrunnerHT Sender).
-- **Erledigt:** N17-N21 ✅, N26-N28 ✅, N30-N32 ✅, Issue #28 ✅, Issue #31 ✅ — 20+ Bugs fixed
+- **16 Module LIVE.** +2 seit letztem Update (Customer Links Page, BigBen Pub).
+- **37 Commits seit 04.03.** (PRs #53–#97).
+- **Website-Template v3 (08.03.):** ServiceDetailOverlay + Bullets + per-Service Galleries + Lightbox z-[200] + Mobile Gallery Arrows. Standardisierter 10-Regeln Intake-Prozess.
+- **Customer Wizard (07.03.):** Branded pro Kunde, Kategorien aus `services[]`, reporter_name, Photo Upload auf Success-Screen.
+- **Voice Agent v4 (07.03.):** reporter_name, deterministic ß→ss, farewell no-repeat, end_call tool, dynamic SIP routing.
+- **Sales Agent Pricing (08.03.):** Starter CHF 199, Alltag CHF 299, Wachstum CHF 399 (war 99/249/349).
+- **Scout Tooling (06.03.):** ICP Scoring, Multi-Query, Municipality Scouting, Prospect Pipeline ready.
+- **BigBen Pub (06.03.):** Custom Demo für Gastronomie-Prospect. Reservierung, Events, Galerie, Google Reviews. Zeigt Template-Flexibilität.
+- **Docs-Standard (08.03.):** `docs/customers/<slug>/links.md` = PFLICHT pro Kunde.
 - **BLOCKER:** Keine. Go-Live möglich.
-- **Vercel Region:** Frankfurt (fra1) — näher an Supabase + CH-Usern.
-- **Ops Tooling:** `retell_sync.mjs` (Retell API Sync), `onboard_tenant.mjs` (Tenant Setup), `prospect_pipeline.mjs` (Full-Stack Prospect Onboarding, ~15min/prospect)
-- **Demo-Kit:** `demo-kit/` — Komplett-Toolkit (SIP-Setup, Audio-Proof, Reset-SQL, Cheat Sheet, Twilio-Diagnose+Fix Scripts)
-- **SIP Call Chain:** Twilio SIP → `/api/demo/sip-twiml` (callerId) → Retell Lisa. MicroSIP credentials: `flowsight-demo`. Verified: Call SID `CAfffc69b90813874e976ba5481258f4db` status `in-progress` (clean, 0 errors).
-- **Nächster Schritt:** Kundenakquise starten. Pipeline: `node prospect_pipeline.mjs --url https://x.ch --slug x`
+- **Nächster Schritt:** Kundenakquise fortsetzen. Offene Issues #79/#80 (BigBen Pub Feedback), #81 (Voice Handy).
 
 ## Fixe Entscheidungen (No Drift)
 
@@ -78,6 +83,8 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 | `docs/sales/pipeline.md` | Sales Pipeline Tracker |
 | `CLAUDE.md` | Repo-Guardrails, Conventions |
 | `docs/customers/<slug>/status.md` | Pro-Kunde Status |
+| `docs/customers/<slug>/links.md` | Kunden-URLs (PFLICHT pro Kunde) |
+| `docs/customers/lessons-learned.md` | Intake-Prozess, Template-Learnings, Kunden-Learnings |
 | `docs/architecture/contracts/` | Case-Datenmodell, Env Vars |
 | `docs/compliance/` | Datenschutz, Subprocessors |
 | `docs/runbooks/` | Onboarding, Release, Incidents, Voice Config, Demo Script, CoreBot Setup, Sales Agent Brief |

--- a/docs/business_briefing.md
+++ b/docs/business_briefing.md
@@ -2,7 +2,7 @@
 
 > Dieses Dokument ist der komplette Kontext für ChatGPT, Claude und externe Partner.
 > Copy-paste als System-Prompt oder ersten Message. Deckt Business, Produkt, Technik und Strategie ab.
-> Letzte Aktualisierung: 2026-03-04
+> Letzte Aktualisierung: 2026-03-08
 
 ---
 
@@ -15,7 +15,7 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 
 **Firma:** FlowSight GmbH (Schweizer GmbH)
 **Gründer:** Gunnar Wende, Solo-Founder, Zürich
-**LinkedIn:** linkedin.com/in/gunnar-wende
+**LinkedIn:** linkedin.com/company/flowsight-gmbh
 **Website:** flowsight.ch
 **Geschäftsnummer:** +41 44 552 09 19 (KI-Assistentin "Lisa")
 
@@ -38,7 +38,7 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 - "Seit 19xx" ist der #1 Trust-Signal
 - Schnelle Reaktionszeit und Sauberkeit sind die meistgenannten Review-Themen
 
-**Spätere Branchen-Erweiterung:** Elektriker, Friseur, Pub (ab Phase 3, 15+ Kunden)
+**Spätere Branchen-Erweiterung:** Elektriker, Gastronomie (BigBen Pub = erste Demo), Friseur (ab Phase 3, 15+ Kunden)
 
 **Typische Kunden-Aussagen:**
 - "Ich bin den ganzen Tag auf der Baustelle, kann nicht ans Telefon."
@@ -52,31 +52,40 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 
 ### 3.1 Moderne Website
 - High-End Website im Firmenlook, mobil-optimiert, SEO
-- Template-System: 12 Sektionen (Hero, Leistungen, Notdienst, Bewertungen, Team, Einzugsgebiet, Karriere, Kontakt, etc.)
+- Template-System: 12 Sektionen (Hero, Leistungen mit Detail-Overlays, Notdienst, Bewertungen, Team, Einzugsgebiet, Karriere, Kontakt, etc.)
+- **ServiceDetailOverlay:** Klick auf Service → Overlay mit Beschreibung, Bullet Points, Bilder-Galerie
+- **Bild-Galerie:** Horizontal-Scroll + Lightbox (z-[200]), per Service
 - Pro Kunde konfigurierbar via Config-Datei (Farben, Texte, Bilder, Services)
 - SSG (Static Site Generation) für maximale Performance
+- **Customer Links Page:** /kunden/[slug]/links — alle URLs auf einen Blick (noindex)
 - URL: flowsight.ch/kunden/[firmen-slug]
-- **Erstellungszeit: ~20 Minuten pro Kunde**
+- **6 Kunden-Websites live** (inkl. Demo-Tenant und BigBen Pub)
+- **Erstellungszeit: ~20 Minuten pro Kunde** (standardisierter 10-Regeln Intake-Prozess)
 
 ### 3.2 Schadenmelde-Wizard
 - 3-Schritt Online-Formular auf der Kunden-Website
-- Schritt 1: Kategorie wählen (Verstopfung, Leck, Heizung, Boiler, Rohrbruch, Sanitär allgemein)
+- **Branded pro Kunde** — Farben, Logo, Kategorien aus `services[]` abgeleitet
+- Schritt 1: Kategorie wählen (dynamisch aus Kunden-Services)
 - Schritt 2: Kontaktdaten (Name, Telefon, E-Mail, Adresse mit PLZ)
 - Schritt 3: Beschreibung + optionale Fotos (Supabase Storage)
+- **Photo Upload auf Success-Screen** (nach Fallanlage)
+- **reporter_name** als Pflichtfeld (Wizard, Voice, Verify, E-Mail)
 - Ergebnis: Fall wird in Supabase erstellt, Ops-E-Mail + Melder-Bestätigung gesendet
 - Mobil-optimiert, branded im Kunden-Look
 
 ### 3.3 KI-Telefonassistent (Voice Agent)
 - **Technologie:** Retell AI (Conversational Voice AI)
 - **Flow:** Anruf → Peoplefone (Schweizer Nummer) → Twilio SIP → Retell Agent → Webhook → Supabase → E-Mail
-- **Dual-Agent:** Deutsch (Stimme "Susi") + International/Englisch (Stimme "Juniper")
+- **Dual-Agent:** Deutsch (Stimme "Susi") + International/Englisch (Stimme custom)
 - **Language Gate:** Erkennt automatisch ob Deutsch oder andere Sprache
 - **Zwei Modi (automatische Erkennung):**
-  - **Intake-Modus:** Schadensmeldung aufnehmen (max 7 Fragen: Kategorie, PLZ, Adresse, Dringlichkeit, Beschreibung) → Fall in Supabase + E-Mails
-  - **Info-Modus:** Allgemeine Fragen beantworten (Öffnungszeiten, Preise, Einzugsgebiet, Team, Bewerbungen, Beratung) → kein Ticket, nur freundliche Auskunft
+  - **Intake-Modus:** Schadensmeldung aufnehmen (max 7 Fragen: Name, Kategorie, PLZ/Ort, Adresse, Dringlichkeit, Beschreibung) → Fall in Supabase + E-Mails
+  - **Info-Modus:** Allgemeine Fragen beantworten (Öffnungszeiten, Preise, Einzugsgebiet, Team, Bewerbungen, Beratung) → kein Ticket
+- **Dynamic SIP Routing** (Twilio → richtiger Agent per Nummer)
+- **Deterministic Closing:** Farewell no-repeat, end_call tool, ß→ss in Analyse
 - **Recording: OFF** (Datenschutz)
 - **24/7 erreichbar**, keine verpassten Anrufe
-- **Template-System:** Agent-Configs als JSON-Schablone für schnelle Kunden-Onboardings (~20 Min)
+- **Template-System:** Agent-Configs als JSON-Schablone (~20 Min pro Kunde)
 
 ### 3.4 Ops Dashboard
 - Web-App unter /ops (Login via Supabase Auth)
@@ -84,7 +93,7 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 - **Filter:** Status, Quelle, Kategorie, Zeitraum, Tenant
 - **Fall-Detailansicht:** Kontaktdaten, Fallbeschreibung, Fotos, Timeline (case_events), Notizen
 - **Aktionen:** Status ändern, Termin senden (E-Mail an Melder), Review anfragen, manueller Fall erstellen
-- **KPI-Cards:** Offene Fälle, Neue heute, Ø Reaktionszeit
+- **KPI-Cards:** Click-to-Filter (Total→all, Neu→new, In Bearbeitung→default, Erledigt→done)
 - **CSV-Export** für Buchhaltung/Reporting
 - **Light Theme**, Sidebar-Navigation, responsive
 
@@ -92,7 +101,7 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 - Nach erledigtem Fall: Button "Review anfragen" im Ops Dashboard
 - Sendet E-Mail an Melder mit direktem Link zur Google-Bewertungsseite
 - Tracking: review_sent_at Timestamp pro Fall
-- Google Review URL pro Tenant konfigurierbar (GOOGLE_REVIEW_URL in Entitlements)
+- Google Review URL pro Tenant konfigurierbar
 
 ### 3.6 Morning Report
 - Täglicher Statusbericht: 10 KPIs, Severity-Ampel (GREEN/YELLOW/RED)
@@ -100,44 +109,52 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 - Nur System-Alerts, keine Kundendaten (PII)
 
 ### 3.7 E-Mail-Notifications
-- **Ops Notification:** Neuer Fall → E-Mail an Betrieb (Zusammenfassung, Link zum Dashboard)
-- **Melder-Bestätigung:** "Wir haben Ihre Meldung erhalten" → E-Mail an den Kunden des Betriebs
+- **Ops Notification:** Neuer Fall → E-Mail an Betrieb
+- **Melder-Bestätigung:** "Wir haben Ihre Meldung erhalten" → E-Mail an Endkunden
 - **Review-Anfrage:** "Wie war unser Service?" → E-Mail mit Google-Review-Link
 - **Demo-Anfrage:** /demo Formular → E-Mail an Founder
 - **Sales Lead:** Voice Agent Lead → E-Mail an Founder
-- Provider: Resend (Transaktional, SPF/DKIM/DMARC verifiziert)
+- Provider: Resend (SPF/DKIM/DMARC verifiziert)
 
 ### 3.8 SMS Channel
-- Post-call SMS mit Korrekturlink an Melder (Twilio alphanumeric sender, z.B. "BrunnerHT")
+- Post-call SMS mit Korrekturlink an Melder (Twilio alphanumeric sender)
 - Kurzlink `/v/[caseId]?t=<16hex>` (~85 Zeichen), HMAC-gesichert
 - Foto-Upload via Verify-Seite (Supabase Storage)
 - Akzeptiert sowohl Full-Token (64-hex) als auch Short-Token (16-hex)
 
 ### 3.9 CoreBot (Ops-Assistent)
-- Telegram Bot → GitHub Issues (automatische Klassifizierung: type + domain Labels)
-- **Voice→STT→Issue:** Sprachnachricht → OpenAI Whisper Transkription → GitHub Issue
-- **Photo/Doc Attachments:** Fotos + Dokumente an Tickets anhängen (Supabase Storage, inline in GitHub)
-- **/ticket Befehl:** Ticket ohne Sprachnachricht erstellen + Anhänge innerhalb 120s
-- **/status Befehl:** Übersicht offener GitHub Issues
-- Session-Persistenz: L1 In-Memory + L2 Supabase Storage (cross-instance, serverless-safe)
-- Limiten: max 5 Anhänge/Ticket, 25MB total, 120s Session-Fenster
+- Telegram Bot → GitHub Issues (automatische Klassifizierung)
+- **Voice→STT→Issue:** Sprachnachricht → OpenAI Whisper → GitHub Issue
+- **Photo/Doc Attachments:** Fotos + Dokumente an Tickets (Supabase Storage)
+- **/ticket** und **/status** Befehle
+- Session-Persistenz: L1 In-Memory + L2 Supabase Storage
 
 ### 3.10 Entitlements
-- Per-Tenant Module Gating via hasModule() Funktion
+- Per-Tenant Module Gating via hasModule()
 - Module: voice, wizard, ops, reviews, morning_report, sms
-- Konfiguration in Supabase tenants-Tabelle (modules JSONB Array)
+- Konfiguration in Supabase tenants-Tabelle
+
+### 3.11 Sales Voice Agent "Lisa"
+- Auf Geschäftsnummer +41 44 552 09 19
+- DE + INTL (auto language swap)
+- Beantwortet Fragen zu FlowSight, sammelt Demo-Anfragen
+- **Pricing aktuell:** Starter CHF 199, Alltag CHF 299, Wachstum CHF 399
 
 ---
 
 ## 4. Pakete & Pricing
 
-| Paket | Inhalt | Preis (indikativ) |
-|-------|--------|-------------------|
-| **Starter** | Website + Wizard | ab CHF 99/Monat + Setup |
-| **Professional** | + Voice Agent + Ops Dashboard | ab CHF 249/Monat + Setup |
-| **Premium** | + Reviews + Morning Report | ab CHF 349/Monat + Setup |
+| Paket | Inhalt | Preis |
+|-------|--------|-------|
+| **Starter** | Moderne Website + Online-Schadensmeldung + E-Mail-Benachrichtigung + Kunden-SMS + Persönliches Onboarding | CHF 199/Monat |
+| **Alltag** | + Digitaler Telefonassistent (24/7) + Fallübersicht + Bestätigungs-SMS + Foto-Upload + Mehrsprachig | CHF 299/Monat |
+| **Wachstum** | + Google Review-Anfragen + Priority Support + Stärkeres Google-Profil | CHF 399/Monat |
 
-Live auf flowsight.ch/pricing. Preise werden vor Launch finalisiert.
+- Telefonminuten: pay-per-use, keine Grundgebühr. Typischer Anruf: 2-4 Minuten.
+- Monatlich kündbar, kein Lock-in.
+- Setup in einer Woche, persönliches Onboarding. Keine Setup-Kosten während Pilotphase.
+
+Live auf flowsight.ch/pricing.
 
 ---
 
@@ -147,7 +164,7 @@ Live auf flowsight.ch/pricing. Preise werden vor Launch finalisiert.
 
 | Layer | Technologie | Plan |
 |-------|------------|------|
-| Frontend + API | Next.js App Router (Vercel) | Hobby (Free) |
+| Frontend + API | Next.js App Router (Vercel Frankfurt) | Hobby (Free) |
 | Datenbank | Supabase (PostgreSQL + Storage + Auth) | Free |
 | Voice | Retell AI → Twilio SIP → Peoplefone | Pay-as-you-go |
 | Email | Resend | Free (100/Tag) |
@@ -169,12 +186,12 @@ VERARBEITUNG:
 OUTPUT:
   → Ops E-Mail an Betrieb (Resend)
   → Bestätigungs-E-Mail an Melder (Resend)
+  → SMS mit Korrekturlink (Twilio, wenn Voice)
   → case_events Eintrag ("Benachrichtigung gesendet")
 
 NACH ERLEDIGUNG:
   → Status → "resolved" (im Dashboard)
   → Optional: Review-Anfrage per E-Mail
-  → Optional: Terminerinnerung (geplant)
 ```
 
 ### Multi-Tenancy
@@ -190,7 +207,7 @@ NACH ERLEDIGUNG:
 - Voice: Intake-only, max 7 Fragen, branchenspezifisch, Recording OFF
 - Output: E-Mail für Kunden. WhatsApp nur Founder-Ops-Alerts (kein PII)
 - SSOT: Supabase = Daten, Vercel Env = Secrets
-- Deploy: Vercel, Root Directory = src/web
+- Deploy: Vercel Frankfurt (fra1), Root Directory = src/web
 - Keine Secrets im Repo
 
 ---
@@ -200,23 +217,33 @@ NACH ERLEDIGUNG:
 | Kunde | Status | Module | URL |
 |-------|--------|--------|-----|
 | **Dörfler AG** (Oberrieden) | Go-Live PARTIAL (3/4 PASS) | voice, wizard, ops, reviews | flowsight.ch/kunden/doerfler-ag |
-| **Brunner Haustechnik AG** (Thalwil) | DEMO (fiktiv) | voice, wizard, ops, reviews, sms | flowsight.ch/brunner-haustechnik |
+| **Brunner Haustechnik AG** (Thalwil) | DEMO (fiktiv) | voice, wizard, ops, reviews, sms | flowsight.ch/kunden/brunner-haustechnik |
+| **Walter Leuthold** (Oberrieden) | Website LIVE | wizard | flowsight.ch/kunden/walter-leuthold |
+| **Orlandini Sanitär** (Horgen) | Website LIVE | wizard | flowsight.ch/kunden/orlandini |
+| **Widmer H. & Co. AG** (Horgen) | Website LIVE | wizard | flowsight.ch/kunden/widmer-sanitaer |
+| **BigBen Pub** (Zürich) | Custom Demo | — | flowsight.ch/bigben-pub |
 
 ### Dörfler AG — Erster Referenzkunde
 - Sanitär/Heizung seit 1926, Oberrieden ZH
 - 3/4 Module getestet und bestanden
 - Reviews noch blockiert (Google Review Link fehlt, nicht Go-Live-kritisch)
-- Founder muss noch E2E Checklist durcharbeiten → Go/No-Go Entscheid
+- Founder muss Go/No-Go Entscheid treffen
 
 ### Brunner Haustechnik AG — Demo-Tenant
 - Fiktiver Betrieb für Sales-Demos (Thalwil ZH)
-- High-End Custom Demo Page (10 Sections, 30 kuratierte Bilder, KI-Teamfoto)
-- 10 Seed Cases im Ops Dashboard (FS-0001 bis FS-0010)
-- Eigener Wizard mit Brunner-Branding
-- Eigener Voice Agent (DE + INTL) auf **+41 44 505 48 18** mit zwei Modi:
-  - **Intake-Modus:** Schadensmeldungen aufnehmen → Ticket im Dashboard
-  - **Info-Modus:** Alltagsfragen beantworten (Öffnungszeiten, Preise, Einzugsgebiet, "Chef sprechen", Bewerbungen, etc.) → kein Ticket
-- Agent-Configs = Schablone für alle künftigen Kunden (`retell/templates/README.md`)
+- Voice Agent (DE + INTL) auf **+41 44 505 48 18**
+- 10 Seed Cases im Ops Dashboard
+- Agent-Configs = Schablone für alle künftigen Kunden
+
+### Walter Leuthold, Orlandini, Widmer — Prospect-Websites
+- High-End Websites mit ServiceDetailOverlay, Galleries, realen Google Reviews
+- Template v3: Standardisierter 10-Regeln Intake-Prozess
+- Jeder Kunde hat `docs/customers/<slug>/links.md` mit allen URLs
+
+### BigBen Pub — Gastronomie-Demo
+- Custom Demo für Pub/Gastronomie (Reservierungen, Events, Galerie)
+- Zeigt Template-Flexibilität über Sanitär hinaus
+- Prospect Paul zeigt sich interessiert (#79/#80)
 
 ---
 
@@ -224,22 +251,21 @@ NACH ERLEDIGUNG:
 
 **Methode:** Demo-Website für Prospect bauen → E-Mail → Anruf nach 2 Tagen
 
+**Tooling:**
+- `scout.mjs` — ICP Scoring, Multi-Query, Municipality Scouting
+- `prospect_pipeline.mjs` — Full-Stack Prospect Onboarding (~15min)
+- Sales Voice Agent "Lisa" auf +41 44 552 09 19
+
 **Ablauf pro Prospect (~30 Min):**
-1. Google Maps → Sanitärbetrieb finden (3-30 MA, Raum Zürichsee, schlechte/keine Website)
+1. Google Maps → Betrieb finden (3-30 MA, Raum Zürichsee, schlechte/keine Website)
 2. Website + Google Reviews analysieren
-3. Demo-Website für den Betrieb erstellen (Template-Config, 20 Min)
+3. Demo-Website erstellen (Template-Config, 20 Min)
 4. E-Mail: "Ich habe einen Entwurf für Ihre Website erstellt: [Link]"
 5. Anruf nach 2 Tagen: "Haben Sie die Website gesehen?"
 6. Demo zeigen → Module besprechen → Abschluss
 
 **Ziel:** 5 Prospects/Woche, 1 Neukunde alle 3-6 Wochen
 **Tracker:** docs/sales/pipeline.md
-
-**Warum das funktioniert:**
-- Kein kalter Pitch, sondern ein Geschenk (fertige Website)
-- Prospect sieht seinen eigenen Namen auf einer professionellen Seite
-- Einstieg in Gespräch über Voice Agent, Dashboard, Reviews
-- Daten sind öffentlich (Google Maps, eigene Website)
 
 ---
 
@@ -256,7 +282,7 @@ NACH ERLEDIGUNG:
 - Branchenspezifisch, nicht generisch
 - All-in-one statt 5 verschiedene Tools
 - In einer Woche live, kein IT-Projekt
-- Ab CHF 99/Monat statt CHF 10'000 einmalig
+- Ab CHF 199/Monat statt CHF 10'000 einmalig
 - Schweizer Nummer, Schweizer Hosting, Deutsch
 
 ---
@@ -267,7 +293,7 @@ NACH ERLEDIGUNG:
 |-------|--------|-----------|-------|
 | 1 | 1-5 | 0-6 Monate | Dörfler live, erste Akquise, manuell |
 | 2 | 5-15 | 6-18 Monate | Website-Content → Supabase, einfaches Admin-UI |
-| 3 | 15-30 | 18-30 Monate | Branchen-Templates (Elektriker), Teilzeit-Hilfe |
+| 3 | 15-30 | 18-30 Monate | Branchen-Templates (Elektriker, Gastro), Teilzeit-Hilfe |
 | 4 | 30-100 | 30-48 Monate | Auto-Provisioning, Self-Service, Mitarbeiter |
 
 **Entscheidung:** Produkt-Agents (Voice, Reviews) = selbst bauen. Business-Admin (Rechnungen, Buchhaltung) = kaufen (Bexio).
@@ -300,9 +326,9 @@ NACH ERLEDIGUNG:
 - **Website:** flowsight.ch
 - **Pricing:** flowsight.ch/pricing
 - **Referenz:** flowsight.ch/kunden/doerfler-ag
-- **Demo:** flowsight.ch/brunner-haustechnik
-- **Demo-Wizard:** flowsight.ch/brunner-haustechnik/meldung
+- **Demo:** flowsight.ch/kunden/brunner-haustechnik
+- **Demo-Wizard:** flowsight.ch/kunden/brunner-haustechnik/meldung
 - **Geschäftsnummer:** +41 44 552 09 19 (Lisa)
-- **LinkedIn:** linkedin.com/in/gunnar-wende
+- **LinkedIn:** linkedin.com/company/flowsight-gmbh
 - **Roadmap:** docs/OPS_BOARD.md
 - **Sales Pipeline:** docs/sales/pipeline.md


### PR DESCRIPTION
## Summary
All three SSOT documents were stuck at 2026-03-04 (4 days, 37 commits behind).

**Updated:**
- **STATUS.md**: 16 modules live (was 14), 6 customer websites, current pricing, new features
- **OPS_BOARD.md**: Open GitHub issues (#79-#93), completed PRs #53-#97, cleaned up backlog, sales status
- **business_briefing.md**: Pricing corrected (199/299/399), LinkedIn company URL, 6 customers, template v3 features, scout tooling, BigBen Pub

## Why this matters
These docs are copy-pasted as context for ChatGPT, partners, and new sessions. Drift = wrong decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)