### PR TITLE
feat: wizard problem categories — 5 derived problems + Allgemein

### DIFF
--- a/src/web/app/kunden/[slug]/meldung/CustomerWizardForm.tsx
+++ b/src/web/app/kunden/[slug]/meldung/CustomerWizardForm.tsx
@@ -672,6 +672,22 @@ function CategoryCard({ selected, onClick, accent, children }: { selected: boole
 function CategoryIcon({ iconKey }: { iconKey: string }) {
   const cls = "h-7 w-7";
   switch (iconKey) {
+    /* ── Problem-specific icons ──────────────────────── */
+    case "drain": // Verstopfung — funnel/drain
+      return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M12 3v1.5M12 21v-1.5M9.75 4.5l.75 3h3l.75-3M7.5 9h9l-1.5 6H9L7.5 9zM10.5 15v3a1.5 1.5 0 003 0v-3" /></svg>);
+    case "drop": // Leck / Wasserschaden — water drop
+      return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M12 3.75c0 0-6.75 7.5-6.75 11.25a6.75 6.75 0 0013.5 0C18.75 11.25 12 3.75 12 3.75z" /><path strokeLinecap="round" strokeLinejoin="round" d="M14.25 16.5a2.25 2.25 0 01-2.25 2.25" /></svg>);
+    case "burst": // Rohrbruch — exploding pipe
+      return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 12h4.5m7.5 0h4.5M11.25 12l-2.25-3m0 6l2.25-3m1.5 0l2.25-3m0 6l-2.25-3" /></svg>);
+    case "thermo": // Kein Warmwasser — thermometer
+      return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M12 9V3.75M12 9a3.75 3.75 0 100 7.5 3.75 3.75 0 000-7.5zM12 16.5V21M9 3.75h6" /></svg>);
+    case "bolt": // Blitzschutz — lightning bolt
+      return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" /></svg>);
+    case "pipe": // Leitungsschaden — pipes
+      return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3 6h6m0 0v6m0-6l3 3M21 18h-6m0 0v-6m0 6l-3-3M3 18h4.5M21 6h-4.5" /></svg>);
+    case "clipboard": // Allgemein — clipboard (distinct from wrench!)
+      return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15a2.25 2.25 0 012.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25z" /></svg>);
+    /* ── Service icons (kept for compatibility) ──────── */
     case "bath":
       return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 12h16.5M3.75 12a2.25 2.25 0 01-2.25-2.25V6a2.25 2.25 0 012.25-2.25h.386c.51 0 .983.273 1.237.718L6.75 6.75M3.75 12v4.5a2.25 2.25 0 002.25 2.25h12a2.25 2.25 0 002.25-2.25V12" /></svg>);
     case "wrench":

--- a/src/web/app/kunden/[slug]/meldung/page.tsx
+++ b/src/web/app/kunden/[slug]/meldung/page.tsx
@@ -26,6 +26,67 @@ export async function generateMetadata({
   };
 }
 
+// ── Problem derivation ────────────────────────────────────────────
+// Maps customer services to the 5 most common problems + "Allgemein" = always 6 tiles.
+
+interface WizardCategory {
+  value: string;
+  label: string;
+  hint: string;
+  iconKey: string;
+}
+
+/** Each problem is triggered by service slugs/icons. Priority = array order. */
+const PROBLEM_POOL: { value: string; label: string; hint: string; iconKey: string; triggers: string[] }[] = [
+  { value: "Verstopfung", label: "Verstopfung", hint: "Abfluss, WC, Leitung", iconKey: "drain", triggers: ["sanitaer", "sanitär", "bath"] },
+  { value: "Leck / Wasserschaden", label: "Leck / Wasserschaden", hint: "Tropft, feucht, nass", iconKey: "drop", triggers: ["sanitaer", "sanitär", "bath", "reparatur"] },
+  { value: "Rohrbruch", label: "Rohrbruch", hint: "Akut, Wasseraustritt", iconKey: "burst", triggers: ["sanitaer", "sanitär", "bath", "reparatur", "pipe"] },
+  { value: "Heizungsausfall", label: "Heizungsausfall", hint: "Kalt, keine Wärme, Störung", iconKey: "flame", triggers: ["heizung", "flame", "heating"] },
+  { value: "Kein Warmwasser", label: "Kein Warmwasser", hint: "Boiler, Speicher defekt", iconKey: "thermo", triggers: ["heizung", "sanitaer", "sanitär", "wartung", "water", "bath"] },
+  { value: "Dachschaden", label: "Dachschaden", hint: "Undicht, Sturmschaden", iconKey: "roof", triggers: ["spenglerei", "roof", "dach"] },
+  { value: "Fassadenschaden", label: "Fassadenschaden", hint: "Risse, Verkleidung lose", iconKey: "facade", triggers: ["fassade", "facade", "spenglerei"] },
+  { value: "Solaranlage defekt", label: "Solaranlage defekt", hint: "Kein Ertrag, Störung", iconKey: "solar", triggers: ["solar", "leaf"] },
+  { value: "Leitungsschaden", label: "Leitungsschaden", hint: "Gas, Wasser, Abwasser", iconKey: "pipe", triggers: ["leitungsbau", "pipe"] },
+  { value: "Blitzschutzprüfung", label: "Blitzschutzprüfung", hint: "Kontrolle, Wartung", iconKey: "bolt", triggers: ["blitzschutz"] },
+];
+
+function deriveWizardProblems(services: { slug: string; icon?: string }[]): WizardCategory[] {
+  // Collect all slugs and icons as trigger keys
+  const keys = new Set<string>();
+  for (const s of services) {
+    keys.add(s.slug.toLowerCase());
+    if (s.icon) keys.add(s.icon);
+    // Also match partial slugs (e.g. "reparaturen-wartung" → "reparatur", "wartung")
+    for (const part of s.slug.toLowerCase().split(/[-_]/)) {
+      keys.add(part);
+    }
+  }
+
+  // Pick problems whose triggers match any service key
+  const matched: WizardCategory[] = [];
+  for (const p of PROBLEM_POOL) {
+    if (matched.length >= 5) break;
+    if (p.triggers.some((t) => keys.has(t))) {
+      matched.push({ value: p.value, label: p.label, hint: p.hint, iconKey: p.iconKey });
+    }
+  }
+
+  // If less than 5 matched, fill from pool (in order) to reach 5
+  if (matched.length < 5) {
+    for (const p of PROBLEM_POOL) {
+      if (matched.length >= 5) break;
+      if (!matched.some((m) => m.value === p.value)) {
+        matched.push({ value: p.value, label: p.label, hint: p.hint, iconKey: p.iconKey });
+      }
+    }
+  }
+
+  // #6: "Allgemein" always last, distinct icon (clipboard)
+  matched.push({ value: "Allgemein", label: "Allgemein", hint: "Sonstiges Anliegen", iconKey: "clipboard" });
+
+  return matched;
+}
+
 // ── Page ──────────────────────────────────────────────────────────
 export default async function MeldungPage({
   params,
@@ -36,21 +97,8 @@ export default async function MeldungPage({
   const c = getCustomer(slug);
   if (!c) notFound();
 
-  // Derive wizard categories from customer services
-  const categories = c.services.map((s) => ({
-    value: s.name,
-    label: s.name,
-    hint: s.summary.split(" — ")[0].slice(0, 50),
-    iconKey: s.icon ?? "tool",
-  }));
-
-  // Always add a general "Allgemein" option
-  categories.push({
-    value: "Allgemein",
-    label: "Allgemein",
-    hint: "Sonstiges Anliegen",
-    iconKey: "wrench",
-  });
+  // Derive the 5 most relevant PROBLEMS from customer services + "Allgemein"
+  const categories = deriveWizardProblems(c.services);
 
   return (
     <CustomerWizardForm


### PR DESCRIPTION
## Summary
Wizard Step 1 zeigt jetzt **Problemfälle** statt Services. Immer genau 6 Kacheln.

**Vorher:** Services direkt (Sanitäre Anlagen, Heizungstechnik, Beratung & Planung...)
**Nachher:** 5 typische Probleme + Allgemein (Verstopfung, Leck, Rohrbruch, Heizungsausfall...)

## How it works
- `deriveWizardProblems(services)` mappt Service-Slugs/Icons auf einen Problem-Pool
- Top 5 passende Probleme werden automatisch pro Kunde abgeleitet
- "Allgemein" immer als #6 mit Clipboard-Icon (nicht Wrench)
- Neue SVG Icons: drain, drop, burst, thermo, bolt, pipe, clipboard

## Per-customer result
| Kunde | Kacheln |
|-------|---------|
| Dörfler | Verstopfung, Leck, Rohrbruch, Heizungsausfall, Kein Warmwasser, Allgemein |
| Orlandini | Verstopfung, Leck, Rohrbruch, Heizungsausfall, Kein Warmwasser, Allgemein |
| Widmer | Verstopfung, Leck, Rohrbruch, Kein Warmwasser, Dachschaden, Allgemein |
| Leuthold | Verstopfung, Leck, Rohrbruch, Kein Warmwasser, Dachschaden, Allgemein |

## Test plan
- [ ] Every customer wizard shows exactly 6 tiles
- [ ] Icons are all distinct (especially Allgemein ≠ Reparaturservice)
- [ ] Category value is submitted correctly to /api/cases
- [ ] Mobile: 2-column grid works

🤖 Generated with [Claude Code](https://claude.com/claude-code)