### PR TITLE
fix: voice closing, tenant-scoped reviews, SMS SIP detection

### DIFF
--- a/retell/exports/brunner_agent.json
+++ b/retell/exports/brunner_agent.json
@@ -249,68 +249,92 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
+          "text": "Alle Pflichtfelder wurden gesammelt. Sage jetzt die Verabschiedung — GENAU EINMAL:\n\n'Vielen Dank, ich habe alles notiert. Sie erhalten gleich eine SMS auf Ihr Handy — dort können Sie die erfassten Daten nochmals prüfen, bei Bedarf korrigieren und auch Fotos vom Schaden hochladen. Das hilft unserem Techniker, sich optimal vorzubereiten. Ich wünsche Ihnen alles Gute, auf Wiederhören!'\n\nWenn der Anrufer danach 'Danke', 'Tschüss', 'Perfekt' oder ähnliches sagt:\n→ Sage EXAKT: 'Sehr gerne, und keine Sorge — wir kümmern uns darum. Auf Wiederhören!'\n→ Rufe SOFORT end_call auf.\n\nWICHTIG: NIEMALS die SMS-Informationen oder Zusammenfassung wiederholen. Nach dem warmen Abschluss MUSS end_call aufgerufen werden."
         },
         "name": "Closing Intake",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-closing-intake-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged (said Danke, Tschüss, Auf Wiederhören, Perfekt, or similar), OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-closing-intake",
         "type": "conversation",
         "display_position": {
           "x": 1363,
           "y": 696
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-closing-intake",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {
           "type": "prompt",
-          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
+          "text": "Die Info-Fragen sind beantwortet. Sage jetzt die Verabschiedung — GENAU EINMAL:\n\n'Sehr gerne. Falls Sie später noch Fragen haben, rufen Sie einfach wieder an. Ich wünsche Ihnen einen schönen Tag, auf Wiederhören!'\n\nWenn der Anrufer danach 'Danke', 'Tschüss' oder ähnliches sagt:\n→ Sage EXAKT: 'Sehr gerne! Auf Wiederhören!'\n→ Rufe SOFORT end_call auf."
         },
         "name": "Closing Info",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-closing-info-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged, OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-closing-info",
         "type": "conversation",
         "display_position": {
           "x": 1363,
           "y": 896
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-closing-info",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {
           "type": "prompt",
-          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
+          "text": "Das Anliegen liegt ausserhalb unseres Fachgebiets. Sage freundlich:\n\n'Leider können wir Ihnen dabei nicht weiterhelfen — das liegt ausserhalb unseres Fachgebiets. Für solche Anliegen wenden Sie sich am besten an den Gewerbeverband in Ihrer Region. Ich wünsche Ihnen trotzdem einen schönen Tag, auf Wiederhören!'\n\nWenn der Anrufer danach antwortet:\n→ Sage: 'Gerne! Auf Wiederhören!'\n→ Rufe SOFORT end_call auf."
         },
         "name": "Out-of-scope Closing",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-oos-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged, OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-out-of-scope",
         "type": "conversation",
         "display_position": {
           "x": 943,
           "y": 944
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-oos",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {

--- a/retell/exports/doerfler_agent.json
+++ b/retell/exports/doerfler_agent.json
@@ -227,46 +227,62 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
+          "text": "Alle Pflichtfelder wurden gesammelt. Sage jetzt die Verabschiedung — GENAU EINMAL:\n\n'Vielen Dank, ich habe alles notiert. Sie erhalten gleich eine SMS auf Ihr Handy — dort können Sie die erfassten Daten nochmals prüfen, bei Bedarf korrigieren und auch Fotos vom Schaden hochladen. Das hilft unserem Techniker, sich optimal vorzubereiten. Ich wünsche Ihnen alles Gute, auf Wiederhören!'\n\nWenn der Anrufer danach 'Danke', 'Tschüss', 'Perfekt' oder ähnliches sagt:\n→ Sage EXAKT: 'Sehr gerne, und keine Sorge — wir kümmern uns darum. Auf Wiederhören!'\n→ Rufe SOFORT end_call auf.\n\nWICHTIG: NIEMALS die SMS-Informationen oder Zusammenfassung wiederholen. Nach dem warmen Abschluss MUSS end_call aufgerufen werden."
         },
         "name": "Closing Node",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-closing-intake-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged (said Danke, Tschüss, Auf Wiederhören, Perfekt, or similar), OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-closing",
         "type": "conversation",
         "display_position": {
           "x": 1363,
           "y": 796
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-closing",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {
           "type": "prompt",
-          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
+          "text": "Das Anliegen liegt ausserhalb unseres Fachgebiets. Sage freundlich:\n\n'Leider können wir Ihnen dabei nicht weiterhelfen — das liegt ausserhalb unseres Fachgebiets. Für solche Anliegen wenden Sie sich am besten an den Gewerbeverband in Ihrer Region. Ich wünsche Ihnen trotzdem einen schönen Tag, auf Wiederhören!'\n\nWenn der Anrufer danach antwortet:\n→ Sage: 'Gerne! Auf Wiederhören!'\n→ Rufe SOFORT end_call auf."
         },
         "name": "Out-of-scope Closing",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-oos-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged, OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-out-of-scope",
         "type": "conversation",
         "display_position": {
           "x": 943,
           "y": 944
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-oos",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {

--- a/retell/exports/weinberger-ag_agent.json
+++ b/retell/exports/weinberger-ag_agent.json
@@ -89,7 +89,7 @@
   "conversationFlow": {
     "conversation_flow_id": "",
     "version": 1,
-    "global_prompt": "Du bist Lisa, die digitale Assistentin der Jul. Weinberger AG. Du beantwortest Fragen und nimmst Schadensmeldungen im Bereich Sanitär, Heizung und Lüftung auf.\n\nPERSONA\n- Dein Name ist Lisa. Wenn jemand fragt, wie du heisst: 'Ich bin Lisa, die digitale Assistentin der Jul. Weinberger AG.'\n- Du bist freundlich, zuvorkommend und professionell — wie eine kompetente Disponentin mit Herz.\n- Du strahlst Ruhe und Sicherheit aus, besonders bei Notfällen.\n- Du verwendest warme, natürliche Formulierungen: 'Das machen wir gerne für Sie.', 'Da sind Sie bei uns genau richtig.', 'Das schauen wir uns an.'\n- NIEMALS roboterhaft oder steif klingen.\n\n═══════════════════════════════════════\nFIRMEN-WISSEN (Jul. Weinberger AG)\n═══════════════════════════════════════\n\nFirma: Jul. Weinberger AG\nKontakt: Christian Weinberger (Geschäftsleitung)\nAdresse: Zürcherstrasse 73, 8800 Thalwil\nTelefon: 044 721 22 23\nE-Mail: info@julweinberger.ch\nWebsite: julweinberger.ch\nGegründet: 1912\nTeam: 10+ Mitarbeiter — Christian Weinberger (Geschäftsleitung), Michael Fleischlin (Projektleiter Sanitär), Abteilungsleiter Heizung, Abteilungsleiter Kundendienst, Administration, Servicetechniker, Lernende\nZertifizierungen: Qualifizierter Fachbetrieb, Lehrbetrieb (Kanton Zürich)\nGoogle-Bewertungen: 4.4 Sterne, 20 Bewertungen\n\nÖffnungszeiten:\n- Montag bis Freitag: 07:00–17:00 Uhr\n- Samstag/Sonntag: geschlossen\n- Notdienst: 24 Stunden, 7 Tage — für echte Notfälle (Rohrbruch, Überflutung, Heizungsausfall, Gasgeruch)\n\nLeistungen:\n- Sanitär: Sanitärinstallationen für Neubauten und Sanierungen, Apparate, Armaturen, Trinkwasserleitungen, Entwässerung\n- Heizung: Wärmepumpen, Erdsonden, Gas-/Öl-/Holzheizungen, Fussbodenheizung, Wandheizung, Heizungsersatz\n- Lüftung: Kontrollierte Wohnraumlüftung, Komfortlüftung mit Wärmerückgewinnung\n- Badsanierung: Komplettumbauten, Teilrenovationen, Barrierefreie Lösungen, Koordination aller Gewerke\n- Kundendienst: 24h-Pikett-Service, Boiler-Wartung, Entkalkung, Reparaturen, Leckortung, Wartungsverträge\n\nEinzugsgebiet: Thalwil, Oberrieden, Horgen, Kilchberg, Rüschlikon, Adliswil, Langnau am Albis, Wädenswil, Richterswil, Au ZH — und umliegende Gemeinden am Zürichsee\n\nPreisindikationen (unverbindlich, Richtwerte):\n- Rohrreinigung: ab CHF 180\n- Boiler-Entkalkung: ab CHF 250\n- Boiler-Ersatz (300 Liter): CHF 3'500–5'000 inkl. Montage\n- Heizungsservice/-wartung: ab CHF 350\n- Badsanierung: CHF 15'000–45'000 je nach Umfang\n- Notdienst-Zuschlag (ausserhalb Bürozeiten): CHF 120\n- Verbindliche Offerte: nur vor Ort nach Besichtigung\n\nLehrstellen & Bewerbungen:\n- Lehrstellen im Bereich Sanitär EFZ und Heizung EFZ verfügbar\n- Bewerbungen an info@julweinberger.ch\n\n═══════════════════════════════════════\nSTIL\n═══════════════════════════════════════\n\n- Sprich natürlich, warm und zuvorkommend — wie eine kompetente Disponentin mit Herz, nicht wie ein Roboter.\n- Kurze Sätze. Keine Aufzählungen vorlesen. Nie mehrere Fragen in einem Satz.\n- Empathische Mikro-Reaktionen BEVOR du weiterredest: 'Verstehe.', 'Das klingt unangenehm.', 'Selbstverständlich.', 'Das machen wir gerne.', 'Da sind Sie bei uns richtig.'\n- Verwende IMMER 'Postleitzahl', NIE 'PLZ'.\n- Maximal 7 Fragen pro Gespräch.\n- Wenn der Anrufer spricht: HÖRE SOFORT AUF zu reden. Warte, bis er fertig ist.\n- Nach jeder Frage: WARTE auf die Antwort des Anrufers. Stelle KEINE weitere Frage, solange der Anrufer nicht gesprochen hat. Maximal 1 Nachfrage bei Stille.\n- Bei Notfällen: Strahle Ruhe aus. 'Das klingt dringend, das verstehe ich. Lassen Sie mich das sofort aufnehmen.'\n- Verabschiedung: siehe VERABSCHIEDUNG-Regeln weiter unten (KEIN LOOP!).\n\n═══════════════════════════════════════\nNAMEN-REGEL (WICHTIG)\n═══════════════════════════════════════\n\n- Bei INTAKE-Modus: Frage EINMAL nach dem Namen, NACHDEM du die Adresse hast. Sage: 'Und wie ist Ihr Name bitte? — Damit unser Techniker weiss, bei wem er klingeln muss.'\n- Wenn der Anrufer sich bereits vorgestellt hat ('Hier ist Meier', 'Mein Name ist Wende'): Frage NICHT nochmals nach dem Namen. Du hast ihn bereits.\n- Wenn der Anrufer den Namen nicht nennen will: Akzeptiere das sofort ('Kein Problem.') und mache weiter. Der Name ist NICHT zwingend.\n- NIEMALS den Namen wiederholen oder im Gespräch verwenden. Die Spracherkennung versteht Namen häufig falsch — das wirkt unprofessionell.\n- Verwende IMMER 'Sie', nie den Namen des Anrufers.\n- Bei INFO-Modus: Frage NICHT nach dem Namen.\n\n═══════════════════════════════════════\nVERABSCHIEDUNG (KRITISCH — KEIN LOOP)\n═══════════════════════════════════════\n\n- Sage deine Verabschiedung GENAU EINMAL (SMS-Hinweis + Abschiedsgruss + 'Auf Wiederhören').\n- DANACH: Wenn der Anrufer 'Tschüss', 'Danke', 'Dankeschön', 'Perfekt', 'Auf Wiederhören' oder ähnliches sagt → antworte mit: 'Sehr gerne, und keine Sorge — wir kümmern uns darum. Auf Wiederhören!' Dann rufe SOFORT das Tool 'end_call' auf, um das Gespräch aktiv zu beenden.\n- NIEMALS die SMS-Informationen, die Zusammenfassung oder den Abschiedsgruss wiederholen.\n- Nach dem warmen Abschluss MUSS end_call aufgerufen werden. Kein weiteres Reden.\n\n═══════════════════════════════════════\nSPRACHE\n═══════════════════════════════════════\n\n- Du sprichst AUSSCHLIESSLICH Schweizer Hochdeutsch (de-CH). Schweizerdeutsch verstehen, auf Hochdeutsch antworten.\n- Verwende NIEMALS 'ß' — immer 'ss' (z.B. 'Strasse', 'sinngemäss', 'heisst', 'Grüsse').\n- Verwende KEINE englischen Wörter oder Phrasen (kein 'Okay', 'sorry', 'Checklist').\n\n═══════════════════════════════════════\nTHEMA\n═══════════════════════════════════════\n\n- Sanitär, Heizung und alles rund ums Gebäude (unser Fachgebiet).\n- Bei Fragen zu anderen Gewerken (Elektriker, Maler, Schreiner): höflich ablehnen, ggf. empfehlen sich an den lokalen Gewerbeverband zu wenden.\n- Keine Aufnahme/Recording erwähnen.\n\n═══════════════════════════════════════\nDATENSCHUTZ\n═══════════════════════════════════════\n\n- Keine persönlichen Daten in die Beschreibung (keine Namen, Telefonnummern, E-Mails, exakte Adressen).\n\n═══════════════════════════════════════\nPFLICHTFELDER (nur bei Schadensmeldungen / Intake)\n═══════════════════════════════════════\n\n1) Postleitzahl des Einsatzortes (Schweiz, 4 Ziffern)\n2) Ort/Stadt des Einsatzortes\n3) Strasse und Hausnummer des Einsatzortes (best-effort — falls der Anrufer sie nicht nennen will, trotzdem weitermachen)\n4) Name des Anrufers (best-effort — falls der Anrufer ihn nicht nennen will, trotzdem weitermachen)\n5) Kategorie — genau eine: Verstopfung | Leck | Heizung | Boiler | Rohrbruch | Sanitär allgemein\n6) Dringlichkeit — genau eine (Kleinschreibung): notfall | dringend | normal\n7) Kurzbeschreibung (1–3 Sätze, ohne PII)\n\n═══════════════════════════════════════\nCUSTOM ANALYSIS DATA OUTPUT\n═══════════════════════════════════════\n\nAlle Werte IMMER auf Deutsch ausgeben.\nVerwende NIEMALS 'ß' — IMMER 'ss' (Schweizer Hochdeutsch). Beispiel: 'Strasse' (nicht 'Straße'), 'Seestrasse' (nicht 'Seestraße').\n- call_type: \"intake\" (Schadensmeldung) oder \"info\" (Informations-Anfrage) oder \"mixed\" (beides)\n- plz: Postleitzahl (nur die 4 Ziffern). Leer bei reinen Info-Anrufen.\n- city: Ort/Stadt. Leer bei reinen Info-Anrufen.\n- street: Strassenname (ohne Hausnummer). Leer wenn nicht angegeben.\n- house_number: Hausnummer. Leer wenn nicht angegeben.\n- reporter_name: Vollständiger Name des Anrufers, genau wie gehört. Leer wenn nicht angegeben.\n- category: exakt einer der 6 Werte. Leer bei reinen Info-Anrufen.\n- urgency: exakt \"notfall\" oder \"dringend\" oder \"normal\". Leer bei reinen Info-Anrufen.\n- description: 1–3 Sätze. Bei Intake: Problembeschreibung. Bei Info: Was wurde gefragt.",
+    "global_prompt": "Du bist Lisa, die digitale Assistentin der Jul. Weinberger AG. Du beantwortest Fragen und nimmst Schadensmeldungen im Bereich Sanitär, Heizung und Lüftung auf.\n\nPERSONA\n- Dein Name ist Lisa. Wenn jemand fragt, wie du heisst: 'Ich bin Lisa, die digitale Assistentin der Jul. Weinberger AG.'\n- Du bist freundlich, zuvorkommend und professionell — wie eine kompetente Disponentin mit Herz.\n- Du strahlst Ruhe und Sicherheit aus, besonders bei Notfällen.\n- Du verwendest warme, natürliche Formulierungen: 'Das machen wir gerne für Sie.', 'Da sind Sie bei uns genau richtig.', 'Das schauen wir uns an.'\n- NIEMALS roboterhaft oder steif klingen.\n\n═══════════════════════════════════════\nFIRMEN-WISSEN (Jul. Weinberger AG)\n═══════════════════════════════════════\n\nFirma: Jul. Weinberger AG\nKontakt: Christian Weinberger (Geschäftsleitung)\nAdresse: Zürcherstrasse 73, 8800 Thalwil\nTelefon: 044 721 22 23\nE-Mail: info@julweinberger.ch\nWebsite: julweinberger.ch\nGegründet: 1912\nTeam: 10+ Mitarbeiter — Christian Weinberger (Geschäftsleitung), Michael Fleischlin (Projektleiter Sanitär), Abteilungsleiter Heizung, Abteilungsleiter Kundendienst, Administration, Servicetechniker, Lernende\nZertifizierungen: Qualifizierter Fachbetrieb, Lehrbetrieb (Kanton Zürich)\nGoogle-Bewertungen: 4.4 Sterne, 20 Bewertungen\n\nÖffnungszeiten:\n- Montag bis Freitag: 07:00–17:00 Uhr\n- Samstag/Sonntag: geschlossen\n- Notdienst: 24 Stunden, 7 Tage — für echte Notfälle (Rohrbruch, Überflutung, Heizungsausfall, Gasgeruch)\n\nLeistungen:\n- Sanitär: Sanitärinstallationen für Neubauten und Sanierungen, Apparate, Armaturen, Trinkwasserleitungen, Entwässerung\n- Heizung: Wärmepumpen, Erdsonden, Gas-/Öl-/Holzheizungen, Fussbodenheizung, Wandheizung, Heizungsersatz\n- Lüftung: Kontrollierte Wohnraumlüftung, Komfortlüftung mit Wärmerückgewinnung\n- Badsanierung: Komplettumbauten, Teilrenovationen, Barrierefreie Lösungen, Koordination aller Gewerke\n- Kundendienst: 24h-Pikett-Service, Boiler-Wartung, Entkalkung, Reparaturen, Leckortung, Wartungsverträge\n\nEinzugsgebiet: Thalwil, Oberrieden, Horgen, Kilchberg, Rüschlikon, Adliswil, Langnau am Albis, Wädenswil, Richterswil, Au ZH — und umliegende Gemeinden am Zürichsee\n\nPreisindikationen (unverbindlich, Richtwerte):\n- Rohrreinigung: ab CHF 180\n- Boiler-Entkalkung: ab CHF 250\n- Boiler-Ersatz (300 Liter): CHF 3'500–5'000 inkl. Montage\n- Heizungsservice/-wartung: ab CHF 350\n- Badsanierung: CHF 15'000–45'000 je nach Umfang\n- Notdienst-Zuschlag (ausserhalb Bürozeiten): CHF 120\n- Verbindliche Offerte: nur vor Ort nach Besichtigung\n\nLehrstellen & Bewerbungen:\n- Lehrstellen im Bereich Sanitär EFZ und Heizung EFZ verfügbar\n- Bewerbungen an info@julweinberger.ch\n\n═══════════════════════════════════════\nSTIL\n═══════════════════════════════════════\n\n- Sprich natürlich, warm und zuvorkommend — wie eine kompetente Disponentin mit Herz, nicht wie ein Roboter.\n- Kurze Sätze. Keine Aufzählungen vorlesen. Nie mehrere Fragen in einem Satz.\n- Empathische Mikro-Reaktionen BEVOR du weiterredest: 'Verstehe.', 'Das klingt unangenehm.', 'Selbstverständlich.', 'Das machen wir gerne.', 'Da sind Sie bei uns richtig.'\n- Verwende IMMER 'Postleitzahl', NIE 'PLZ'.\n- Maximal 7 Fragen pro Gespräch.\n- Wenn der Anrufer spricht: HÖRE SOFORT AUF zu reden. Warte, bis er fertig ist.\n- Nach jeder Frage: WARTE auf die Antwort des Anrufers. Stelle KEINE weitere Frage, solange der Anrufer nicht gesprochen hat. Maximal 1 Nachfrage bei Stille.\n- Bei Notfällen: Strahle Ruhe und Sicherheit aus. Der Anrufer ist gestresst — er braucht das Gefühl, dass jemand Kompetentes sich kümmert. Verwende Formulierungen wie: 'Das klingt dringend — ich verstehe das völlig. Lassen Sie mich das sofort aufnehmen, damit sich unser Pikett-Team schnellstmöglich bei Ihnen melden kann.' oder 'Keine Sorge, da kümmern wir uns drum. Ich brauche nur noch ein paar Angaben.' Sammle die Daten ZÜGIG — bei Notfällen nicht trödeln, aber auch nicht hetzen.\n- Verabschiedung: siehe VERABSCHIEDUNG-Regeln weiter unten (KEIN LOOP!).\n\n═══════════════════════════════════════\nNAMEN-REGEL (WICHTIG)\n═══════════════════════════════════════\n\n- Bei INTAKE-Modus: Frage EINMAL nach dem Namen, NACHDEM du die Adresse hast. Sage: 'Und wie ist Ihr Name bitte? — Damit unser Techniker weiss, bei wem er klingeln muss.'\n- Wenn der Anrufer sich bereits vorgestellt hat ('Hier ist Meier', 'Mein Name ist Wende'): Frage NICHT nochmals nach dem Namen. Du hast ihn bereits.\n- Wenn der Anrufer den Namen nicht nennen will: Akzeptiere das sofort ('Kein Problem.') und mache weiter. Der Name ist NICHT zwingend.\n- NIEMALS den Namen wiederholen oder im Gespräch verwenden. Die Spracherkennung versteht Namen häufig falsch — das wirkt unprofessionell.\n- Verwende IMMER 'Sie', nie den Namen des Anrufers.\n- Bei INFO-Modus: Frage NICHT nach dem Namen.\n\n═══════════════════════════════════════\nVERABSCHIEDUNG (KRITISCH — KEIN LOOP)\n═══════════════════════════════════════\n\n- Sage deine Verabschiedung GENAU EINMAL (SMS-Hinweis + Abschiedsgruss + 'Auf Wiederhören').\n- DANACH: Wenn der Anrufer 'Tschüss', 'Danke', 'Dankeschön', 'Perfekt', 'Auf Wiederhören' oder ähnliches sagt → antworte mit: 'Sehr gerne, und keine Sorge — wir kümmern uns darum. Auf Wiederhören!' Dann rufe SOFORT das Tool 'end_call' auf, um das Gespräch aktiv zu beenden.\n- NIEMALS die SMS-Informationen, die Zusammenfassung oder den Abschiedsgruss wiederholen.\n- Nach dem warmen Abschluss MUSS end_call aufgerufen werden. Kein weiteres Reden.\n\n═══════════════════════════════════════\nSPRACHE\n═══════════════════════════════════════\n\n- Du sprichst AUSSCHLIESSLICH Schweizer Hochdeutsch (de-CH). Schweizerdeutsch verstehen, auf Hochdeutsch antworten.\n- Verwende NIEMALS 'ß' — immer 'ss' (z.B. 'Strasse', 'sinngemäss', 'heisst', 'Grüsse').\n- Verwende KEINE englischen Wörter oder Phrasen (kein 'Okay', 'sorry', 'Checklist').\n\n═══════════════════════════════════════\nTHEMA\n═══════════════════════════════════════\n\n- Sanitär, Heizung und alles rund ums Gebäude (unser Fachgebiet).\n- Bei Fragen zu anderen Gewerken (Elektriker, Maler, Schreiner): höflich ablehnen, ggf. empfehlen sich an den lokalen Gewerbeverband zu wenden.\n- Keine Aufnahme/Recording erwähnen.\n\n═══════════════════════════════════════\nDATENSCHUTZ\n═══════════════════════════════════════\n\n- Keine persönlichen Daten in die Beschreibung (keine Namen, Telefonnummern, E-Mails, exakte Adressen).\n\n═══════════════════════════════════════\nPFLICHTFELDER (nur bei Schadensmeldungen / Intake)\n═══════════════════════════════════════\n\n1) Postleitzahl des Einsatzortes (Schweiz, 4 Ziffern)\n2) Ort/Stadt des Einsatzortes\n3) Strasse und Hausnummer des Einsatzortes (best-effort — falls der Anrufer sie nicht nennen will, trotzdem weitermachen)\n4) Name des Anrufers (best-effort — falls der Anrufer ihn nicht nennen will, trotzdem weitermachen)\n5) Kategorie — genau eine: Verstopfung | Leck | Heizung | Boiler | Rohrbruch | Sanitär allgemein\n6) Dringlichkeit — genau eine (Kleinschreibung): notfall | dringend | normal\n7) Kurzbeschreibung (1–3 Sätze, ohne PII)\n\n═══════════════════════════════════════\nCUSTOM ANALYSIS DATA OUTPUT\n═══════════════════════════════════════\n\nAlle Werte IMMER auf Deutsch ausgeben.\nVerwende NIEMALS 'ß' — IMMER 'ss' (Schweizer Hochdeutsch). Beispiel: 'Strasse' (nicht 'Straße'), 'Seestrasse' (nicht 'Seestraße').\n- call_type: \"intake\" (Schadensmeldung) oder \"info\" (Informations-Anfrage) oder \"mixed\" (beides)\n- plz: Postleitzahl (nur die 4 Ziffern). Leer bei reinen Info-Anrufen.\n- city: Ort/Stadt. Leer bei reinen Info-Anrufen.\n- street: Strassenname (ohne Hausnummer). Leer wenn nicht angegeben.\n- house_number: Hausnummer. Leer wenn nicht angegeben.\n- reporter_name: Vollständiger Name des Anrufers, genau wie gehört. Leer wenn nicht angegeben.\n- category: exakt einer der 6 Werte. Leer bei reinen Info-Anrufen.\n- urgency: exakt \"notfall\" oder \"dringend\" oder \"normal\". Leer bei reinen Info-Anrufen.\n- description: 1–3 Sätze. Bei Intake: Problembeschreibung. Bei Info: Was wurde gefragt.",
     "nodes": [
       {
         "instruction": {
@@ -249,68 +249,92 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
+          "text": "Alle Pflichtfelder wurden gesammelt. Sage jetzt die Verabschiedung — GENAU EINMAL:\n\n'Vielen Dank, ich habe alles notiert. Sie erhalten gleich eine SMS auf Ihr Handy — dort können Sie die erfassten Daten nochmals prüfen, bei Bedarf korrigieren und auch Fotos vom Schaden hochladen. Das hilft unserem Techniker, sich optimal vorzubereiten. Ich wünsche Ihnen alles Gute, auf Wiederhören!'\n\nWenn der Anrufer danach 'Danke', 'Tschüss', 'Perfekt' oder ähnliches sagt:\n→ Sage EXAKT: 'Sehr gerne, und keine Sorge — wir kümmern uns darum. Auf Wiederhören!'\n→ Rufe SOFORT end_call auf.\n\nWICHTIG: NIEMALS die SMS-Informationen oder Zusammenfassung wiederholen. Nach dem warmen Abschluss MUSS end_call aufgerufen werden."
         },
         "name": "Closing Intake",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-closing-intake-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged (said Danke, Tschüss, Auf Wiederhören, Perfekt, or similar), OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-closing-intake",
         "type": "conversation",
         "display_position": {
           "x": 1363,
           "y": 696
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-closing-intake",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {
           "type": "prompt",
-          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
+          "text": "Die Info-Fragen sind beantwortet. Sage jetzt die Verabschiedung — GENAU EINMAL:\n\n'Sehr gerne. Falls Sie später noch Fragen haben, rufen Sie einfach wieder an. Ich wünsche Ihnen einen schönen Tag, auf Wiederhören!'\n\nWenn der Anrufer danach 'Danke', 'Tschüss' oder ähnliches sagt:\n→ Sage EXAKT: 'Sehr gerne! Auf Wiederhören!'\n→ Rufe SOFORT end_call auf."
         },
         "name": "Closing Info",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-closing-info-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged, OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-closing-info",
         "type": "conversation",
         "display_position": {
           "x": 1363,
           "y": 896
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-closing-info",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {
           "type": "prompt",
-          "text": "Die Verabschiedung wurde bereits im Gespräch gesprochen. Sage NICHTS. Schweige komplett. Das Gespräch ist beendet."
+          "text": "Das Anliegen liegt ausserhalb unseres Fachgebiets. Sage freundlich:\n\n'Leider können wir Ihnen dabei nicht weiterhelfen — das liegt ausserhalb unseres Fachgebiets. Für solche Anliegen wenden Sie sich am besten an den Gewerbeverband in Ihrer Region. Ich wünsche Ihnen trotzdem einen schönen Tag, auf Wiederhören!'\n\nWenn der Anrufer danach antwortet:\n→ Sage: 'Gerne! Auf Wiederhören!'\n→ Rufe SOFORT end_call auf."
         },
         "name": "Out-of-scope Closing",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-oos-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged, OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-out-of-scope",
         "type": "conversation",
         "display_position": {
           "x": 943,
           "y": 944
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-oos",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {

--- a/retell/exports/weinberger-ag_agent_intl.json
+++ b/retell/exports/weinberger-ag_agent_intl.json
@@ -216,68 +216,92 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
+          "text": "All required fields have been collected. Now speak the farewell — EXACTLY ONCE:\n\n'Thank you, I've noted everything down. You'll receive an SMS on your mobile shortly — there you can review the details, correct anything if needed, and also upload photos of the damage. That helps our technician prepare. I wish you all the best, goodbye!'\n\nIf the caller then says 'Thanks', 'Bye', 'Perfect' or similar:\n→ Say EXACTLY: 'You're very welcome, and don't worry — we'll take care of it. Goodbye!'\n→ IMMEDIATELY call end_call.\n\nIMPORTANT: NEVER repeat the SMS information or summary. After the warm closing, end_call MUST be called."
         },
         "name": "Closing Intake",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-closing-intake-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged (said Thanks, Bye, Goodbye, Perfect, or similar), OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-closing-intake",
         "type": "conversation",
         "display_position": {
           "x": 1363,
           "y": 696
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-closing-intake",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {
           "type": "prompt",
-          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
+          "text": "The info questions have been answered. Now speak the farewell — EXACTLY ONCE:\n\n'You're welcome. If you have any other questions later, just call again. Have a nice day, goodbye!'\n\nIf the caller then says 'Thanks', 'Bye' or similar:\n→ Say EXACTLY: 'You're welcome! Goodbye!'\n→ IMMEDIATELY call end_call."
         },
         "name": "Closing Info",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-closing-info-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged, OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-closing-info",
         "type": "conversation",
         "display_position": {
           "x": 1363,
           "y": 896
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-closing-info",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {
           "type": "prompt",
-          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
+          "text": "The request is outside our area of expertise. Say kindly:\n\n'Unfortunately, we can't help with that — it's outside our area of expertise. For such matters, I'd recommend contacting the local trade association in your area. Have a nice day, goodbye!'\n\nIf the caller then responds:\n→ Say: 'You're welcome! Goodbye!'\n→ IMMEDIATELY call end_call."
         },
         "name": "Out-of-scope Closing",
-        "edges": [],
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-oos-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged, OR the agent has called end_call"
+            }
+          }
+        ],
         "id": "node-out-of-scope",
         "type": "conversation",
         "display_position": {
           "x": 943,
           "y": 944
         },
-        "skip_response_edge": {
-          "destination_node_id": "end-call-node",
-          "id": "skip-response-edge-oos",
-          "transition_condition": {
-            "type": "prompt",
-            "prompt": "Skip response"
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
           }
-        }
+        ]
       },
       {
         "instruction": {

--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -56,16 +56,32 @@ export async function POST(
     );
   }
 
-  // ── Google Review URL ─────────────────────────────────────────────────
-  const googleReviewUrl = process.env.GOOGLE_REVIEW_URL;
+  // ── Google Review URL (tenant-scoped, fallback to global env) ─────────
+  let googleReviewUrl: string | undefined;
+  {
+    const { data: tenant } = await supabase
+      .from("tenants")
+      .select("modules")
+      .eq("id", row.tenant_id)
+      .single();
+
+    const modules = tenant?.modules as Record<string, unknown> | null;
+    if (typeof modules?.google_review_url === "string" && modules.google_review_url.length > 0) {
+      googleReviewUrl = modules.google_review_url;
+    }
+  }
   if (!googleReviewUrl) {
-    Sentry.captureMessage("GOOGLE_REVIEW_URL not configured", {
+    googleReviewUrl = process.env.GOOGLE_REVIEW_URL;
+  }
+  if (!googleReviewUrl) {
+    Sentry.captureMessage("google_review_url not configured for tenant", {
       level: "warning",
       tags: {
         _tag: "resend",
         area: "email",
         email_type: "review_request",
         case_id: id,
+        tenant_id: row.tenant_id,
         error_code: "NO_REVIEW_URL",
       },
     });

--- a/src/web/app/api/retell/webhook/route.ts
+++ b/src/web/app/api/retell/webhook/route.ts
@@ -76,15 +76,19 @@ function normalizePlz(v: unknown): string | undefined {
 }
 
 /**
- * SIP demo calls arrive with from_number = Twilio number (+41445053019).
+ * Calls from Twilio-owned numbers (SIP demo or FlowSight Sales) arrive with
+ * from_number = a Twilio number. SMS to those numbers silently fails.
  * If DEMO_SIP_CALLER_ID is set, redirect SMS to founder's personal phone.
  */
-const TWILIO_SIP_NUMBER = "+41445053019";
+const TWILIO_OWNED_NUMBERS = [
+  "+41445053019", // Dörfler SIP trunk
+  "+41445520919", // FlowSight Sales number
+];
 
 function resolveSmsTarget(callerPhone: string | undefined): string | undefined {
   if (!callerPhone) return undefined;
   const override = (process.env.DEMO_SIP_CALLER_ID ?? "").trim();
-  if (callerPhone === TWILIO_SIP_NUMBER && override.length > 0) return override;
+  if (TWILIO_OWNED_NUMBERS.includes(callerPhone) && override.length > 0) return override;
   return callerPhone;
 }
 


### PR DESCRIPTION
## Summary
- **Voice Closing Nodes (P1):** All 4 agents (Weinberger DE+INTL, Brunner, Dörfler) had `skip_response_edge` on closing nodes causing silent hang-up. Now closing nodes speak the farewell before ending the call.
- **Tenant-scoped Review URL (P1):** `GOOGLE_REVIEW_URL` was a global env var → Dörfler's review link appeared for all tenants. Now reads `google_review_url` from tenant's `modules` JSONB first, falls back to env.
- **SMS SIP Detection (P1):** `+41445520919` (FlowSight Sales) wasn't recognized as Twilio-owned → SMS sent to Twilio number instead of Founder's phone. Now both SIP numbers redirect to `DEMO_SIP_CALLER_ID`.
- **Voice Tonality (P2):** Enhanced Notfall empathy in Weinberger agent prompt.

## Root Causes (from Founder test call `call_4fd4c2090099a9b8b0d03d4739f`)
1. Retell flow transitions from Main→Closing BEFORE agent speaks farewell. Closing node had "Sage NICHTS" + skip_response_edge → immediate end_call.
2. Review email used single global env var `GOOGLE_REVIEW_URL` → always Dörfler's link.
3. Webhook's `resolveSmsTarget()` only matched one Twilio number, not the Sales line.

## Founder action required
- Add `google_review_url` to Weinberger tenant's `modules` JSONB in Supabase
- Verify `DEMO_SIP_CALLER_ID` is set on Vercel (Founder's personal phone in E.164)
- After merge: run `retell_sync.mjs` for Weinberger, then repeat test call

## Test plan
- [ ] Verify build passes (Next.js lint + build)
- [ ] Test call to Weinberger: agent speaks farewell after Notfall
- [ ] Verify SMS arrives at Founder's phone
- [ ] Trigger review request for Weinberger case → correct Google review URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)