### PR TITLE
feat: Weinberger C (E2E) — tenant + SMS ready for test

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -49,7 +49,7 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 | Walter Leuthold (Oberrieden) | walter-leuthold | wizard | Website LIVE |
 | Orlandini Sanitär (Horgen) | orlandini | wizard | Website LIVE |
 | Widmer H. & Co. AG (Horgen) | widmer-sanitaer | wizard | Website LIVE |
-| **Jul. Weinberger AG (Thalwil)** | weinberger-ag | wizard | **GTM Goldstandard** — Website LIVE |
+| **Jul. Weinberger AG (Thalwil)** | weinberger-ag | voice, wizard, ops, reviews, sms | **GTM Goldstandard** — D+B LIVE, C READY |
 | BigBen Pub (Zürich) | bigben-pub | — | Custom Demo |
 
 ## Aktueller Stand

--- a/docs/customers/weinberger-ag/status.md
+++ b/docs/customers/weinberger-ag/status.md
@@ -2,7 +2,9 @@
 
 **Slug:** weinberger-ag
 **Rolle:** GTM Goldstandard (ICP 90+, Leckerli A+B+C+D)
-**Stand:** 2026-03-09
+**Stand:** 2026-03-10
+**Tenant-ID:** fc4ba994-c99c-4c17-9fa7-6c10bd0d6fa8
+**Twilio-Nr:** +41 43 505 11 01
 
 ## Eckdaten
 - Gründung: 1912
@@ -17,9 +19,37 @@
 | Leckerli | Was | Status |
 |----------|-----|--------|
 | **D** | Website (Services, Team, Notdienst, Wizard) | **DONE** ✅ (PR #116) |
-| **B-Full** | Eigener Voice Agent (Lisa DE + INTL) | **DONE** ✅ (PR #118) — needs Twilio number |
-| **C** | E2E Proof (Tenant, SMS, Ops-Fall) | OFFEN |
+| **B-Full** | Eigener Voice Agent (Lisa DE + INTL, Ela Voice) | **DONE** ✅ (PR #118 + #124) — Twilio +41435051101 |
+| **C** | E2E Proof (Tenant, SMS, Ops-Fall) | **READY** ⏳ — Tenant + SMS aktiv, wartet auf Founder-Testanruf |
 | **A** | Video (5 Szenen, Founder-Aufnahme) | OFFEN |
+
+## Infrastruktur (Leckerli C)
+
+| Komponente | Status | Detail |
+|------------|--------|--------|
+| Supabase Tenant | ✅ | `fc4ba994-...`, Module: voice, wizard, ops, reviews, sms |
+| Phone Routing | ✅ | +41435051101 → tenant_id via tenant_numbers |
+| SMS Channel | ✅ | Sender: "Weinberger", alphanumeric |
+| Webhook | ✅ | flowsight-mvp.vercel.app/api/retell/webhook |
+| Voice Agents | ✅ | DE + INTL published (Ela Voice) |
+| Wizard | ✅ | /kunden/weinberger-ag/meldung |
+| Ops Dashboard | ✅ | /ops → Fälle sichtbar |
+
+### Testanruf-Anleitung (Founder)
+
+1. **Anrufen:** +41 43 505 11 01 (von persönlichem Handy)
+2. **Testfall durchspielen:** "Guten Tag, ich habe ein Wasserleck im Keller. Es ist dringend."
+3. **Lisa antwortet → Daten angeben:**
+   - PLZ: 8800, Ort: Thalwil
+   - Adresse: Seestrasse 15
+   - Name: Müller
+   - Telefon: (deine Handynummer)
+4. **Nach Anruf prüfen:**
+   - [ ] SMS erhalten? Sender: "Weinberger"
+   - [ ] SMS enthält Korrekturlink? (`/v/...`)
+   - [ ] Ops Dashboard: /ops → Fall sichtbar?
+   - [ ] Fall-Details: Kategorie, Dringlichkeit, PLZ korrekt?
+5. **Ergebnis an CC melden** → CC dokumentiert Evidence + markiert C als DONE
 
 ## Datenquellen (Goldene Regel #1: keine erfundenen Fakten)
 - julweinberger.ch (Sitemap, Impressum, Kontakt)

--- a/docs/gtm/gtm_tracker.md
+++ b/docs/gtm/gtm_tracker.md
@@ -50,7 +50,7 @@
 |----------|-----|--------|----------|
 | **D** | Website (Services, Team, Reviews, Notdienst, Galerie, Wizard) | **DONE** ✅ | PR #116 — 5 Services, 17 Bilder, 24h Notdienst, 4.4★/20 Reviews, Brand #004994 |
 | **B-Full** | Eigener Voice Agent (Lisa, Greeting, Triage, Kategorien) | **DONE** ✅ | PR #118 — DE + INTL, published, 8 Kategorien, 24h Pikett |
-| **C** | E2E Proof (Tenant, SMS, Ops-Fall, Samstag-Nacht-Test) | OFFEN | — |
+| **C** | E2E Proof (Tenant, SMS, Ops-Fall, Samstag-Nacht-Test) | **READY** ⏳ | Tenant fc4ba994, SMS "Weinberger", +41435051101 → wartet auf Founder-Testanruf |
 | **A** | Video (5 Szenen, 45-60s, Founder-Aufnahme) | OFFEN | Founder |
 | **Outreach** | Email + Testnummer + URL + Video | OFFEN | Founder |
 

--- a/retell/agent_ids.json
+++ b/retell/agent_ids.json
@@ -25,6 +25,6 @@
     "de_flow_id": "conversation_flow_4254de993a58",
     "intl_agent_id": "agent_0976aabe2c12ab0ca4d48933a5",
     "intl_flow_id": "conversation_flow_ac5b3603b478",
-    "last_synced": "2026-03-10T08:39:03.636Z"
+    "last_synced": "2026-03-10T10:40:28.826Z"
   }
 }


### PR DESCRIPTION
## Summary
- **Supabase tenant onboarded:** `fc4ba994` with modules voice, wizard, ops, reviews, sms
- **Phone routing:** `+41435051101` → weinberger-ag tenant (verified via tenant_numbers lookup)
- **SMS sender:** "Weinberger" (alphanumeric, compliant with Swiss carrier rules)
- **Voice agents re-synced + published** with Ela voice
- **Testanruf-Anleitung** for Founder added to `docs/customers/weinberger-ag/status.md`

Weinberger C = READY — waiting for Founder test call to complete E2E proof.

## Test plan
- [ ] Founder calls +41 43 505 11 01 → Lisa answers with Ela voice
- [ ] SMS received with sender "Weinberger" + correction link
- [ ] Case visible in /ops dashboard with correct category + urgency
- [ ] After test: CC marks C as DONE with evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)