### PR TITLE
feat: trial lifecycle runner + prospect welcome page

### DIFF
--- a/.github/workflows/lifecycle-tick.yml
+++ b/.github/workflows/lifecycle-tick.yml
@@ -1,0 +1,38 @@
+name: Lifecycle Tick
+
+on:
+  schedule:
+    # Daily at 07:00 UTC (08:00 CET / 09:00 CEST)
+    - cron: "0 7 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  tick:
+    name: lifecycle-tick
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger lifecycle tick
+        env:
+          APP_URL: ${{ secrets.APP_URL }}
+          LIFECYCLE_TICK_SECRET: ${{ secrets.LIFECYCLE_TICK_SECRET }}
+        run: |
+          RESPONSE=$(curl -sS -w "\n%{http_code}" \
+            -X POST "${APP_URL}/api/lifecycle/tick" \
+            -H "Authorization: Bearer ${LIFECYCLE_TICK_SECRET}" \
+            -H "Content-Type: application/json")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          echo "HTTP Status: ${HTTP_CODE}"
+          echo "Response: ${BODY}"
+
+          if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "::error::Lifecycle tick failed with HTTP ${HTTP_CODE}"
+            exit 1
+          fi
+
+          # Parse results for summary
+          PROCESSED=$(echo "$BODY" | jq -r '.processed // 0')
+          ACTIONS=$(echo "$BODY" | jq -r '.actions // 0')
+          echo "Processed ${PROCESSED} trials, ${ACTIONS} actions taken"

--- a/docs/OPS_BOARD.md
+++ b/docs/OPS_BOARD.md
@@ -1,6 +1,6 @@
 # OPS Board — FlowSight Roadmap (SSOT)
 
-**Updated:** 2026-03-11 (PRs #133-#135: Repo Cleanup, Trial Emails, Scout v3)
+**Updated:** 2026-03-11 (PR #136: Trial Lifecycle Runner + Prospect Welcome Page)
 **Rule:** CC updates with every deliverable. Founder reviews weekly.
 **Einziger Task-Tracker.** Alle offenen Tasks leben hier.
 
@@ -14,7 +14,7 @@
 - **Shipped seit 04.03.:** 50+ Commits, PRs #53–#128
 - **DB Security:** RLS applied (tenant isolation), Founder = admin, Demo-Cases seeded
 - **Ops Tooling:** `retell_sync.mjs` + `onboard_tenant.mjs` + `provision_trial.mjs` + `offboard_tenant.mjs` + `scout.mjs` (ICP Scoring)
-- **CI/CD:** GitHub Actions (lint + build + Telegram notify). Branch Protection: PR required.
+- **CI/CD:** GitHub Actions (lint + build + Telegram notify + lifecycle-tick cron). Branch Protection: PR required.
 - **Vercel Region:** Frankfurt (fra1)
 - **Phase:** Trial Machine Build-Out + GTM Pipeline v2.
 - **Operating Model:** `docs/gtm/operating_model.md` — 6 Phases, Trial Lifecycle, Quality Gates
@@ -189,6 +189,9 @@
 | 2026-03-11 | Repo Cleanup Round 2 — archive plan_v2, fix 10 stale references, Orlandini status.md, Runbooks README | PR #133 |
 | 2026-03-11 | Trial Lifecycle Emails — Welcome-Mail (auto), Offboarding-Mail (auto), Morning Report TRIALS section | PR #134 |
 | 2026-03-11 | Scout v3 — Module 2 Voice Fit Scoring (Emergency + Hours Gap + Breadth), aligned tier thresholds | PR #135 |
+| 2026-03-11 | Trial Lifecycle Runner — Idempotent Tick-Route, per-Milestone Timestamps, Day 13 Email, GH Actions Cron | PR #136 |
+| 2026-03-11 | Prospect Welcome Page — /ops/welcome, Primary CTA = Testnummer, Admin bypass, Trial info | PR #136 |
+| 2026-03-11 | Morning Report — tick_stale detection for missed lifecycle events | PR #136 |
 
 **Ältere Completed (vor 04.03.):** Siehe `docs/archive/wave_log.md`
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # FlowSight — STATUS (Company SSOT)
 
-**Datum:** 2026-03-11 (PR #131: Trial Lifecycle — Operating Model + Provisioning + Offboarding)
+**Datum:** 2026-03-11 (PR #136: Trial Lifecycle Runner + Prospect Welcome Page)
 **Owner:** Founder + CC (Head Ops)
 
 ## Was ist FlowSight?
@@ -68,8 +68,9 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 - **Trial Machine (11.03.):** PR #131. Operating Model (6 Phasen), Trial Lifecycle DB-Felder, provision_trial.mjs, offboard_tenant.mjs. B-Quick eliminiert — immer B-Full.
 - **Trial Lifecycle Emails (11.03.):** PR #134. Welcome-Mail (auto via provision_trial.mjs), Offboarding-Mail (auto via offboard_tenant.mjs), Morning Report mit Trial-Awareness (active/follow-up/expiring/zombie).
 - **Scout v3 (11.03.):** PR #135. Module 2 (Voice Fit) Scoring: Emergency + Hours Gap + Service Breadth. Tier-Thresholds mit Einsatzlogik aligned (HOT >= 8, WARM >= 6).
+- **Trial Lifecycle Runner (11.03.):** PR #136. Idempotent Tick-Route (`/api/lifecycle/tick`), per-Milestone Timestamps (day7/10/13/14), Day 13 Trial-Expiry E-Mail, GitHub Actions Cron (daily 07:00 UTC), Morning Report tick_stale detection. Prospect Welcome Page (`/ops/welcome`) mit Primary CTA = Testnummer anrufen.
 - **BLOCKER:** Keine. Go-Live möglich.
-- **Nächster Schritt:** Trial Lifecycle Cron/Scheduler (automatische Day 7/10/13/14 Events), Prospect Welcome Page (/trial/welcome), E2E-Test mit Weinberger. Founder: DEMO_SIP_CALLER_ID prüfen → SMS E2E.
+- **Nächster Schritt:** E2E-Test Trial Lifecycle mit Weinberger (provision → tick → emails). Env: LIFECYCLE_TICK_SECRET + APP_URL als GitHub Secrets setzen. Founder: DEMO_SIP_CALLER_ID prüfen → SMS E2E.
 
 ## Fixe Entscheidungen (No Drift)
 

--- a/docs/architecture/env_vars.md
+++ b/docs/architecture/env_vars.md
@@ -55,8 +55,11 @@ Diese Datei ist eine Liste aller benötigten Env Vars + Herkunft. Keine Werte ei
 ## Scout (Prospect Discovery)
 - GOOGLE_SCOUT_KEY -> Google Cloud Console (Places API New). Used by scripts/_ops/scout.mjs for prospect discovery. $200/month free credit.
 
+## Trial Lifecycle
+- LIFECYCLE_TICK_SECRET -> selbst generiert (Bitwarden). Bearer token für POST /api/lifecycle/tick. Auch als GitHub Actions Secret setzen.
+
 ## App / Routing
-- APP_URL -> Canonical app URL (server-side, z.B. https://flowsight-mvp.vercel.app)
+- APP_URL -> Canonical app URL (server-side, z.B. https://flowsight-mvp.vercel.app). Auch als GitHub Actions Secret (für lifecycle-tick cron).
 - NEXT_PUBLIC_APP_URL -> Same, but client-accessible (NEXT_PUBLIC_ prefix)
 - FALLBACK_TENANT_ID -> UUID eines Default-Tenants (nur server-side, temporär bis Routing steht)
 

--- a/scripts/_ops/morning_report.mjs
+++ b/scripts/_ops/morning_report.mjs
@@ -169,6 +169,19 @@ if (eT4) console.error("Query zombies:", eT4.message);
 
 const zombieCount = zombieTrials?.length ?? 0;
 
+// T5. Lifecycle tick errors: milestone columns that should be set but aren't
+// Check for trials past Day 14 still in trial_active (tick may have failed)
+const { data: staleTrials, error: eT5 } = await supabase
+  .from("tenants")
+  .select("slug, trial_start, day14_marked_at")
+  .eq("trial_status", "trial_active")
+  .is("day14_marked_at", null)
+  .lt("trial_start", new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000).toISOString());
+if (eT5) console.error("Query stale lifecycle:", eT5.message);
+
+const staleCount = staleTrials?.length ?? 0;
+const staleNames = staleTrials?.map((t) => t.slug).join(", ") ?? "";
+
 // 8. Health check
 let healthOk = false;
 try {
@@ -183,7 +196,7 @@ try {
 // Severity
 // ---------------------------------------------------------------------------
 
-const isRed = (stuck48h ?? 0) > 0 || !healthOk || expiring24h.length > 0;
+const isRed = (stuck48h ?? 0) > 0 || !healthOk || expiring24h.length > 0 || staleCount > 0;
 const isYellow = (backlogNew ?? 0) > 5 || notfallCount > 0 || followUpDueCount > 0;
 const severity = isRed ? "🔴" : isYellow ? "🟡" : "🟢";
 
@@ -213,6 +226,7 @@ const report = [
   `follow_up_due:  ${followUpDueCount}${followUpNames ? ` (${followUpNames})` : ""}`,
   `expiring_48h:   ${expiring48hCount}${expiringNames ? ` (${expiringNames})` : ""}`,
   `zombie_trials:  ${zombieCount}`,
+  `tick_stale:     ${staleCount}${staleNames ? ` (${staleNames})` : ""}`,
   `health:         ${healthOk ? "OK" : "FAIL"}`,
   `━━━━━━━━━━━━━━━━━━━`,
 ].join("\n");

--- a/scripts/_ops/provision_trial.mjs
+++ b/scripts/_ops/provision_trial.mjs
@@ -220,7 +220,7 @@ async function main() {
     const { data: linkData, error: linkErr } = await supabase.auth.admin.generateLink({
       type: "magiclink",
       email: prospectEmail,
-      options: { redirectTo: `${appUrl}/ops/cases` },
+      options: { redirectTo: `${appUrl}/ops/welcome` },
     });
 
     if (linkErr) {
@@ -229,7 +229,7 @@ async function main() {
     }
 
     const props = linkData.properties;
-    const magicLink = `${url}/auth/v1/verify?token=${props.hashed_token}&type=magiclink&redirect_to=${encodeURIComponent(`${appUrl}/ops/cases`)}`;
+    const magicLink = `${url}/auth/v1/verify?token=${props.hashed_token}&type=magiclink&redirect_to=${encodeURIComponent(`${appUrl}/ops/welcome`)}`;
 
     // ── Step 5: Welcome-Mail ─────────────────────────────────────────────
     console.log("\n── Step 5: Welcome-Mail ────────────────────────────");

--- a/src/web/app/api/lifecycle/tick/route.ts
+++ b/src/web/app/api/lifecycle/tick/route.ts
@@ -1,0 +1,264 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceClient } from "@/src/lib/supabase/server";
+
+// ---------------------------------------------------------------------------
+// POST /api/lifecycle/tick
+//
+// Deterministic, idempotent lifecycle processor for active trials.
+// Triggered by GitHub Actions Cron (daily) or Morning Report (fallback).
+// Auth: Bearer token must match LIFECYCLE_TICK_SECRET env var.
+//
+// Milestones:
+//   Day 7  — Engagement check → log (no email yet, just marks checked)
+//   Day 10 — Founder alert (follow-up due) → updates follow_up_at awareness
+//   Day 13 — Trial expiry reminder to prospect → sends email
+//   Day 14 — Status → decision_pending (no auto-offboard)
+// ---------------------------------------------------------------------------
+
+const MILESTONES = [
+  { day: 7, column: "day7_checked_at", action: "check" },
+  { day: 10, column: "day10_alerted_at", action: "alert_founder" },
+  { day: 13, column: "day13_reminder_sent_at", action: "remind_prospect" },
+  { day: 14, column: "day14_marked_at", action: "mark_decision_pending" },
+] as const;
+
+type MilestoneColumn = (typeof MILESTONES)[number]["column"];
+
+interface TickResult {
+  slug: string;
+  milestone: string;
+  action: string;
+  ok: boolean;
+  error?: string;
+}
+
+export async function POST(req: NextRequest) {
+  // ── Auth ──────────────────────────────────────────────────────────────
+  const secret = process.env.LIFECYCLE_TICK_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "LIFECYCLE_TICK_SECRET not configured" },
+      { status: 500 }
+    );
+  }
+
+  const auth = req.headers.get("authorization");
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  // ── Load active trials ────────────────────────────────────────────────
+  const supabase = getServiceClient();
+  const now = new Date();
+
+  const { data: trials, error: fetchErr } = await supabase
+    .from("tenants")
+    .select(
+      "id, slug, name, trial_start, trial_end, trial_status, prospect_email, prospect_phone, day7_checked_at, day10_alerted_at, day13_reminder_sent_at, day14_marked_at"
+    )
+    .in("trial_status", ["trial_active", "live_dock"]);
+
+  if (fetchErr) {
+    return NextResponse.json(
+      { error: "db_fetch_failed", detail: fetchErr.message },
+      { status: 500 }
+    );
+  }
+
+  if (!trials || trials.length === 0) {
+    return NextResponse.json({ processed: 0, results: [] });
+  }
+
+  // ── Process each trial ────────────────────────────────────────────────
+  const results: TickResult[] = [];
+
+  for (const tenant of trials) {
+    if (!tenant.trial_start) continue;
+
+    const trialStart = new Date(tenant.trial_start);
+    const daysSinceStart = Math.floor(
+      (now.getTime() - trialStart.getTime()) / (1000 * 60 * 60 * 24)
+    );
+
+    for (const ms of MILESTONES) {
+      // Not yet reached this milestone day
+      if (daysSinceStart < ms.day) continue;
+
+      // Already processed (idempotent guard)
+      const alreadyDone = tenant[ms.column as MilestoneColumn];
+      if (alreadyDone) continue;
+
+      // Execute milestone
+      const result = await executeMilestone(
+        supabase,
+        tenant,
+        ms,
+        now
+      );
+      results.push(result);
+    }
+  }
+
+  return NextResponse.json({
+    processed: trials.length,
+    actions: results.length,
+    results,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Milestone execution
+// ---------------------------------------------------------------------------
+
+async function executeMilestone(
+  supabase: ReturnType<typeof getServiceClient>,
+  tenant: {
+    id: string;
+    slug: string;
+    name: string;
+    prospect_email?: string | null;
+    trial_end?: string | null;
+  },
+  milestone: (typeof MILESTONES)[number],
+  now: Date
+): Promise<TickResult> {
+  const base: Omit<TickResult, "ok" | "error"> = {
+    slug: tenant.slug,
+    milestone: `day${milestone.day}`,
+    action: milestone.action,
+  };
+
+  try {
+    switch (milestone.action) {
+      case "check":
+        // Day 7: Just mark as checked. Future: engagement metrics.
+        break;
+
+      case "alert_founder":
+        // Day 10: Log awareness. Morning Report already shows follow_up_due.
+        // No additional email needed — Morning Report is the channel.
+        break;
+
+      case "remind_prospect": {
+        // Day 13: Send trial-expiry reminder to prospect
+        if (tenant.prospect_email) {
+          const trialEnd = tenant.trial_end
+            ? new Date(tenant.trial_end).toISOString().slice(0, 10)
+            : "bald";
+
+          const emailOk = await sendDay13Email(
+            tenant.prospect_email,
+            tenant.name,
+            trialEnd
+          );
+          if (!emailOk) {
+            return { ...base, ok: false, error: "email_send_failed" };
+          }
+        }
+        break;
+      }
+
+      case "mark_decision_pending": {
+        // Day 14: Set status to decision_pending (manual offboard later)
+        const { error: statusErr } = await supabase
+          .from("tenants")
+          .update({ trial_status: "decision_pending" })
+          .eq("id", tenant.id);
+
+        if (statusErr) {
+          return { ...base, ok: false, error: statusErr.message };
+        }
+        break;
+      }
+    }
+
+    // Mark milestone as done
+    const { error: updateErr } = await supabase
+      .from("tenants")
+      .update({ [milestone.column]: now.toISOString() })
+      .eq("id", tenant.id);
+
+    if (updateErr) {
+      return { ...base, ok: false, error: `mark_failed: ${updateErr.message}` };
+    }
+
+    return { ...base, ok: true };
+  } catch (err) {
+    return {
+      ...base,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Day 13 email — Trial expiry reminder
+// ---------------------------------------------------------------------------
+
+async function sendDay13Email(
+  to: string,
+  companyName: string,
+  trialEndDate: string
+): Promise<boolean> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return false;
+
+  const from = process.env.MAIL_FROM || "noreply@send.flowsight.ch";
+
+  const html = `<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:24px 0">
+<tr><td align="center">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#0b1120;border-radius:8px;overflow:hidden">
+<tr><td style="height:4px;background:#d4a853;font-size:0;line-height:0">&nbsp;</td></tr>
+<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">FlowSight</td></tr>
+<tr><td style="padding:0 24px;color:#e2e8f0;font-size:22px;font-weight:700">Ihr Trial endet bald</td></tr>
+<tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
+Guten Tag,<br><br>
+Ihr FlowSight Trial f&uuml;r <strong style="color:#e2e8f0">${companyName}</strong> endet am <strong style="color:#e2e8f0">${trialEndDate}</strong>.
+</td></tr>
+<tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
+Falls Sie FlowSight weiterhin nutzen m&ouml;chten, melden Sie sich bei uns &mdash; wir k&uuml;mmern uns um alles Weitere.
+</td></tr>
+<tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
+Falls nicht: kein Problem. Ihre Daten werden nach Ablauf des Trials sicher gel&ouml;scht.
+</td></tr>
+<tr><td style="padding:28px 24px 20px;border-top:1px solid #1e293b;margin-top:24px">
+  <div style="color:#64748b;font-size:13px;line-height:1.6;text-align:center">Gunnar Wende &mdash; 044 552 09 19 &mdash; flowsight.ch</div>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+  const text = [
+    "Guten Tag,",
+    "",
+    `Ihr FlowSight Trial für ${companyName} endet am ${trialEndDate}.`,
+    "",
+    "Falls Sie FlowSight weiterhin nutzen möchten, melden Sie sich bei uns — wir kümmern uns um alles Weitere.",
+    "",
+    "Falls nicht: kein Problem. Ihre Daten werden nach Ablauf des Trials sicher gelöscht.",
+    "",
+    "---",
+    "Gunnar Wende — 044 552 09 19 — flowsight.ch",
+  ].join("\n");
+
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ from, to, subject: "Ihr FlowSight Trial endet bald", html, text }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/web/app/ops/(dashboard)/welcome/page.tsx
+++ b/src/web/app/ops/(dashboard)/welcome/page.tsx
@@ -1,0 +1,174 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
+import { getServiceClient } from "@/src/lib/supabase/server";
+
+// ---------------------------------------------------------------------------
+// /ops/welcome — Prospect Welcome Page
+//
+// First premium moment for trial prospects. Shows:
+// - Greeting with company name
+// - Primary CTA: "Rufen Sie jetzt an" (product-led)
+// - Secondary CTA: "Dashboard öffnen"
+// - Trial info (dates, what's included)
+//
+// Admin users bypass → redirect to /ops/cases
+// ---------------------------------------------------------------------------
+
+interface TenantInfo {
+  name: string;
+  trial_start: string | null;
+  trial_end: string | null;
+  trial_status: string | null;
+}
+
+interface TenantNumberInfo {
+  phone_number: string;
+}
+
+async function getTenantInfo(tenantId: string): Promise<{
+  tenant: TenantInfo | null;
+  phoneNumber: string | null;
+}> {
+  const supabase = getServiceClient();
+
+  const { data: tenant } = await supabase
+    .from("tenants")
+    .select("name, trial_start, trial_end, trial_status")
+    .eq("id", tenantId)
+    .single();
+
+  const { data: number } = await supabase
+    .from("tenant_numbers")
+    .select("phone_number")
+    .eq("tenant_id", tenantId)
+    .eq("active", true)
+    .limit(1)
+    .maybeSingle();
+
+  return {
+    tenant: tenant as TenantInfo | null,
+    phoneNumber: (number as TenantNumberInfo | null)?.phone_number ?? null,
+  };
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleDateString("de-CH", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+function formatPhone(phone: string): string {
+  // +41441234567 → 044 123 45 67
+  if (phone.startsWith("+41") && phone.length === 12) {
+    const local = "0" + phone.slice(3);
+    return `${local.slice(0, 3)} ${local.slice(3, 6)} ${local.slice(6, 8)} ${local.slice(8)}`;
+  }
+  return phone;
+}
+
+export default async function WelcomePage() {
+  const scope = await resolveTenantScope();
+  if (!scope) redirect("/ops/login");
+
+  // Admin bypasses welcome → straight to cases
+  if (scope.isAdmin) redirect("/ops/cases");
+
+  // Must have a tenant assigned
+  if (!scope.tenantId) redirect("/ops/cases");
+
+  const { tenant, phoneNumber } = await getTenantInfo(scope.tenantId);
+  if (!tenant) redirect("/ops/cases");
+
+  const trialEndFmt = formatDate(tenant.trial_end);
+  const trialStartFmt = formatDate(tenant.trial_start);
+
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center px-4">
+      <div className="max-w-lg w-full">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center gap-2 bg-amber-500/10 text-amber-400 text-sm font-medium px-4 py-1.5 rounded-full mb-6">
+            Trial aktiv
+          </div>
+          <h1 className="text-2xl sm:text-3xl font-bold text-slate-100 mb-3">
+            Willkommen, {tenant.name}
+          </h1>
+          <p className="text-slate-400 text-base">
+            Ihr FlowSight Trial ist bereit. Testen Sie jetzt Ihre persönliche KI-Assistentin.
+          </p>
+        </div>
+
+        {/* Primary CTA — Call test number */}
+        {phoneNumber && (
+          <div className="bg-slate-800/50 border border-slate-700 rounded-xl p-6 mb-4">
+            <div className="text-xs uppercase tracking-wider text-slate-500 mb-2">
+              Ihre Testnummer
+            </div>
+            <div className="text-2xl font-bold text-slate-100 tracking-wide mb-3">
+              {formatPhone(phoneNumber)}
+            </div>
+            <a
+              href={`tel:${phoneNumber}`}
+              className="inline-flex items-center justify-center w-full bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-base py-3 px-6 rounded-lg transition-colors"
+            >
+              Jetzt anrufen
+            </a>
+            <p className="text-slate-500 text-sm mt-3 text-center">
+              Lisa nimmt ab, erkennt Ihr Anliegen und leitet alles strukturiert weiter.
+            </p>
+          </div>
+        )}
+
+        {/* Secondary CTA — Dashboard */}
+        <Link
+          href="/ops/cases"
+          className="block w-full text-center bg-slate-800/50 hover:bg-slate-700/50 border border-slate-700 text-slate-300 font-medium text-base py-3 px-6 rounded-lg transition-colors mb-6"
+        >
+          Dashboard öffnen
+        </Link>
+
+        {/* Trial Info */}
+        <div className="bg-slate-800/30 border border-slate-700/50 rounded-xl p-5">
+          <div className="text-xs uppercase tracking-wider text-slate-500 mb-3">
+            Trial-Zeitraum
+          </div>
+          <div className="text-slate-300 text-sm font-medium mb-4">
+            {trialStartFmt} — {trialEndFmt} (14 Tage)
+          </div>
+
+          <div className="text-xs uppercase tracking-wider text-slate-500 mb-3">
+            Das ist enthalten
+          </div>
+          <ul className="space-y-2 text-slate-400 text-sm">
+            <li className="flex items-start gap-2">
+              <span className="text-amber-500 mt-0.5">•</span>
+              <span>Persönliche KI-Assistentin (Lisa)</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-amber-500 mt-0.5">•</span>
+              <span>SMS-Bestätigung nach jedem Anruf</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-amber-500 mt-0.5">•</span>
+              <span>Dashboard mit Fallübersicht</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-amber-500 mt-0.5">•</span>
+              <span>Bewertungssystem für Kunden</span>
+            </li>
+          </ul>
+        </div>
+
+        {/* Footer */}
+        <p className="text-center text-slate-600 text-xs mt-6">
+          Fragen? Gunnar Wende — 044 552 09 19 — flowsight.ch
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260311100000_lifecycle_milestones.sql
+++ b/supabase/migrations/20260311100000_lifecycle_milestones.sql
@@ -1,0 +1,14 @@
+-- Lifecycle milestone timestamps for idempotent tick processing.
+-- Each column tracks when a specific lifecycle event was last executed,
+-- preventing duplicate emails/actions on re-runs.
+
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS day7_checked_at    timestamptz,
+  ADD COLUMN IF NOT EXISTS day10_alerted_at   timestamptz,
+  ADD COLUMN IF NOT EXISTS day13_reminder_sent_at timestamptz,
+  ADD COLUMN IF NOT EXISTS day14_marked_at    timestamptz;
+
+COMMENT ON COLUMN tenants.day7_checked_at IS 'Timestamp when Day 7 engagement check was executed';
+COMMENT ON COLUMN tenants.day10_alerted_at IS 'Timestamp when Day 10 founder alert was sent';
+COMMENT ON COLUMN tenants.day13_reminder_sent_at IS 'Timestamp when Day 13 trial-expiry reminder was sent to prospect';
+COMMENT ON COLUMN tenants.day14_marked_at IS 'Timestamp when Day 14 status was set to decision_pending';


### PR DESCRIPTION
## Summary

- **Trial Lifecycle Runner:** Idempotent tick route (`POST /api/lifecycle/tick`) with per-milestone timestamps (`day7_checked_at`, `day10_alerted_at`, `day13_reminder_sent_at`, `day14_marked_at`). Each milestone executes exactly once per tenant, regardless of how often the tick runs.
- **Day 13 Email:** Branded trial-expiry reminder sent to prospect ("Ihr Trial endet bald")
- **Day 14:** Status → `decision_pending` (destructive offboarding stays manual via `offboard_tenant.mjs`)
- **GitHub Actions Cron:** Daily at 07:00 UTC triggers the tick route. Also supports `workflow_dispatch` for manual trigger.
- **Prospect Welcome Page:** `/ops/welcome` — first premium moment for trial prospects. Primary CTA = "Jetzt anrufen" with tel: link to test number. Secondary CTA = "Dashboard öffnen". Admin users bypass → `/ops/cases`.
- **Magic Link Redirect:** Updated from `/ops/cases` to `/ops/welcome` in `provision_trial.mjs`
- **Morning Report:** Added `tick_stale` detection (trials past Day 14 still in `trial_active`)
- **DB Migration:** 4 milestone timestamp columns on `tenants` table (already applied to prod)
- **Env Docs:** `LIFECYCLE_TICK_SECRET` documented in `env_vars.md`

## Founder Action Required

After merge, set these **GitHub Actions Secrets** (Settings → Secrets → Actions):
1. `APP_URL` = `https://flowsight-mvp.vercel.app`
2. `LIFECYCLE_TICK_SECRET` = generate a random 32+ char string, also add to Vercel env vars

## Test plan

- [ ] Verify build passes (CI)
- [ ] Set `LIFECYCLE_TICK_SECRET` on Vercel + GitHub Actions
- [ ] Manual trigger: `gh workflow run lifecycle-tick.yml`
- [ ] Verify `/ops/welcome` renders for prospect users (magic link login)
- [ ] Verify admin users redirect from `/ops/welcome` to `/ops/cases`

🤖 Generated with [Claude Code](https://claude.com/claude-code)