### PR TITLE
feat: trial lifecycle emails + morning report trial awareness

### DIFF
--- a/docs/gtm/outreach_templates.md
+++ b/docs/gtm/outreach_templates.md
@@ -1,6 +1,6 @@
 # Premium Outreach-Templates (Leckerli-Varianten)
 
-**Erstellt:** 2026-03-09 | **Owner:** Founder (Versand) + CC (Templates)
+**Erstellt:** 2026-03-09 | **Aktualisiert:** 2026-03-11 | **Owner:** Founder (Versand) + CC (Templates)
 **Referenz:** `docs/gtm/operating_model.md`
 **Regel:** Founder sendet IMMER aus eigener E-Mail. Kein Massenversand. Jede Mail personalisiert.
 
@@ -13,6 +13,20 @@
 3. **CTA immer konkret:** "Testen Sie Ihre eigene Lisa: [Nummer]" — nicht "Buchen Sie eine Demo".
 4. **Keine PII** anderer Kunden im Outreach.
 5. **Max 3 Touches** pro Prospect, dann Ruhe.
+
+---
+
+## Trial Machine Kontext
+
+Seit März 2026 bieten wir jedem qualifizierten Prospect einen **14-Tage Trial** an:
+- **Eigene Testnummer** — Lisa nimmt Anrufe für den Prospect entgegen
+- **Dashboard-Zugang** — Magic-Link, Demo-Fälle, Status-Übersicht
+- **SMS-Flow** — automatische Bestätigung nach jedem Anruf
+- **Review-System** — Google-style Bewertungsseite
+
+Der Outreach führt den Prospect zum Testen, nicht zum Kaufen. Die Templates spiegeln das wider: CTA ist immer "Testen Sie", nie "Buchen Sie".
+
+**Referenz:** `docs/gtm/operating_model.md` (6 Phasen, Trial Timeline)
 
 ---
 
@@ -43,7 +57,7 @@
 
 ---
 
-## Template 2: A+B-Quick+D (ICP 75-89, gute Prospects)
+## Template 2: A+B-Full+D (ICP 75-89, gute Prospects)
 
 **Betreff:** {FIRMA} — Ihre eigene Lisa wartet
 
@@ -67,7 +81,7 @@
 
 ---
 
-## Template 3: B-Quick+D (ICP 60-74, solide Prospects)
+## Template 3: B-Full+D (ICP 60-74, solide Prospects)
 
 **Betreff:** Kein verpasster Anruf mehr — Demo für {FIRMA}
 
@@ -87,6 +101,26 @@
 > Grüsse
 > Gunnar Wende
 > FlowSight — flowsight.ch
+
+---
+
+## Template 4: Trial-Einladung (nach Provision)
+
+**Trigger:** Prospect hat Interesse gezeigt → Trial provisioniert → Welcome-Mail geht automatisch via `provision_trial.mjs`.
+
+> Dieser Text wird automatisch als HTML-E-Mail gesendet. Die folgenden Inhalte sind zur Dokumentation.
+
+**Betreff:** Willkommen — Ihr 14-Tage Trial bei FlowSight
+
+**Inhalt:**
+- Begrüssung + "Ihr Trial ist aktiv"
+- Magic-Link zum Dashboard
+- Testnummer (falls zugewiesen)
+- Was enthalten ist: Dashboard, Lisa, SMS-Flow, Reviews
+- Trial-Zeitraum (14 Tage)
+- Founder-Kontakt
+
+**Automatisierung:** `provision_trial.mjs` sendet diese E-Mail automatisch nach Provisioning.
 
 ---
 
@@ -154,6 +188,7 @@ Vor jedem Versand:
 
 | Touch | Kanal | Timing | Template |
 |-------|-------|--------|----------|
+| 0 | E-Mail (auto) | Nach Provision | Template 4 (automatisch via provision_trial.mjs) |
 | 1 | E-Mail | Tag 0 | Template 1/2/3 (nach ICP) |
 | 2 | Anruf | Tag 2 | Anruf-Script |
 | 3 | E-Mail | Tag 7 | Kurzer Follow-up ("Hatten Sie Zeit zum Testen?") |

--- a/scripts/_ops/_lib/send_email.mjs
+++ b/scripts/_ops/_lib/send_email.mjs
@@ -1,0 +1,47 @@
+/**
+ * Shared email helper for CLI scripts.
+ * Calls Resend HTTP API directly (no Next.js dependency).
+ *
+ * Usage:
+ *   import { sendEmail } from "./_lib/send_email.mjs";
+ *   const result = await sendEmail({ to, subject, html, text });
+ */
+
+const RESEND_API = "https://api.resend.com/emails";
+
+/**
+ * @param {{ to: string, subject: string, html: string, text?: string }} opts
+ * @returns {Promise<{ success: boolean, messageId?: string, error?: string }>}
+ */
+export async function sendEmail({ to, subject, html, text }) {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    return { success: false, error: "RESEND_API_KEY not set" };
+  }
+
+  const from = process.env.MAIL_FROM || "noreply@send.flowsight.ch";
+
+  try {
+    const body = { from, to, subject, html };
+    if (text) body.text = text;
+
+    const res = await fetch(RESEND_API, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const err = await res.text();
+      return { success: false, error: `HTTP ${res.status}: ${err}` };
+    }
+
+    const data = await res.json();
+    return { success: true, messageId: data.id };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}

--- a/scripts/_ops/morning_report.mjs
+++ b/scripts/_ops/morning_report.mjs
@@ -116,6 +116,59 @@ if (oldestRow) {
   oldestAge = ageD > 0 ? `${ageD}d ${ageH % 24}h` : `${ageH}h`;
 }
 
+// ---------------------------------------------------------------------------
+// Trial Lifecycle Queries
+// ---------------------------------------------------------------------------
+
+const h24ahead = new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString();
+const h48ahead = new Date(now.getTime() + 48 * 60 * 60 * 1000).toISOString();
+
+// T1. Active trials: trial_status IN ('trial_active', 'live_dock')
+const { data: activeTrials, error: eT1 } = await supabase
+  .from("tenants")
+  .select("slug, trial_status")
+  .in("trial_status", ["trial_active", "live_dock"]);
+if (eT1) console.error("Query active trials:", eT1.message);
+
+const activeTrialCount = activeTrials?.length ?? 0;
+
+// T2. Follow-ups due today: follow_up_at <= todayEnd AND trial_status = 'trial_active'
+const { data: followUpsDue, error: eT2 } = await supabase
+  .from("tenants")
+  .select("slug")
+  .eq("trial_status", "trial_active")
+  .lte("follow_up_at", todayEnd.toISOString());
+if (eT2) console.error("Query follow-ups:", eT2.message);
+
+const followUpDueCount = followUpsDue?.length ?? 0;
+const followUpNames = followUpsDue?.map((t) => t.slug).join(", ") ?? "";
+
+// T3. Expiring within 48h: trial_end <= now + 48h AND trial_status IN ('trial_active', 'live_dock')
+const { data: expiring48h, error: eT3 } = await supabase
+  .from("tenants")
+  .select("slug, trial_end")
+  .in("trial_status", ["trial_active", "live_dock"])
+  .lte("trial_end", h48ahead);
+if (eT3) console.error("Query expiring:", eT3.message);
+
+const expiring48hCount = expiring48h?.length ?? 0;
+const expiringNames = expiring48h?.map((t) => t.slug).join(", ") ?? "";
+
+// T3b. Subset: expiring within 24h (for RED severity)
+const expiring24h = expiring48h?.filter(
+  (t) => t.trial_end && new Date(t.trial_end).getTime() <= new Date(h24ahead).getTime()
+) ?? [];
+
+// T4. Zombie trials: trial_active but trial_start > 7 days ago (no activity signal)
+const { data: zombieTrials, error: eT4 } = await supabase
+  .from("tenants")
+  .select("slug")
+  .eq("trial_status", "trial_active")
+  .lt("trial_start", d7ago);
+if (eT4) console.error("Query zombies:", eT4.message);
+
+const zombieCount = zombieTrials?.length ?? 0;
+
 // 8. Health check
 let healthOk = false;
 try {
@@ -130,8 +183,8 @@ try {
 // Severity
 // ---------------------------------------------------------------------------
 
-const isRed = (stuck48h ?? 0) > 0 || !healthOk;
-const isYellow = (backlogNew ?? 0) > 5 || notfallCount > 0;
+const isRed = (stuck48h ?? 0) > 0 || !healthOk || expiring24h.length > 0;
+const isYellow = (backlogNew ?? 0) > 5 || notfallCount > 0 || followUpDueCount > 0;
 const severity = isRed ? "🔴" : isYellow ? "🟡" : "🟢";
 
 // ---------------------------------------------------------------------------
@@ -155,6 +208,11 @@ const report = [
   `done_7d:        ${done7d ?? "?"}`,
   `reviews_7d:     ${reviewsSent7d ?? "?"}`,
   `oldest_open:    ${oldestAge}`,
+  `━━━ TRIALS ━━━━━━━━━`,
+  `active_trials:  ${activeTrialCount}`,
+  `follow_up_due:  ${followUpDueCount}${followUpNames ? ` (${followUpNames})` : ""}`,
+  `expiring_48h:   ${expiring48hCount}${expiringNames ? ` (${expiringNames})` : ""}`,
+  `zombie_trials:  ${zombieCount}`,
   `health:         ${healthOk ? "OK" : "FAIL"}`,
   `━━━━━━━━━━━━━━━━━━━`,
 ].join("\n");

--- a/scripts/_ops/offboard_tenant.mjs
+++ b/scripts/_ops/offboard_tenant.mjs
@@ -28,6 +28,7 @@
 import { createRequire } from "node:module";
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { sendEmail } from "./_lib/send_email.mjs";
 
 const require = createRequire(import.meta.url);
 const { createClient } = require("../../src/web/node_modules/@supabase/supabase-js/dist/index.cjs");
@@ -100,6 +101,90 @@ async function main() {
   console.log(`  Found: ${tenant.name} (${tenant.id})`);
   console.log(`  Status: ${tenant.trial_status || "(none)"}`);
   console.log(`  Prospect: ${tenant.prospect_email || "(none)"}`);
+
+  // ── Step 1b: Offboarding-Mail ─────────────────────────────────────────
+  console.log("\n── Step 1b: Offboarding-Mail ───────────────────────");
+
+  if (tenant.prospect_email) {
+    const offboardHtml = `<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:24px 0">
+<tr><td align="center">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#0b1120;border-radius:8px;overflow:hidden">
+<!-- Gold accent bar -->
+<tr><td style="height:4px;background:#d4a853;font-size:0;line-height:0">&nbsp;</td></tr>
+<!-- Logo -->
+<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">FlowSight</td></tr>
+<!-- Heading -->
+<tr><td style="padding:0 24px;color:#e2e8f0;font-size:22px;font-weight:700">Guten Tag</td></tr>
+<!-- Body text -->
+<tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
+Ihr 14-Tage Trial bei FlowSight ist abgelaufen. Vielen Dank f&uuml;r Ihr Interesse.
+</td></tr>
+<!-- What they experienced -->
+<tr><td style="padding:20px 24px 0;color:#94a3b8;font-size:13px;text-transform:uppercase;letter-spacing:1px">In den letzten 14 Tagen hatten Sie Zugang zu</td></tr>
+<tr><td style="padding:8px 24px 0;color:#e2e8f0;font-size:14px;line-height:2">
+&bull; Ihrer pers&ouml;nlichen KI-Assistentin Lisa<br>
+&bull; Dem FlowSight Dashboard<br>
+&bull; Automatisierten SMS-Best&auml;tigungen<br>
+&bull; Dem Review-System
+</td></tr>
+<!-- Door stays open -->
+<tr><td style="padding:24px 24px 0">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#1e293b;border-radius:6px">
+  <tr><td style="padding:20px;color:#e2e8f0;font-size:15px;line-height:1.6">
+Falls Sie FlowSight in Ihrem Betrieb einsetzen m&ouml;chten, melden Sie sich jederzeit.
+  </td></tr>
+  </table>
+</td></tr>
+<!-- Founder contact -->
+<tr><td style="padding:28px 24px 20px;border-top:1px solid #1e293b;margin-top:24px">
+  <div style="color:#64748b;font-size:13px;line-height:1.6;text-align:center">Gunnar Wende &mdash; 044 552 09 19 &mdash; gunnar@flowsight.ch</div>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+    const offboardText = [
+      "Guten Tag",
+      "",
+      "Ihr 14-Tage Trial bei FlowSight ist abgelaufen. Vielen Dank für Ihr Interesse.",
+      "",
+      "In den letzten 14 Tagen hatten Sie Zugang zu:",
+      "- Ihrer persönlichen KI-Assistentin Lisa",
+      "- Dem FlowSight Dashboard",
+      "- Automatisierten SMS-Bestätigungen",
+      "- Dem Review-System",
+      "",
+      "Falls Sie FlowSight in Ihrem Betrieb einsetzen möchten, melden Sie sich jederzeit.",
+      "",
+      "---",
+      "Gunnar Wende — 044 552 09 19 — gunnar@flowsight.ch",
+    ].join("\n");
+
+    if (dryRun) {
+      console.log(`  Would send offboarding mail to: ${tenant.prospect_email}`);
+    } else {
+      const offboardResult = await sendEmail({
+        to: tenant.prospect_email,
+        subject: "Ihr FlowSight Trial — Danke für Ihr Interesse",
+        html: offboardHtml,
+        text: offboardText,
+      });
+
+      if (offboardResult.success) {
+        console.log(`  Offboarding-Mail sent: ${offboardResult.messageId}`);
+      } else {
+        console.error(`  Offboarding-Mail failed (non-fatal): ${offboardResult.error}`);
+      }
+    }
+  } else {
+    console.log("  No prospect_email on tenant — skipping");
+  }
 
   // ── Step 2: Delete case_attachments ─────────────────────────────────────
   console.log("\n── Step 2: Case Attachments ────────────────────────");

--- a/scripts/_ops/provision_trial.mjs
+++ b/scripts/_ops/provision_trial.mjs
@@ -32,6 +32,8 @@
 // ===========================================================================
 
 import { createRequire } from "node:module";
+import { sendEmail } from "./_lib/send_email.mjs";
+
 const require = createRequire(import.meta.url);
 const { createClient } = require("../../src/web/node_modules/@supabase/supabase-js/dist/index.cjs");
 
@@ -229,6 +231,105 @@ async function main() {
     const props = linkData.properties;
     const magicLink = `${url}/auth/v1/verify?token=${props.hashed_token}&type=magiclink&redirect_to=${encodeURIComponent(`${appUrl}/ops/cases`)}`;
 
+    // ── Step 5: Welcome-Mail ─────────────────────────────────────────────
+    console.log("\n── Step 5: Welcome-Mail ────────────────────────────");
+
+    const trialStartFmt = trialStart.toISOString().slice(0, 10);
+    const trialEndFmt = trialEnd.toISOString().slice(0, 10);
+
+    const phoneSection = phone
+      ? `<!-- Trial phone -->
+<tr><td style="padding:20px 24px 0">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#1e293b;border-radius:6px">
+  <tr><td style="padding:16px 20px;color:#94a3b8;font-size:13px;text-transform:uppercase;letter-spacing:1px">Ihre Testnummer</td></tr>
+  <tr><td style="padding:0 20px 6px;color:#e2e8f0;font-size:20px;font-weight:700;letter-spacing:0.5px">${phone}</td></tr>
+  <tr><td style="padding:0 20px 16px;color:#94a3b8;font-size:14px;line-height:1.5">Rufen Sie jetzt an und sprechen Sie mit Ihrer pers&ouml;nlichen KI-Assistentin Lisa.</td></tr>
+  </table>
+</td></tr>`
+      : "";
+
+    const welcomeHtml = `<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:24px 0">
+<tr><td align="center">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#0b1120;border-radius:8px;overflow:hidden">
+<!-- Gold accent bar -->
+<tr><td style="height:4px;background:#d4a853;font-size:0;line-height:0">&nbsp;</td></tr>
+<!-- Logo -->
+<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">FlowSight</td></tr>
+<!-- Heading -->
+<tr><td style="padding:0 24px;color:#e2e8f0;font-size:22px;font-weight:700">Guten Tag</td></tr>
+<!-- Welcome text -->
+<tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
+Ihr FlowSight Trial ist aktiv. Ab sofort k&ouml;nnen Sie unser System testen.
+</td></tr>
+<!-- CTA button -->
+<tr><td style="padding:24px 24px 8px" align="center">
+  <a href="${magicLink}" target="_blank" style="display:inline-block;background:#d4a853;color:#0b1120;font-size:15px;font-weight:700;text-decoration:none;padding:14px 36px;border-radius:6px">Dashboard &ouml;ffnen</a>
+</td></tr>
+${phoneSection}
+<!-- Trial period -->
+<tr><td style="padding:20px 24px 0">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#1e293b;border-radius:6px">
+  <tr><td style="padding:16px 20px;color:#94a3b8;font-size:13px;text-transform:uppercase;letter-spacing:1px">Trial-Zeitraum</td></tr>
+  <tr><td style="padding:0 20px 16px;color:#e2e8f0;font-size:15px;font-weight:600">${trialStartFmt} bis ${trialEndFmt} (14 Tage)</td></tr>
+  </table>
+</td></tr>
+<!-- What's included -->
+<tr><td style="padding:20px 24px 0;color:#94a3b8;font-size:13px;text-transform:uppercase;letter-spacing:1px">Das ist enthalten</td></tr>
+<tr><td style="padding:8px 24px 0;color:#e2e8f0;font-size:14px;line-height:2">
+&bull; Dashboard mit Demo-F&auml;llen<br>
+&bull; Pers&ouml;nliche KI-Assistentin (Lisa)<br>
+&bull; SMS-Best&auml;tigung nach jedem Anruf<br>
+&bull; Review-System
+</td></tr>
+<!-- Footer -->
+<tr><td style="padding:28px 24px 20px;border-top:1px solid #1e293b;margin-top:24px">
+  <div style="color:#64748b;font-size:13px;line-height:1.6;text-align:center">Fragen? Gunnar Wende &mdash; 044 552 09 19 &mdash; flowsight.ch</div>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+    const welcomeText = [
+      "Guten Tag",
+      "",
+      "Ihr FlowSight Trial ist aktiv. Ab sofort können Sie unser System testen.",
+      "",
+      `Dashboard öffnen: ${magicLink}`,
+      "",
+      ...(phone
+        ? [`Ihre Testnummer: ${phone}`, "Rufen Sie jetzt an und sprechen Sie mit Ihrer persönlichen KI-Assistentin Lisa.", ""]
+        : []),
+      `Trial-Zeitraum: ${trialStartFmt} bis ${trialEndFmt} (14 Tage)`,
+      "",
+      "Das ist enthalten:",
+      "- Dashboard mit Demo-Fällen",
+      "- Persönliche KI-Assistentin (Lisa)",
+      "- SMS-Bestätigung nach jedem Anruf",
+      "- Review-System",
+      "",
+      "---",
+      "Fragen? Gunnar Wende — 044 552 09 19 — flowsight.ch",
+    ].join("\n");
+
+    const welcomeResult = await sendEmail({
+      to: prospectEmail,
+      subject: "Willkommen — Ihr 14-Tage Trial bei FlowSight",
+      html: welcomeHtml,
+      text: welcomeText,
+    });
+
+    if (welcomeResult.success) {
+      console.log(`  Welcome-Mail sent: ${welcomeResult.messageId}`);
+    } else {
+      console.error(`  Welcome-Mail failed (non-fatal): ${welcomeResult.error}`);
+    }
+
     // ── Summary ──────────────────────────────────────────────────────────
     console.log(`\n${"=".repeat(60)}`);
     console.log("  TRIAL PROVISIONED");
@@ -238,17 +339,18 @@ async function main() {
     console.log(`  Phone:        ${phone || "(none)"}`);
     console.log(`  Prospect:     ${prospectEmail}`);
     console.log(`  User ID:      ${userId}`);
-    console.log(`  Trial:        ${trialStart.toISOString().slice(0, 10)} → ${trialEnd.toISOString().slice(0, 10)} (14 days)`);
+    console.log(`  Trial:        ${trialStartFmt} → ${trialEndFmt} (14 days)`);
     console.log(`  Follow-up:    ${followUpAt.toISOString().slice(0, 10)} (day 10)`);
     console.log(`  Demo Cases:   ${seedCount}`);
+    console.log(`  Welcome-Mail: ${welcomeResult.success ? "sent" : "failed"}`);
     console.log(`\n  Magic Link:`);
     console.log(`  ${magicLink}`);
     console.log(`\n${"=".repeat(60)}`);
     console.log("\n  Next steps:");
-    console.log("  1. Send magic link to prospect (Welcome-Mail)");
+    console.log("  1. Welcome-Mail sent automatically (contains magic link)");
     console.log("  2. First-Call-Moment within 48h (call prospect number)");
     console.log("  3. Follow-up on " + followUpAt.toISOString().slice(0, 10));
-    console.log("  4. Decision Day: " + trialEnd.toISOString().slice(0, 10));
+    console.log("  4. Decision Day: " + trialEndFmt);
     console.log(`\n  Offboard (if needed):`);
     console.log(`  node --env-file=src/web/.env.local scripts/_ops/offboard_tenant.mjs --slug=${slug}`);
     console.log("=".repeat(60));


### PR DESCRIPTION
## Summary
- **Welcome-Mail** (auto-sent by `provision_trial.mjs`): branded HTML with magic link, trial number, dashboard access, trial dates, what's included
- **Offboarding-Mail** (auto-sent by `offboard_tenant.mjs`): thank you, what they experienced, door stays open, founder contact
- **Morning Report TRIALS section**: active trials, follow-ups due, expiring within 48h, zombie trials + updated severity (RED/YELLOW)
- **Outreach Templates**: fix last B-Quick remnants, add Trial Machine context, add Template 4 (Trial-Einladung), update Touch-Kadenz
- **Shared email helper** (`scripts/_ops/_lib/send_email.mjs`): reusable Resend API caller for CLI scripts

Closes GAP-01, GAP-02, GAP-05, GAP-06, GAP-07, GAP-08 from the trial experience gap analysis.

## Test plan
- [ ] `node --check scripts/_ops/_lib/send_email.mjs` — syntax OK
- [ ] `node --check scripts/_ops/provision_trial.mjs` — syntax OK
- [ ] `node --check scripts/_ops/offboard_tenant.mjs` — syntax OK
- [ ] `node --check scripts/_ops/morning_report.mjs` — syntax OK
- [ ] `npx next build` (src/web) — no regressions
- [ ] Run morning report: `node --env-file=src/web/.env.local scripts/_ops/morning_report.mjs` — TRIALS section visible
- [ ] Dry-run provision: `provision_trial.mjs --dry-run` — Welcome-Mail step shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)