### PR TITLE
feat: wizard restructure — Anliegen + top-3 + photo in Step 3

### DIFF
--- a/src/web/app/(demos)/brunner-haustechnik/meldung/BrunnerWizardForm.tsx
+++ b/src/web/app/(demos)/brunner-haustechnik/meldung/BrunnerWizardForm.tsx
@@ -17,14 +17,21 @@ const BRAND = {
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-const CATEGORIES = [
+/** Top row: dynamic top-3 cases for Brunner */
+const TOP_CATEGORIES = [
   { value: "Verstopfung", label: "Verstopfung", icon: <IconDrain />, hint: "Abfluss, WC, Leitung" },
   { value: "Leck", label: "Leck", icon: <IconDrop />, hint: "Tropft, feucht, nass" },
   { value: "Heizung", label: "Heizung", icon: <IconFlame />, hint: "Kalt, Ausfall, Störung" },
-  { value: "Boiler", label: "Boiler", icon: <IconThermo />, hint: "Warmwasser, Speicher" },
-  { value: "Rohrbruch", label: "Rohrbruch", icon: <IconBurst />, hint: "Akut, Wasseraustritt" },
-  { value: "Sanitär allgemein", label: "Allgemein", icon: <IconWrench />, hint: "Sonstiges Anliegen" },
 ] as const;
+
+/** Bottom row: fixed for all wizards */
+const FIXED_CATEGORIES = [
+  { value: "Allgemein", label: "Allgemein", icon: <IconClipboard />, hint: "Sonstiges Anliegen" },
+  { value: "Angebot", label: "Angebot", icon: <IconDocument />, hint: "Offerte, Beratung" },
+  { value: "Kontakt", label: "Kontakt", icon: <IconChat />, hint: "Frage, Rückruf" },
+] as const;
+
+const ALL_CATEGORIES = [...TOP_CATEGORIES, ...FIXED_CATEGORIES];
 
 const URGENCIES = [
   { value: "notfall", label: "Notfall", hint: "Sofort — Wasser läuft, Gefahr", color: "red" },
@@ -44,11 +51,6 @@ interface ApiSuccess {
   city: string;
   created_at: string;
   verify_token: string;
-}
-
-interface PendingFile {
-  file: File;
-  preview: string;
 }
 
 const MAX_PHOTOS = 5;
@@ -108,10 +110,24 @@ function IconBurst() {
     </svg>
   );
 }
-function IconWrench() {
+function IconClipboard() {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-7 w-7">
-      <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15a2.25 2.25 0 012.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25z" />
+    </svg>
+  );
+}
+function IconDocument() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-7 w-7">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+    </svg>
+  );
+}
+function IconChat() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-7 w-7">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z" />
     </svg>
   );
 }
@@ -135,7 +151,7 @@ function Spinner() {
 // Sub-components
 // ---------------------------------------------------------------------------
 function StepIndicator({ current, total, onStepClick }: { current: number; total: number; onStepClick?: (step: number) => void }) {
-  const labels = ["Problem", "Adresse", "Kontakt"];
+  const labels = ["Anliegen", "Adresse", "Kontakt"];
   return (
     <div className="mb-8 flex items-center justify-center gap-1 sm:gap-2">
       {Array.from({ length: total }, (_, i) => {
@@ -209,6 +225,10 @@ export default function BrunnerWizardForm({ initialCategory }: { initialCategory
   const [step, setStep] = useState(1);
   const [pageState, setPageState] = useState<PageState>({ status: "form" });
 
+  // Photo pre-submit state
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   // Form data
   const [category, setCategory] = useState(initialCategory ?? "");
   const [urgency, setUrgency] = useState("");
@@ -255,7 +275,12 @@ export default function BrunnerWizardForm({ initialCategory }: { initialCategory
       });
       const json = await res.json();
       if (res.status === 201) {
-        setPageState({ status: "success", data: json as ApiSuccess });
+        const data = json as ApiSuccess;
+        setPageState({ status: "success", data });
+        // Auto-upload pending photos in background
+        if (data.verify_token && pendingFiles.length > 0) {
+          autoUploadPhotos(data.id, data.verify_token, pendingFiles);
+        }
       } else {
         setPageState({ status: "error", detail: json as ApiError });
       }
@@ -279,6 +304,7 @@ export default function BrunnerWizardForm({ initialCategory }: { initialCategory
     setContactPhone("");
     setContactEmail("");
     setDescription("");
+    setPendingFiles([]);
   }
 
   // ── Success ────────────────────────────────────────────────────────
@@ -314,8 +340,12 @@ export default function BrunnerWizardForm({ initialCategory }: { initialCategory
             </div>
           </div>
 
-          {/* Photo upload */}
-          <PhotoUpload caseId={pageState.data.id} token={pageState.data.verify_token} />
+          {/* Photo upload status (auto-uploaded from Step 3) */}
+          {pendingFiles.length > 0 && (
+            <div className="mx-auto mt-6 max-w-sm rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+              {pendingFiles.length} {pendingFiles.length === 1 ? "Foto wird" : "Fotos werden"} hochgeladen…
+            </div>
+          )}
 
           <div className="mt-6 rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-600">
             <p className="font-semibold" style={{ color: BRAND.primary }}>Nächster Schritt</p>
@@ -351,7 +381,7 @@ export default function BrunnerWizardForm({ initialCategory }: { initialCategory
     <Shell>
       {/* Header */}
       <div className="text-center mb-2">
-        <h1 className="text-2xl font-bold sm:text-3xl" style={{ color: BRAND.primary }}>Schadensmeldung</h1>
+        <h1 className="text-2xl font-bold sm:text-3xl" style={{ color: BRAND.primary }}>Meldung erfassen</h1>
         <p className="mt-1 text-sm text-gray-500">
           Beschreiben Sie Ihr Anliegen in 3 kurzen Schritten.
         </p>
@@ -364,9 +394,24 @@ export default function BrunnerWizardForm({ initialCategory }: { initialCategory
         {step === 1 && (
           <div className="space-y-6">
             <div>
-              <StepLabel>Was ist das Problem?</StepLabel>
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-                {CATEGORIES.map((c) => (
+              <StepLabel>Was ist Ihr Anliegen?</StepLabel>
+              {/* Top row: dynamic top-3 cases */}
+              <div className="grid grid-cols-3 gap-3">
+                {TOP_CATEGORIES.map((c) => (
+                  <Card key={c.value} selected={category === c.value} onClick={() => setCategory(c.value)}>
+                    <div className={`mb-1 ${category === c.value ? "" : "text-gray-400"}`} style={category === c.value ? { color: BRAND.accent } : undefined}>
+                      {c.icon}
+                    </div>
+                    <div className={`text-sm font-semibold ${category === c.value ? "text-gray-900" : "text-gray-700"}`}>
+                      {c.label}
+                    </div>
+                    <div className="text-xs text-gray-400">{c.hint}</div>
+                  </Card>
+                ))}
+              </div>
+              {/* Bottom row: fixed (Allgemein, Angebot, Kontakt) */}
+              <div className="mt-3 grid grid-cols-3 gap-3">
+                {FIXED_CATEGORIES.map((c) => (
                   <Card key={c.value} selected={category === c.value} onClick={() => setCategory(c.value)}>
                     <div className={`mb-1 ${category === c.value ? "" : "text-gray-400"}`} style={category === c.value ? { color: BRAND.accent } : undefined}>
                       {c.icon}
@@ -468,27 +513,58 @@ export default function BrunnerWizardForm({ initialCategory }: { initialCategory
                 rows={3}
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                placeholder="Beschreiben Sie das Problem kurz…"
+                placeholder="Beschreiben Sie Ihr Anliegen kurz…"
                 className="w-full rounded-xl border-2 border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 placeholder-gray-400 transition-colors focus:border-current focus:outline-none"
                 style={{ "--tw-ring-color": BRAND.accent } as React.CSSProperties}
               />
             </div>
 
-            {/* Review summary */}
-            <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm">
-              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-400">Zusammenfassung</p>
-              <div className="grid grid-cols-2 gap-y-2 text-gray-600">
-                <span className="text-gray-400">Kategorie</span>
-                <span className="font-medium text-gray-800">{category || "—"}</span>
-                <span className="text-gray-400">Dringlichkeit</span>
-                <span className="font-medium text-gray-800">{URGENCIES.find((u) => u.value === urgency)?.label || "—"}</span>
-                <span className="text-gray-400">Adresse</span>
-                <span className="font-medium text-gray-800">{street && houseNumber ? `${street} ${houseNumber}` : "\u2014"}</span>
-                <span className="text-gray-400">Ort</span>
-                <span className="font-medium text-gray-800">{plz && city ? `${plz} ${city}` : "\u2014"}</span>
-                <span className="text-gray-400">Kontakt</span>
-                <span className="font-medium text-gray-800">{contactPhone || contactEmail || "—"}</span>
-              </div>
+            {/* Photo upload (pre-submit) */}
+            <div className="rounded-xl border border-gray-200 bg-white p-4">
+              <p className="text-sm font-semibold" style={{ color: BRAND.primary }}>Fotos (optional)</p>
+              <p className="mt-1 mb-3 text-xs text-gray-400">Bis zu 5 Fotos — hilft bei der Einschätzung.</p>
+              {pendingFiles.length > 0 && (
+                <div className="mb-3 space-y-2">
+                  {pendingFiles.map((f, i) => (
+                    <div key={i} className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-sm">
+                      <span className="truncate text-gray-600">{f.name}</span>
+                      <button type="button" onClick={() => setPendingFiles((prev) => prev.filter((_, j) => j !== i))} className="ml-2 text-xs text-gray-400 hover:text-red-500">&#10005;</button>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {pendingFiles.length < MAX_PHOTOS && (
+                <>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*,video/*"
+                    multiple
+                    className="hidden"
+                    onChange={(e) => {
+                      const files = e.target.files;
+                      if (!files) return;
+                      const remaining = MAX_PHOTOS - pendingFiles.length;
+                      const toAdd = Array.from(files).slice(0, remaining).filter(
+                        (f) => f.size <= MAX_FILE_SIZE && (f.type.startsWith("image/") || f.type.startsWith("video/"))
+                      );
+                      setPendingFiles((prev) => [...prev, ...toAdd]);
+                      e.target.value = "";
+                    }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 px-4 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:border-teal-500 hover:text-teal-700"
+                  >
+                    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z" />
+                    </svg>
+                    Foto hinzufügen {pendingFiles.length > 0 && `(${MAX_PHOTOS - pendingFiles.length} verbleibend)`}
+                  </button>
+                </>
+              )}
             </div>
 
             {/* Error */}
@@ -543,125 +619,29 @@ export default function BrunnerWizardForm({ initialCategory }: { initialCategory
 }
 
 // ---------------------------------------------------------------------------
-// Photo Upload (on success screen)
+// Auto-upload photos (fires after successful case creation)
 // ---------------------------------------------------------------------------
-
-function PhotoUpload({ caseId, token }: { caseId: string; token: string }) {
-  const [files, setFiles] = useState<PendingFile[]>([]);
-  const [uploading, setUploading] = useState(false);
-  const [uploaded, setUploaded] = useState(false);
-  const [error, setError] = useState("");
-  const [progress, setProgress] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  function handleSelect(e: React.ChangeEvent<HTMLInputElement>) {
-    const selected = e.target.files;
-    if (!selected || selected.length === 0) return;
-
-    const remaining = MAX_PHOTOS - files.length;
-    if (remaining <= 0) { setError(`Max ${MAX_PHOTOS} Fotos.`); e.target.value = ""; return; }
-
-    const next: PendingFile[] = [];
-    for (const f of Array.from(selected).slice(0, remaining)) {
-      if (f.size > MAX_FILE_SIZE) { setError(`"${f.name}" ist zu gross (max 10 MB).`); e.target.value = ""; return; }
-      next.push({ file: f, preview: URL.createObjectURL(f) });
-    }
-    setError("");
-    setFiles((prev) => [...prev, ...next]);
-    e.target.value = "";
-  }
-
-  function removeFile(idx: number) {
-    setFiles((prev) => { const c = [...prev]; URL.revokeObjectURL(c[idx].preview); c.splice(idx, 1); return c; });
-  }
-
-  async function uploadAll() {
-    setUploading(true); setError("");
+async function autoUploadPhotos(caseId: string, token: string, files: File[]) {
+  for (const file of files) {
     try {
-      for (let i = 0; i < files.length; i++) {
-        setProgress(`Foto ${i + 1}/${files.length}...`);
-        const pf = files[i];
+      const urlRes = await fetch(`/api/verify/${caseId}/attachments`, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, action: "request-upload", file_name: file.name, mime_type: file.type, size_bytes: file.size }),
+      });
+      if (!urlRes.ok) continue;
+      const { upload_url, storage_path } = await urlRes.json();
 
-        const urlRes = await fetch(`/api/verify/${caseId}/attachments`, {
-          method: "POST", headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ token, action: "request-upload", file_name: pf.file.name, mime_type: pf.file.type, size_bytes: pf.file.size }),
-        });
-        if (!urlRes.ok) throw new Error("Upload-URL fehlgeschlagen.");
-        const { upload_url, storage_path } = await urlRes.json();
+      const putRes = await fetch(upload_url, { method: "PUT", headers: { "Content-Type": file.type }, body: file });
+      if (!putRes.ok) continue;
 
-        const putRes = await fetch(upload_url, { method: "PUT", headers: { "Content-Type": pf.file.type }, body: pf.file });
-        if (!putRes.ok) throw new Error(`Upload fehlgeschlagen: "${pf.file.name}"`);
-
-        const confirmRes = await fetch(`/api/verify/${caseId}/attachments`, {
-          method: "POST", headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ token, action: "confirm", storage_path, file_name: pf.file.name, mime_type: pf.file.type, size_bytes: pf.file.size }),
-        });
-        if (!confirmRes.ok) throw new Error("Bestätigung fehlgeschlagen.");
-      }
-      setUploaded(true);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Fehler beim Hochladen.");
-    } finally {
-      setUploading(false); setProgress("");
+      await fetch(`/api/verify/${caseId}/attachments`, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, action: "confirm", storage_path, file_name: file.name, mime_type: file.type, size_bytes: file.size }),
+      });
+    } catch {
+      // Best-effort upload, don't block the success screen
     }
   }
-
-  if (uploaded) {
-    return (
-      <div className="mx-auto mt-6 max-w-sm rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
-        {files.length} {files.length === 1 ? "Foto" : "Fotos"} hochgeladen — danke!
-      </div>
-    );
-  }
-
-  return (
-    <div className="mx-auto mt-6 max-w-sm rounded-xl border border-gray-200 bg-white p-5 text-left">
-      <p className="text-sm font-semibold" style={{ color: BRAND.primary }}>Fotos vom Schaden (optional)</p>
-      <p className="mt-1 text-xs text-gray-400">Fotos helfen dem Techniker, sich vorzubereiten.</p>
-
-      {files.length > 0 && (
-        <div className="mt-3 grid grid-cols-3 gap-2">
-          {files.map((pf, i) => (
-            <div key={i} className="group relative">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={pf.preview} alt={pf.file.name} className="h-20 w-full rounded-lg object-cover" />
-              <button type="button" onClick={() => removeFile(i)} disabled={uploading}
-                className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white shadow"
-              >X</button>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {files.length < MAX_PHOTOS && !uploading && (
-        <label className="mt-3 inline-flex cursor-pointer items-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 px-4 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:border-teal-500 hover:text-teal-700">
-          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" />
-            <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z" />
-          </svg>
-          Foto hinzufügen
-          <input ref={inputRef} type="file" accept="image/*" capture="environment" multiple onChange={handleSelect} className="hidden" />
-        </label>
-      )}
-
-      {files.length > 0 && !uploading && (
-        <button type="button" onClick={uploadAll}
-          className="mt-3 w-full rounded-xl px-4 py-2.5 text-sm font-semibold text-white transition-all hover:brightness-110"
-          style={{ backgroundColor: BRAND.accent }}
-        >
-          {files.length} {files.length === 1 ? "Foto" : "Fotos"} hochladen
-        </button>
-      )}
-
-      {progress && (
-        <div className="mt-2 flex items-center gap-2 text-xs text-teal-700">
-          <Spinner /> {progress}
-        </div>
-      )}
-
-      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/web/app/(demos)/brunner-haustechnik/meldung/page.tsx
+++ b/src/web/app/(demos)/brunner-haustechnik/meldung/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import BrunnerWizardForm from "./BrunnerWizardForm";
 
 export const metadata: Metadata = {
-  title: "Schadensmeldung — Brunner Haustechnik AG",
+  title: "Anliegen melden — Brunner Haustechnik AG",
   description:
     "Melden Sie Ihr Anliegen in 3 einfachen Schritten. Sanitär, Heizung, Rohrbruch und mehr.",
 };
@@ -11,9 +11,9 @@ const ALLOWED_CATEGORIES = [
   "Verstopfung",
   "Leck",
   "Heizung",
-  "Boiler",
-  "Rohrbruch",
-  "Sanitär allgemein",
+  "Allgemein",
+  "Angebot",
+  "Kontakt",
 ];
 
 export default async function MeldungPage({

--- a/src/web/app/(demos)/brunner-haustechnik/page.tsx
+++ b/src/web/app/(demos)/brunner-haustechnik/page.tsx
@@ -206,7 +206,7 @@ export default function BrunnerHaustechnikDemo() {
                   className="inline-flex items-center justify-center px-8 py-4 rounded-lg bg-white font-semibold text-lg transition-all hover:bg-gray-100"
                   style={{ color: theme.primaryHex }}
                 >
-                  Schaden online melden
+                  Anliegen melden
                 </a>
                 <a
                   href={theme.phoneHref}
@@ -610,10 +610,10 @@ export default function BrunnerHaustechnikDemo() {
             {/* CTA Banner */}
             <div className="mb-14 rounded-2xl p-8 sm:p-10 text-center text-white" style={{ backgroundColor: theme.accentHex }}>
               <h2 className="text-2xl sm:text-3xl font-bold mb-3">
-                Schaden melden — schnell und unkompliziert
+                Anliegen melden — schnell und unkompliziert
               </h2>
               <p className="mx-auto max-w-xl text-white/80 mb-6">
-                Nutzen Sie unseren digitalen Assistenten, um Ihren Schaden direkt zu erfassen.
+                Nutzen Sie unseren digitalen Assistenten, um Ihr Anliegen direkt zu erfassen.
                 Wir melden uns umgehend bei Ihnen.
               </p>
               <a
@@ -621,7 +621,7 @@ export default function BrunnerHaustechnikDemo() {
                 className="inline-flex items-center justify-center rounded-xl bg-white px-8 py-4 text-lg font-semibold transition-opacity hover:opacity-90"
                 style={{ color: theme.primaryHex }}
               >
-                Jetzt Schaden melden →
+                Jetzt Anliegen melden →
               </a>
             </div>
 

--- a/src/web/app/kunden/[slug]/links/page.tsx
+++ b/src/web/app/kunden/[slug]/links/page.tsx
@@ -40,9 +40,9 @@ export default async function CustomerLinksPage({
       icon: "🌐",
     },
     {
-      label: "Schaden melden (Wizard)",
+      label: "Anliegen melden (Wizard)",
       url: `${baseUrl}/kunden/${c.slug}/meldung`,
-      description: "Online-Formular für Schadensmeldungen",
+      description: "Online-Formular für Anliegen und Schadensmeldungen",
       icon: "📋",
     },
   ];

--- a/src/web/app/kunden/[slug]/meldung/CustomerWizardForm.tsx
+++ b/src/web/app/kunden/[slug]/meldung/CustomerWizardForm.tsx
@@ -11,6 +11,7 @@ interface WizardCategory {
   label: string;
   hint: string;
   iconKey: string;
+  fixed?: boolean;
 }
 
 interface Props {
@@ -90,9 +91,12 @@ export function CustomerWizardForm({
   const [contactEmail, setContactEmail] = useState("");
   const [description, setDescription] = useState("");
 
-  // Photo upload state
-  const [uploads, setUploads] = useState<UploadedFile[]>([]);
+  // Photo upload state (inline in Step 3, before submit)
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Post-submit upload state
+  const [uploads, setUploads] = useState<UploadedFile[]>([]);
 
   // Validation
   const step1Valid = category !== "" && urgency !== "";
@@ -138,7 +142,14 @@ export function CustomerWizardForm({
       });
       const json = await res.json();
       if (res.status === 201) {
-        setPageState({ status: "success", data: json as ApiSuccess });
+        const data = json as ApiSuccess;
+        setPageState({ status: "success", data });
+        // Auto-upload pending photos in background
+        if (data.verify_token && pendingFiles.length > 0) {
+          for (const file of pendingFiles) {
+            uploadPhoto(file, data.id, data.verify_token);
+          }
+        }
       } else {
         setPageState({ status: "error", detail: json as ApiError });
       }
@@ -203,21 +214,19 @@ export function CustomerWizardForm({
     }
   }
 
-  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
-    if (pageState.status !== "success" || !pageState.data.verify_token) return;
+  function handleFileSelectPreSubmit(e: React.ChangeEvent<HTMLInputElement>) {
     const files = e.target.files;
     if (!files) return;
-
-    const remaining = MAX_PHOTOS - uploads.length;
-    const toUpload = Array.from(files).slice(0, remaining);
-
-    for (const file of toUpload) {
-      if (file.size > MAX_FILE_SIZE) continue;
-      if (!file.type.startsWith("image/") && !file.type.startsWith("video/")) continue;
-      uploadPhoto(file, pageState.data.id, pageState.data.verify_token);
-    }
-    // Reset input so same file can be re-selected
+    const remaining = MAX_PHOTOS - pendingFiles.length;
+    const toAdd = Array.from(files).slice(0, remaining).filter(
+      (f) => f.size <= MAX_FILE_SIZE && (f.type.startsWith("image/") || f.type.startsWith("video/"))
+    );
+    setPendingFiles((prev) => [...prev, ...toAdd]);
     e.target.value = "";
+  }
+
+  function removePendingFile(idx: number) {
+    setPendingFiles((prev) => prev.filter((_, i) => i !== idx));
   }
 
   function reset() {
@@ -233,13 +242,13 @@ export function CustomerWizardForm({
     setContactPhone("");
     setContactEmail("");
     setDescription("");
+    setPendingFiles([]);
     setUploads([]);
   }
 
   // ── Success ────────────────────────────────────────────────────────
   if (pageState.status === "success") {
     const urgLabel = URGENCIES.find((u) => u.value === urgency)?.label ?? urgency;
-    const canUpload = !!pageState.data.verify_token && uploads.length < MAX_PHOTOS;
     return (
       <Shell>
         <TopBar companyName={companyName} phone={phone} phoneRaw={phoneRaw} accent={accent} backUrl={backUrl} />
@@ -262,60 +271,28 @@ export function CustomerWizardForm({
             <Row label="Ort" value={`${plz} ${city}`} />
           </div>
 
-          {/* Photo upload section */}
-          {pageState.data.verify_token && (
+          {/* Upload progress (auto-uploaded from Step 3 selection) */}
+          {uploads.length > 0 && (
             <div className="mx-auto mt-6 max-w-sm rounded-xl border border-gray-200 bg-white p-5 text-left">
-              <p className="mb-1 text-sm font-semibold text-gray-900">Fotos vom Schaden</p>
-              <p className="mb-4 text-xs text-gray-400">
-                {"Bis zu 5 Fotos hochladen \u2014 hilft uns bei der Einschätzung."}
-              </p>
-
-              {/* Upload list */}
-              {uploads.length > 0 && (
-                <div className="mb-3 space-y-2">
-                  {uploads.map((u, i) => (
-                    <div key={i} className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2 text-sm">
-                      {u.status === "uploading" && <Spinner />}
-                      {u.status === "done" && (
-                        <svg className="h-4 w-4 text-green-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 12l5 5L20 7" />
-                        </svg>
-                      )}
-                      {u.status === "error" && (
-                        <svg className="h-4 w-4 text-red-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                        </svg>
-                      )}
-                      <span className="truncate text-gray-600">{u.name}</span>
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {/* Upload button */}
-              {canUpload && (
-                <>
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    accept="image/*,video/*"
-                    multiple
-                    className="hidden"
-                    onChange={handleFileSelect}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    className="flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-gray-200 px-4 py-3 text-sm font-medium text-gray-500 transition hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700"
-                  >
-                    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" />
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z" />
-                    </svg>
-                    Foto hinzuf&uuml;gen ({MAX_PHOTOS - uploads.length} verbleibend)
-                  </button>
-                </>
-              )}
+              <p className="mb-3 text-sm font-semibold text-gray-900">Fotos</p>
+              <div className="space-y-2">
+                {uploads.map((u, i) => (
+                  <div key={i} className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2 text-sm">
+                    {u.status === "uploading" && <Spinner />}
+                    {u.status === "done" && (
+                      <svg className="h-4 w-4 text-green-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M5 12l5 5L20 7" />
+                      </svg>
+                    )}
+                    {u.status === "error" && (
+                      <svg className="h-4 w-4 text-red-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    )}
+                    <span className="truncate text-gray-600">{u.name}</span>
+                  </div>
+                ))}
+              </div>
             </div>
           )}
 
@@ -354,14 +331,14 @@ export function CustomerWizardForm({
   }
 
   // ── Form ───────────────────────────────────────────────────────────
-  const stepLabels = ["Problem", "Adresse", "Kontakt"];
+  const stepLabels = ["Anliegen", "Adresse", "Kontakt"];
 
   return (
     <Shell>
       <TopBar companyName={companyName} phone={phone} phoneRaw={phoneRaw} accent={accent} backUrl={backUrl} />
 
       <div className="mx-auto max-w-xl px-4 py-8 sm:py-12">
-        <h1 className="mb-1 text-center text-2xl font-semibold text-gray-900">Schadensmeldung</h1>
+        <h1 className="mb-1 text-center text-2xl font-semibold text-gray-900">Meldung erfassen</h1>
         <p className="mb-8 text-center text-sm text-gray-500">
           Beschreiben Sie Ihr Anliegen in 3 kurzen Schritten.
         </p>
@@ -373,9 +350,29 @@ export function CustomerWizardForm({
           {step === 1 && (
             <div className="space-y-6">
               <div>
-                <StepLabel>Was ist das Problem?</StepLabel>
-                <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-                  {categories.map((c) => (
+                <StepLabel>Was ist Ihr Anliegen?</StepLabel>
+                {/* Top row: dynamic top-3 cases */}
+                <div className="grid grid-cols-3 gap-3">
+                  {categories.filter((c) => !c.fixed).map((c) => (
+                    <CategoryCard
+                      key={c.value}
+                      selected={category === c.value}
+                      onClick={() => setCategory(c.value)}
+                      accent={accent}
+                    >
+                      <div className={`mb-1.5 ${category === c.value ? "" : "text-gray-400"}`} style={category === c.value ? { color: accent } : undefined}>
+                        <CategoryIcon iconKey={c.iconKey} />
+                      </div>
+                      <div className={`text-sm font-medium ${category === c.value ? "text-gray-900" : "text-gray-700"}`}>
+                        {c.label}
+                      </div>
+                      <div className="text-xs text-gray-400">{c.hint}</div>
+                    </CategoryCard>
+                  ))}
+                </div>
+                {/* Bottom row: fixed (Allgemein, Angebot, Kontakt) */}
+                <div className="mt-3 grid grid-cols-3 gap-3">
+                  {categories.filter((c) => c.fixed).map((c) => (
                     <CategoryCard
                       key={c.value}
                       selected={category === c.value}
@@ -495,24 +492,48 @@ export function CustomerWizardForm({
                   rows={3}
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  placeholder={"Beschreiben Sie das Problem kurz\u2026"}
+                  placeholder={"Beschreiben Sie Ihr Anliegen kurz\u2026"}
                   className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 transition focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400"
                 />
               </div>
 
-              {/* Summary */}
-              <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm">
-                <p className="mb-2 text-xs font-medium uppercase tracking-wider text-gray-400">Zusammenfassung</p>
-                <div className="grid grid-cols-2 gap-y-1.5 text-gray-600">
-                  <span className="text-gray-400">Kategorie</span>
-                  <span>{category || "\u2014"}</span>
-                  <span className="text-gray-400">Dringlichkeit</span>
-                  <span>{URGENCIES.find((u) => u.value === urgency)?.label || "\u2014"}</span>
-                  <span className="text-gray-400">Adresse</span>
-                  <span>{street && houseNumber ? `${street} ${houseNumber}` : "\u2014"}</span>
-                  <span className="text-gray-400">Ort</span>
-                  <span>{plz && city ? `${plz} ${city}` : "\u2014"}</span>
-                </div>
+              {/* Photo upload (pre-submit) */}
+              <div className="rounded-xl border border-gray-200 bg-white p-4">
+                <p className="mb-1 text-sm font-semibold text-gray-900">Fotos (optional)</p>
+                <p className="mb-3 text-xs text-gray-400">{"Bis zu 5 Fotos \u2014 hilft bei der Einschätzung."}</p>
+                {pendingFiles.length > 0 && (
+                  <div className="mb-3 space-y-2">
+                    {pendingFiles.map((f, i) => (
+                      <div key={i} className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-sm">
+                        <span className="truncate text-gray-600">{f.name}</span>
+                        <button type="button" onClick={() => removePendingFile(i)} className="ml-2 text-xs text-gray-400 hover:text-red-500">&#10005;</button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {pendingFiles.length < MAX_PHOTOS && (
+                  <>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/*,video/*"
+                      multiple
+                      className="hidden"
+                      onChange={handleFileSelectPreSubmit}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      className="flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-gray-200 px-4 py-3 text-sm font-medium text-gray-500 transition hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700"
+                    >
+                      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z" />
+                      </svg>
+                      Foto hinzuf&uuml;gen {pendingFiles.length > 0 && `(${MAX_PHOTOS - pendingFiles.length} verbleibend)`}
+                    </button>
+                  </>
+                )}
               </div>
 
               {/* Error */}
@@ -685,8 +706,12 @@ function CategoryIcon({ iconKey }: { iconKey: string }) {
       return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" /></svg>);
     case "pipe": // Leitungsschaden — pipes
       return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3 6h6m0 0v6m0-6l3 3M21 18h-6m0 0v-6m0 6l-3-3M3 18h4.5M21 6h-4.5" /></svg>);
-    case "clipboard": // Allgemein — clipboard (distinct from wrench!)
+    case "clipboard": // Allgemein — clipboard
       return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15a2.25 2.25 0 012.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25z" /></svg>);
+    case "document": // Angebot — document/file
+      return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" /></svg>);
+    case "chat": // Kontakt — chat bubble
+      return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z" /></svg>);
     /* ── Service icons (kept for compatibility) ──────── */
     case "bath":
       return (<svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 12h16.5M3.75 12a2.25 2.25 0 01-2.25-2.25V6a2.25 2.25 0 012.25-2.25h.386c.51 0 .983.273 1.237.718L6.75 6.75M3.75 12v4.5a2.25 2.25 0 002.25 2.25h12a2.25 2.25 0 002.25-2.25V12" /></svg>);

--- a/src/web/app/kunden/[slug]/meldung/page.tsx
+++ b/src/web/app/kunden/[slug]/meldung/page.tsx
@@ -20,29 +20,32 @@ export async function generateMetadata({
   const c = getCustomer(slug);
   if (!c) return {};
   return {
-    title: `Schaden melden — ${c.companyName}`,
+    title: `Anliegen melden — ${c.companyName}`,
     description: `Melden Sie Ihr Anliegen direkt an ${c.companyName}. Schnell, unkompliziert, digital.`,
     robots: { index: false },
   };
 }
 
-// ── Problem derivation ────────────────────────────────────────────
-// Maps customer services to the 5 most common problems + "Allgemein" = always 6 tiles.
+// ── Category derivation ───────────────────────────────────────────
+// Top row: 3 most common cases per business (dynamic from services).
+// Bottom row: "Allgemein" + "Angebot" + "Kontakt" (fixed, all customers).
 
 interface WizardCategory {
   value: string;
   label: string;
   hint: string;
   iconKey: string;
+  /** true = fixed bottom row */
+  fixed?: boolean;
 }
 
-/** Each problem is triggered by service slugs/icons. Priority = array order. */
-const PROBLEM_POOL: { value: string; label: string; hint: string; iconKey: string; triggers: string[] }[] = [
+/** Each case is triggered by service slugs/icons. Priority = array order. */
+const CASE_POOL: { value: string; label: string; hint: string; iconKey: string; triggers: string[] }[] = [
   { value: "Verstopfung", label: "Verstopfung", hint: "Abfluss, WC, Leitung", iconKey: "drain", triggers: ["sanitaer", "sanitär", "bath"] },
   { value: "Leck / Wasserschaden", label: "Leck / Wasserschaden", hint: "Tropft, feucht, nass", iconKey: "drop", triggers: ["sanitaer", "sanitär", "bath", "reparatur"] },
-  { value: "Rohrbruch", label: "Rohrbruch", hint: "Akut, Wasseraustritt", iconKey: "burst", triggers: ["sanitaer", "sanitär", "bath", "reparatur", "pipe"] },
   { value: "Heizungsausfall", label: "Heizungsausfall", hint: "Kalt, keine Wärme, Störung", iconKey: "flame", triggers: ["heizung", "flame", "heating"] },
   { value: "Kein Warmwasser", label: "Kein Warmwasser", hint: "Boiler, Speicher defekt", iconKey: "thermo", triggers: ["heizung", "sanitaer", "sanitär", "wartung", "water", "bath"] },
+  { value: "Rohrbruch", label: "Rohrbruch", hint: "Akut, Wasseraustritt", iconKey: "burst", triggers: ["sanitaer", "sanitär", "bath", "reparatur", "pipe"] },
   { value: "Dachschaden", label: "Dachschaden", hint: "Undicht, Sturmschaden", iconKey: "roof", triggers: ["spenglerei", "roof", "dach"] },
   { value: "Fassadenschaden", label: "Fassadenschaden", hint: "Risse, Verkleidung lose", iconKey: "facade", triggers: ["fassade", "facade", "spenglerei"] },
   { value: "Solaranlage defekt", label: "Solaranlage defekt", hint: "Kein Ertrag, Störung", iconKey: "solar", triggers: ["solar", "leaf"] },
@@ -50,41 +53,44 @@ const PROBLEM_POOL: { value: string; label: string; hint: string; iconKey: strin
   { value: "Blitzschutzprüfung", label: "Blitzschutzprüfung", hint: "Kontrolle, Wartung", iconKey: "bolt", triggers: ["blitzschutz"] },
 ];
 
-function deriveWizardProblems(services: { slug: string; icon?: string }[]): WizardCategory[] {
-  // Collect all slugs and icons as trigger keys
+/** Fixed bottom row — always shown on every wizard. */
+const FIXED_CATEGORIES: WizardCategory[] = [
+  { value: "Allgemein", label: "Allgemein", hint: "Sonstiges Anliegen", iconKey: "clipboard", fixed: true },
+  { value: "Angebot", label: "Angebot", hint: "Offerte, Beratung", iconKey: "document", fixed: true },
+  { value: "Kontakt", label: "Kontakt", hint: "Frage, Rückruf", iconKey: "chat", fixed: true },
+];
+
+function deriveWizardCategories(services: { slug: string; icon?: string }[]): WizardCategory[] {
   const keys = new Set<string>();
   for (const s of services) {
     keys.add(s.slug.toLowerCase());
     if (s.icon) keys.add(s.icon);
-    // Also match partial slugs (e.g. "reparaturen-wartung" → "reparatur", "wartung")
     for (const part of s.slug.toLowerCase().split(/[-_]/)) {
       keys.add(part);
     }
   }
 
-  // Pick problems whose triggers match any service key
+  // Pick top 3 dynamic cases matching this customer's services
   const matched: WizardCategory[] = [];
-  for (const p of PROBLEM_POOL) {
-    if (matched.length >= 5) break;
+  for (const p of CASE_POOL) {
+    if (matched.length >= 3) break;
     if (p.triggers.some((t) => keys.has(t))) {
       matched.push({ value: p.value, label: p.label, hint: p.hint, iconKey: p.iconKey });
     }
   }
 
-  // If less than 5 matched, fill from pool (in order) to reach 5
-  if (matched.length < 5) {
-    for (const p of PROBLEM_POOL) {
-      if (matched.length >= 5) break;
+  // If less than 3 matched, fill from pool
+  if (matched.length < 3) {
+    for (const p of CASE_POOL) {
+      if (matched.length >= 3) break;
       if (!matched.some((m) => m.value === p.value)) {
         matched.push({ value: p.value, label: p.label, hint: p.hint, iconKey: p.iconKey });
       }
     }
   }
 
-  // #6: "Allgemein" always last, distinct icon (clipboard)
-  matched.push({ value: "Allgemein", label: "Allgemein", hint: "Sonstiges Anliegen", iconKey: "clipboard" });
-
-  return matched;
+  // Append fixed bottom row
+  return [...matched, ...FIXED_CATEGORIES];
 }
 
 // ── Page ──────────────────────────────────────────────────────────
@@ -97,8 +103,8 @@ export default async function MeldungPage({
   const c = getCustomer(slug);
   if (!c) notFound();
 
-  // Derive the 5 most relevant PROBLEMS from customer services + "Allgemein"
-  const categories = deriveWizardProblems(c.services);
+  // Derive top-3 dynamic cases from services + fixed bottom row
+  const categories = deriveWizardCategories(c.services);
 
   return (
     <CustomerWizardForm

--- a/src/web/app/kunden/[slug]/page.tsx
+++ b/src/web/app/kunden/[slug]/page.tsx
@@ -154,7 +154,7 @@ function HeroSection({ company: c, accent, wizardUrl }: { company: CustomerSite;
           <p className="mt-4 text-lg text-white/80 sm:text-xl">{c.tagline}</p>
           <div className="mt-8 flex flex-col gap-4 sm:flex-row">
             <a href={wizardUrl} className="inline-flex items-center justify-center rounded-xl px-8 py-4 text-lg font-semibold text-white transition-opacity hover:opacity-90" style={{ backgroundColor: accent }}>
-              Schaden online melden
+              Anliegen melden
             </a>
             <a href={`tel:${c.contact.phoneRaw}`} className="inline-flex items-center justify-center rounded-xl border border-white/30 px-8 py-4 text-lg font-semibold text-white backdrop-blur-sm transition-colors hover:bg-white/10">
               Anrufen: {c.contact.phone}
@@ -523,12 +523,12 @@ function ContactSection({ company: c, accent, wizardUrl }: { company: CustomerSi
         {/* Wizard CTA */}
         <div className="mb-12 overflow-hidden rounded-2xl" style={{ backgroundColor: accent }}>
           <div className="p-8 text-center text-white sm:p-12">
-            <h2 className="text-2xl font-bold sm:text-3xl">Schaden melden — schnell und unkompliziert</h2>
+            <h2 className="text-2xl font-bold sm:text-3xl">Anliegen melden — schnell und unkompliziert</h2>
             <p className="mx-auto mt-3 max-w-xl text-white/80">
-              Nutzen Sie unseren digitalen Assistenten, um Ihren Schaden direkt zu erfassen. Wir melden uns umgehend bei Ihnen.
+              Nutzen Sie unseren digitalen Assistenten, um Ihr Anliegen direkt zu erfassen. Wir melden uns umgehend bei Ihnen.
             </p>
             <a href={wizardUrl} className="mt-6 inline-flex items-center justify-center rounded-xl bg-white px-8 py-4 text-lg font-semibold transition-opacity hover:opacity-90" style={{ color: accent }}>
-              Jetzt Schaden melden &rarr;
+              Jetzt Anliegen melden &rarr;
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **#110:** All "Schaden online melden" buttons → "Anliegen melden" (customer pages, demo, links page)
- **#111:** Wizard Step 1 restructured: "Was ist Ihr Anliegen?" with top-3 dynamic cases + fixed bottom row (Allgemein/Angebot/Kontakt)
- **#112:** Photo upload moved from success screen → Step 3 (contact step), summary section removed

Closes #110, Closes #111, Closes #112

## Changes
- `kunden/[slug]/page.tsx` — Button text + contact CTA
- `kunden/[slug]/meldung/page.tsx` — New category derivation (3 dynamic + 3 fixed)
- `kunden/[slug]/meldung/CustomerWizardForm.tsx` — Title, step labels, 2-row category grid, photo upload in Step 3, summary removed
- `kunden/[slug]/links/page.tsx` — Link label + description
- `brunner-haustechnik/page.tsx` — Button text + contact CTA
- `brunner-haustechnik/meldung/BrunnerWizardForm.tsx` — Same wizard restructure
- `brunner-haustechnik/meldung/page.tsx` — Updated allowed categories + title

## Test plan
- [ ] Visit /kunden/doerfler-ag — verify "Anliegen melden" button
- [ ] Visit /kunden/doerfler-ag/meldung — verify 3+3 category layout, "Was ist Ihr Anliegen?"
- [ ] Select "Angebot" or "Kontakt" — verify it works through full flow
- [ ] Add photo in Step 3, submit — verify photo appears in success screen upload status
- [ ] Visit /brunner-haustechnik — verify same changes on demo
- [ ] Visit /brunner-haustechnik/meldung — verify 3+3 layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)