### PR TITLE
fix: Widmer/Orlandini cleanup + cross-customer template rules

### DIFF
--- a/docs/customers/lessons-learned.md
+++ b/docs/customers/lessons-learned.md
@@ -35,12 +35,18 @@
 | 2 | **Bilder** | Nur die Bilder aus dem jeweiligen Ordner. Keine generischen Platzhalter. |
 | 3 | **Hero** | Immer das Bild aus `titelbild/`. Founder entscheidet. |
 | 4 | **Reviews** | NUR wenn `reviews/`-Ordner existiert. Screenshots → Struct extrahieren. Sonst: `highlights: []` |
+| 4b | **Reviews < 5** | "Basierend auf X Bewertungen" wird NICHT angezeigt wenn `totalReviews < 5`. Template-Regel. |
 | 5 | **Brand Color** | Aus alter Website extrahieren. Falls sehr veraltet (>15 Jahre Design) → modernisieren, Founder fragen. |
 | 6 | **Gründungsjahr** | Nur anzeigen wenn Betrieb >20 Jahre alt. |
 | 7 | **History** | Nur wenn >20 Jahre UND alte Website hat Meilensteine/Text. Wenn nichts → History-Section weglassen. |
 | 8 | **Team** | NUR verifizierte Personen (auf alter Website auffindbar). Minimum 2 für Section-Anzeige. |
 | 9 | **Text** | Alte Website als Basis + High-End Creative Writing. Keine 1:1-Kopie, kein Erfinden von Fakten. |
 | 10 | **Wizard** | Immer aktiv. Kategorien aus `services[]` ableiten. |
+| 11 | **Notfall/Notdienst** | NUR wenn alte Website explizit Notdienst/Notfall anbietet. Sonst: `emergency` weglassen → Nav zeigt "Anrufen"-Button statt "Notfall". |
+| 12 | **Firmenname** | EXAKT wie auf alter Website/Impressum. Kein Buchstabe dazu, keiner weg. |
+| 13 | **Stellenanzeigen** | Wenn alte Website Jobs ausschreibt → `careers[]` übernehmen. |
+| 14 | **Partner/Verbände** | Wenn alte Website Partner/Verbände zeigt → `brandPartners[]` + `certifications[]` übernehmen. URLs prüfen! Tote Links → entfernen. |
+| 15 | **Partner-URLs** | JEDE URL muss vor Commit geprüft werden (HTTP 200). Tote URLs = nicht aufnehmen. |
 
 ### Pflicht-Output pro Kunde (IMMER):
 - `docs/customers/<slug>/links.md` — Website-URL, Links-Seite, Wizard-URL

--- a/docs/customers/widmer/links.md
+++ b/docs/customers/widmer/links.md
@@ -1,4 +1,4 @@
-# Widmer H. & Co. AG — Links
+# Widmer & Co. AG — Links
 
 - **Website:** https://flowsight.ch/kunden/widmer-sanitaer
 - **Links-Seite:** https://flowsight.ch/kunden/widmer-sanitaer/links

--- a/src/web/app/kunden/[slug]/page.tsx
+++ b/src/web/app/kunden/[slug]/page.tsx
@@ -99,16 +99,22 @@ function Nav({ company: c, accent, wizardUrl }: { company: CustomerSite; accent:
           <a href="#leistungen" className="text-sm text-gray-600 transition-colors hover:text-gray-900">Leistungen</a>
           {c.team.length > 1 && <a href="#team" className="text-sm text-gray-600 transition-colors hover:text-gray-900">Team</a>}
           <a href="#kontakt" className="text-sm text-gray-600 transition-colors hover:text-gray-900">Kontakt</a>
-          {c.emergency?.enabled && (
+          {c.emergency?.enabled ? (
             <a href={`tel:${c.emergency.phoneRaw}`} className="rounded-lg bg-[#c41e3a] px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90">
               {c.emergency.label}
+            </a>
+          ) : (
+            <a href={`tel:${c.contact.phoneRaw}`} className="rounded-lg px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90" style={{ backgroundColor: accent }}>
+              Anrufen
             </a>
           )}
         </div>
         <div className="flex items-center gap-2 md:hidden">
           <a href="#kontakt" className="text-sm text-gray-600">Kontakt</a>
-          {c.emergency?.enabled && (
+          {c.emergency?.enabled ? (
             <a href={`tel:${c.emergency.phoneRaw}`} className="rounded-lg bg-[#c41e3a] px-4 py-2 text-sm font-bold text-white">Notfall</a>
+          ) : (
+            <a href={`tel:${c.contact.phoneRaw}`} className="rounded-lg px-4 py-2 text-sm font-bold text-white" style={{ backgroundColor: accent }}>Anrufen</a>
           )}
         </div>
       </div>
@@ -240,13 +246,17 @@ function ReviewsSection({
                 ))}
               </div>
               <p className="text-2xl font-bold text-gray-900">{reviews.averageRating} von 5 Sternen</p>
-              <p className="mt-1 text-sm text-gray-500">Basierend auf {reviews.totalReviews} Bewertungen</p>
+              {reviews.totalReviews >= 5 && (
+                <p className="mt-1 text-sm text-gray-500">Basierend auf {reviews.totalReviews} Bewertungen</p>
+              )}
             </>
           )}
           {!showScore && (
             <>
               <h2 className="text-2xl font-bold text-gray-900">Was unsere Kunden sagen</h2>
-              <p className="mt-1 text-sm text-gray-500">{reviews.totalReviews} Bewertungen</p>
+              {reviews.totalReviews >= 5 && (
+                <p className="mt-1 text-sm text-gray-500">{reviews.totalReviews} Bewertungen</p>
+              )}
             </>
           )}
         </div>

--- a/src/web/src/lib/customers/orlandini.ts
+++ b/src/web/src/lib/customers/orlandini.ts
@@ -14,7 +14,7 @@ export const orlandini: CustomerSite = {
     "Heizung Horgen",
     "Wärmepumpe Horgen",
     "Badsanierung Horgen",
-    "Sanitär Notdienst Horgen",
+    "Sanitär Reparatur Horgen",
     "Orlandini Sanitär",
     "Heizung Zürichsee",
   ],
@@ -37,14 +37,7 @@ export const orlandini: CustomerSite = {
     ],
   },
 
-  emergency: {
-    enabled: true,
-    phone: "044 725 41 44",
-    phoneRaw: "+41447254144",
-    label: "Notfall",
-    description:
-      "Rohrbruch, Heizungsausfall oder Wasserschaden? Rufen Sie uns an \u2014 wir helfen schnell und unkompliziert.",
-  },
+  /* Kein Notdienst auf alter Website → kein Notfall-Button, stattdessen "Anrufen" in Nav */
 
   services: [
     {
@@ -108,7 +101,7 @@ export const orlandini: CustomerSite = {
         "Reparatur von Armaturen, Ventilen und Dichtungen",
         "Behebung von Abflussverstopfungen",
         "Heizungsstörungen und Kesselreparaturen",
-        "Notdienst für dringende Fälle",
+        "Schnelle Terminvergabe für dringende Fälle",
       ],
     },
     {
@@ -237,6 +230,59 @@ export const orlandini: CustomerSite = {
       name: "Marco Orlandini",
       role: "Betriebsleitung",
       bio: "Verantwortlich für den operativen Betrieb und die Projektabwicklung.",
+    },
+  ],
+
+  certifications: [
+    { name: "Suissetec", issuer: "Schweizerisch-Liechtensteinischer Gebäudetechnikverband" },
+    { name: "VSSH", issuer: "Verband Schweizerischer Sanitär- und Heizungsfachleute" },
+    { name: "FWS", issuer: "Fachvereinigung Wärmepumpen Schweiz" },
+  ],
+
+  brandPartners: [
+    { name: "Geberit", url: "https://www.geberit.ch" },
+    { name: "Hansgrohe", url: "https://www.hansgrohe.ch" },
+    { name: "Duravit", url: "https://www.duravit.ch" },
+    { name: "Villeroy & Boch", url: "https://www.villeroy-boch.ch" },
+    { name: "Sanitas Troesch", url: "https://www.sanitastroesch.ch" },
+    { name: "Duscholux", url: "https://www.duscholux.ch" },
+    { name: "KWC", url: "https://www.kwc.com" },
+    { name: "Koralle", url: "https://www.koralle.de" },
+    /* Similor Kugler: Domain tot, Firma aufgegangen → entfernt */
+    { name: "Richner Miauton", url: "https://www.richner.ch" },
+    { name: "BWT Aqua", url: "https://www.bwt.com" },
+    { name: "Hoval", url: "https://www.hoval.ch" },
+    { name: "Vaillant", url: "https://www.vaillant.ch" },
+    { name: "Elco", url: "https://www.elco.ch" },
+    { name: "Domotec", url: "https://www.domotec.ch" },
+    { name: "Zehnder", url: "https://www.zehnder.ch" },
+    { name: "Meier Tobler", url: "https://www.meiertobler.ch" },
+  ],
+
+  careers: [
+    {
+      title: "Sanitär-Service-Fachleute (m/w), 80-100%",
+      type: "fulltime" as const,
+      description: "Wir sind eine 50-jährige Haustechnikfirma mit Schwerpunkt im Bereich Service, Reparaturen, Wartungen und kleineren Umbauten. Unsere Kundenliste wird immer länger — wir brauchen dringend Verstärkung.",
+      requirements: [
+        "Gelernte Fachfrauen und Männer mit Serviceerfahrung",
+        "Freude am selbständigen Arbeiten",
+        "Zuverlässigkeit, gepflegtes Auftreten und Teamfähigkeit",
+        "Deutsch in Wort und Schrift",
+        "Führerschein Kat. B",
+      ],
+    },
+    {
+      title: "Heizungs-Service-Fachleute (m/w), 80-100%",
+      type: "fulltime" as const,
+      description: "Service-Spezialisten für Heizungstechnik gesucht. Persönliches Servicefahrzeug, modernes Werkzeug und Terminplanungstools mit Tablets. Langfristig sichere Anstellung in einem familiären Umfeld.",
+      requirements: [
+        "Erfahrung im Heizungsservice oder Bereitschaft zur Einarbeitung",
+        "Freude an Kundenkontakt und selbständigem Arbeiten",
+        "Zuverlässigkeit und Teamfähigkeit",
+        "Deutsch in Wort und Schrift",
+        "Führerschein Kat. B",
+      ],
     },
   ],
 

--- a/src/web/src/lib/customers/widmer-sanitaer.ts
+++ b/src/web/src/lib/customers/widmer-sanitaer.ts
@@ -4,17 +4,17 @@ const IMG = "/kunden/widmer-sanitaer";
 
 export const widmerSanitaer: CustomerSite = {
   slug: "widmer-sanitaer",
-  companyName: "Widmer H. & Co. AG",
+  companyName: "Widmer & Co. AG",
   tagline: "Sanitär, Heizung, Spenglerei & Blitzschutz in Horgen — seit 1898",
   metaDescription:
-    "Widmer H. & Co. AG — Ihr Fachbetrieb für Sanitär, Heizung, Spenglerei und Blitzschutz in Horgen. Familienbetrieb seit 1898. Über 125 Jahre Erfahrung am Zürichsee.",
+    "Widmer & Co. AG — Ihr Fachbetrieb für Sanitär, Heizung, Spenglerei und Blitzschutz in Horgen. Familienbetrieb seit 1898. Über 125 Jahre Erfahrung am Zürichsee.",
   brandColor: "#1a4b8c",
   seoKeywords: [
     "Sanitär Horgen",
     "Heizung Horgen",
     "Spenglerei Horgen",
     "Blitzschutz Zürichsee",
-    "Widmer Sanitär Horgen",
+    "Widmer & Co. Sanitär Horgen",
     "Sanitär seit 1898",
   ],
 
@@ -36,14 +36,7 @@ export const widmerSanitaer: CustomerSite = {
     ],
   },
 
-  emergency: {
-    enabled: true,
-    phone: "044 725 47 00",
-    phoneRaw: "+41447254700",
-    label: "Notfall",
-    description:
-      "Rohrbruch, Heizungsausfall oder Wasserschaden? Rufen Sie uns an \u2014 wir sind für Sie da.",
-  },
+  /* Kein Notdienst auf alter Website → kein Notfall-Button, stattdessen "Anrufen" in Nav */
 
   services: [
     {
@@ -189,7 +182,7 @@ export const widmerSanitaer: CustomerSite = {
     averageRating: 5.0,
     totalReviews: 1,
     googleUrl:
-      "https://www.google.com/maps/place/Widmer+H.+%26+Co.+AG",
+      "https://www.google.com/maps/place/Widmer+%26+Co.+AG",
     highlights: [],
   },
 


### PR DESCRIPTION
## Summary
- **Widmer**: Name "H." entfernt → "Widmer & Co. AG", Emergency entfernt (nicht auf alter Website)
- **Orlandini**: 3 Verbände + 16 Partner + 2 Stellenanzeigen hinzugefügt, Emergency entfernt
- **Template**: Nav "Anrufen"-Fallback wenn kein Notdienst, Reviews < 5 versteckt "Basierend auf"
- **Lessons-learned**: 5 neue betriebsübergreifende Regeln (#11–#15)

Closes #89, Closes #90

## Test plan
- [ ] Widmer: Name = "Widmer & Co. AG", kein roter Notfall-Button, blauer "Anrufen"-Button in Nav
- [ ] Orlandini: Verbände + Partner-Section sichtbar, 2 Stellenanzeigen, kein Notfall-Button
- [ ] Orlandini: Similor Kugler nicht in Partners (toter Link)
- [ ] Widmer Reviews: kein "Basierend auf 1 Bewertungen" Text
- [ ] Alle Partner-URLs erreichbar (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)