### PR TITLE
feat: monitoring hardening — reise-readiness

### DIFF
--- a/.github/workflows/lifecycle-tick.yml
+++ b/.github/workflows/lifecycle-tick.yml
@@ -10,8 +10,12 @@ jobs:
   tick:
     name: lifecycle-tick
     runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.run.outputs.status }}
+      summary: ${{ steps.run.outputs.summary }}
     steps:
       - name: Trigger lifecycle tick
+        id: run
         env:
           APP_URL: ${{ secrets.APP_URL }}
           LIFECYCLE_TICK_SECRET: ${{ secrets.LIFECYCLE_TICK_SECRET }}
@@ -28,6 +32,8 @@ jobs:
           echo "Response: ${BODY}"
 
           if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "status=FAILED" >> "$GITHUB_OUTPUT"
+            echo "summary=HTTP ${HTTP_CODE}: ${BODY}" >> "$GITHUB_OUTPUT"
             echo "::error::Lifecycle tick failed with HTTP ${HTTP_CODE}"
             exit 1
           fi
@@ -36,3 +42,44 @@ jobs:
           PROCESSED=$(echo "$BODY" | jq -r '.processed // 0')
           ACTIONS=$(echo "$BODY" | jq -r '.actions // 0')
           echo "Processed ${PROCESSED} trials, ${ACTIONS} actions taken"
+          echo "status=OK" >> "$GITHUB_OUTPUT"
+          echo "summary=${PROCESSED} trials, ${ACTIONS} actions" >> "$GITHUB_OUTPUT"
+
+  notify:
+    name: telegram-notify
+    runs-on: ubuntu-latest
+    needs: [tick]
+    if: always()
+    steps:
+      - name: Send notification
+        env:
+          BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TICK_RESULT: ${{ needs.tick.result }}
+          TICK_SUMMARY: ${{ needs.tick.outputs.summary }}
+        run: |
+          if [ "$TICK_RESULT" = "success" ]; then
+            ICON="✅"
+            STATUS="Lifecycle tick OK"
+          else
+            ICON="🔴"
+            STATUS="Lifecycle tick FAILED"
+          fi
+
+          TEXT="${ICON} ${STATUS}
+          ${TICK_SUMMARY}
+
+          Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          HTTP_CODE=$(curl -sS -o /tmp/tg_response.txt -w "%{http_code}" \
+            -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+            -d chat_id="${CHAT_ID}" \
+            -d text="${TEXT}" \
+            -d disable_web_page_preview=true)
+
+          echo "Telegram HTTP status: ${HTTP_CODE}"
+          if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "Telegram response:"
+            cat /tmp/tg_response.txt
+            exit 1
+          fi

--- a/.github/workflows/morning-report.yml
+++ b/.github/workflows/morning-report.yml
@@ -1,0 +1,112 @@
+name: Morning Report
+
+on:
+  schedule:
+    # Daily at 07:30 UTC (08:30 CET / 09:30 CEST) — 30min after lifecycle-tick
+    - cron: "30 7 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  report:
+    name: morning-report
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: src/web/package-lock.json
+
+      - name: Install dependencies
+        run: cd src/web && npm ci
+
+      - name: Run morning report
+        id: report
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          APP_URL: ${{ secrets.APP_URL }}
+          NEXT_PUBLIC_APP_URL: ${{ secrets.APP_URL }}
+        run: |
+          OUTPUT=$(node scripts/_ops/morning_report.mjs 2>&1) || true
+          echo "$OUTPUT"
+
+          # Store report for downstream steps
+          echo "report<<REPORT_EOF" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "REPORT_EOF" >> "$GITHUB_OUTPUT"
+
+          # Detect severity for email trigger
+          if echo "$OUTPUT" | grep -q '🔴'; then
+            echo "severity=RED" >> "$GITHUB_OUTPUT"
+          elif echo "$OUTPUT" | grep -q '🟡'; then
+            echo "severity=YELLOW" >> "$GITHUB_OUTPUT"
+          else
+            echo "severity=GREEN" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Send Telegram
+        if: always()
+        env:
+          BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          REPORT: ${{ steps.report.outputs.report }}
+        run: |
+          # Trim to Telegram 4096 char limit
+          BODY=$(echo "$REPORT" | head -30)
+
+          HTTP_CODE=$(curl -sS -o /tmp/tg_response.txt -w "%{http_code}" \
+            -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+            -d chat_id="${CHAT_ID}" \
+            -d text="${BODY}" \
+            -d disable_web_page_preview=true)
+
+          echo "Telegram HTTP status: ${HTTP_CODE}"
+          if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "Telegram response:"
+            cat /tmp/tg_response.txt
+          fi
+
+      - name: Send Email (RED/YELLOW only)
+        if: steps.report.outputs.severity == 'RED' || steps.report.outputs.severity == 'YELLOW'
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          FOUNDER_EMAIL: ${{ secrets.FOUNDER_EMAIL }}
+          REPORT: ${{ steps.report.outputs.report }}
+          SEVERITY: ${{ steps.report.outputs.severity }}
+        run: |
+          if [ -z "$RESEND_API_KEY" ] || [ -z "$FOUNDER_EMAIL" ]; then
+            echo "Missing RESEND_API_KEY or FOUNDER_EMAIL — skipping email"
+            exit 0
+          fi
+
+          SUBJECT="FlowSight ${SEVERITY}: Morning Report"
+          # Convert plain text to simple HTML (preserve line breaks)
+          HTML_BODY=$(echo "$REPORT" | sed 's/$/<br>/g' | sed 's/^/<p style="font-family:monospace;margin:0">/' | sed 's/$/<\/p>/')
+          WRAPPED="<div style=\"background:#0b1120;color:#e2e8f0;padding:24px;border-radius:8px;font-family:monospace;font-size:14px;line-height:1.8\"><div style=\"height:4px;background:#d4a853;border-radius:2px;margin-bottom:16px\"></div>${HTML_BODY}</div>"
+
+          # Send via Resend API
+          PAYLOAD=$(jq -n \
+            --arg from "noreply@send.flowsight.ch" \
+            --arg to "$FOUNDER_EMAIL" \
+            --arg subject "$SUBJECT" \
+            --arg html "$WRAPPED" \
+            --arg text "$REPORT" \
+            '{from: $from, to: $to, subject: $subject, html: $html, text: $text}')
+
+          HTTP_CODE=$(curl -sS -o /tmp/resend_response.txt -w "%{http_code}" \
+            -X POST "https://api.resend.com/emails" \
+            -H "Authorization: Bearer ${RESEND_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          echo "Resend HTTP status: ${HTTP_CODE}"
+          if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "Resend response:"
+            cat /tmp/resend_response.txt
+          fi

--- a/docs/OPS_BOARD.md
+++ b/docs/OPS_BOARD.md
@@ -1,6 +1,6 @@
 # OPS Board — FlowSight Roadmap (SSOT)
 
-**Updated:** 2026-03-11 (PR #136: Trial Lifecycle Runner + Prospect Welcome Page)
+**Updated:** 2026-03-11 (PR #138: Monitoring-Härtung — Reise-Readiness)
 **Rule:** CC updates with every deliverable. Founder reviews weekly.
 **Einziger Task-Tracker.** Alle offenen Tasks leben hier.
 
@@ -14,7 +14,7 @@
 - **Shipped seit 04.03.:** 50+ Commits, PRs #53–#128
 - **DB Security:** RLS applied (tenant isolation), Founder = admin, Demo-Cases seeded
 - **Ops Tooling:** `retell_sync.mjs` + `onboard_tenant.mjs` + `provision_trial.mjs` + `offboard_tenant.mjs` + `scout.mjs` (ICP Scoring)
-- **CI/CD:** GitHub Actions (lint + build + Telegram notify + lifecycle-tick cron). Branch Protection: PR required.
+- **CI/CD:** GitHub Actions (lint + build + Telegram notify + lifecycle-tick cron + morning-report cron). Branch Protection: PR required.
 - **Vercel Region:** Frankfurt (fra1)
 - **Phase:** Trial Machine Build-Out + GTM Pipeline v2.
 - **Operating Model:** `docs/gtm/operating_model.md` — 6 Phases, Trial Lifecycle, Quality Gates
@@ -192,6 +192,7 @@
 | 2026-03-11 | Trial Lifecycle Runner — Idempotent Tick-Route, per-Milestone Timestamps, Day 13 Email, GH Actions Cron | PR #136 |
 | 2026-03-11 | Prospect Welcome Page — /ops/welcome, Primary CTA = Testnummer, Admin bypass, Trial info | PR #136 |
 | 2026-03-11 | Morning Report — tick_stale detection for missed lifecycle events | PR #136 |
+| 2026-03-11 | Monitoring-Härtung — Morning Report Cron (GH Actions, Telegram + E-Mail), Tick-Failure Telegram, Health Check DB+Resend | PR #138 |
 
 **Ältere Completed (vor 04.03.):** Siehe `docs/archive/wave_log.md`
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # FlowSight — STATUS (Company SSOT)
 
-**Datum:** 2026-03-11 (PR #136: Trial Lifecycle Runner + Prospect Welcome Page)
+**Datum:** 2026-03-11 (PR #138: Monitoring-Härtung — Reise-Readiness)
 **Owner:** Founder + CC (Head Ops)
 
 ## Was ist FlowSight?
@@ -69,8 +69,9 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 - **Trial Lifecycle Emails (11.03.):** PR #134. Welcome-Mail (auto via provision_trial.mjs), Offboarding-Mail (auto via offboard_tenant.mjs), Morning Report mit Trial-Awareness (active/follow-up/expiring/zombie).
 - **Scout v3 (11.03.):** PR #135. Module 2 (Voice Fit) Scoring: Emergency + Hours Gap + Service Breadth. Tier-Thresholds mit Einsatzlogik aligned (HOT >= 8, WARM >= 6).
 - **Trial Lifecycle Runner (11.03.):** PR #136. Idempotent Tick-Route (`/api/lifecycle/tick`), per-Milestone Timestamps (day7/10/13/14), Day 13 Trial-Expiry E-Mail, GitHub Actions Cron (daily 07:00 UTC), Morning Report tick_stale detection. Prospect Welcome Page (`/ops/welcome`) mit Primary CTA = Testnummer anrufen.
+- **Monitoring-Härtung (11.03.):** PR #138. Morning Report als GH Actions Cron (daily 07:30 UTC, Telegram + E-Mail bei RED/YELLOW). Lifecycle-Tick Failure → Telegram-Alert. Health Check mit DB-Ping + Resend-Key-Validation.
 - **BLOCKER:** Keine. Go-Live möglich.
-- **Nächster Schritt:** E2E-Test Trial Lifecycle mit Weinberger (provision → tick → emails). Env: LIFECYCLE_TICK_SECRET + APP_URL als GitHub Secrets setzen. Founder: DEMO_SIP_CALLER_ID prüfen → SMS E2E.
+- **Nächster Schritt:** Founder-Actions: (1) GitHub Secrets setzen (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, RESEND_API_KEY, FOUNDER_EMAIL, LIFECYCLE_TICK_SECRET, APP_URL), (2) DEMO_SIP_CALLER_ID auf Vercel prüfen, (3) Sentry Alert Rules einrichten. Reise-Runbook erstellen.
 
 ## Fixe Entscheidungen (No Drift)
 

--- a/docs/architecture/env_vars.md
+++ b/docs/architecture/env_vars.md
@@ -58,8 +58,12 @@ Diese Datei ist eine Liste aller benötigten Env Vars + Herkunft. Keine Werte ei
 ## Trial Lifecycle
 - LIFECYCLE_TICK_SECRET -> selbst generiert (Bitwarden). Bearer token für POST /api/lifecycle/tick. Auch als GitHub Actions Secret setzen.
 
+## Morning Report (GH Actions Cron)
+- FOUNDER_EMAIL -> Founder Outlook-Adresse. Empfängt Morning Report bei RED/YELLOW. GitHub Actions Secret.
+- (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, RESEND_API_KEY, APP_URL -> bereits oben, müssen auch als GitHub Actions Secrets gesetzt sein)
+
 ## App / Routing
-- APP_URL -> Canonical app URL (server-side, z.B. https://flowsight-mvp.vercel.app). Auch als GitHub Actions Secret (für lifecycle-tick cron).
+- APP_URL -> Canonical app URL (server-side, z.B. https://flowsight-mvp.vercel.app). Auch als GitHub Actions Secret (für lifecycle-tick + morning-report cron).
 - NEXT_PUBLIC_APP_URL -> Same, but client-accessible (NEXT_PUBLIC_ prefix)
 - FALLBACK_TENANT_ID -> UUID eines Default-Tenants (nur server-side, temporär bis Routing steht)
 

--- a/src/web/app/api/health/route.ts
+++ b/src/web/app/api/health/route.ts
@@ -1,10 +1,52 @@
 import { NextResponse } from "next/server";
+import { getServiceClient } from "@/src/lib/supabase/server";
 
-export function GET() {
+// ---------------------------------------------------------------------------
+// GET /api/health — System health check
+//
+// Checks:
+//   1. Vercel process alive (implicit — if this runs, it's alive)
+//   2. Supabase DB connectivity (lightweight count query)
+//   3. Resend API key present (presence check, no API call)
+//
+// Returns:
+//   { ok: boolean, ts, commit, env, db: "ok"|"fail", email: "ok"|"missing_key" }
+//
+// Used by: Morning Report (health line), external monitoring
+// ---------------------------------------------------------------------------
+
+export async function GET() {
+  const checks: Record<string, string> = {};
+  let allOk = true;
+
+  // ── DB connectivity ─────────────────────────────────────────────────
+  try {
+    const supabase = getServiceClient();
+    const { error } = await supabase
+      .from("tenants")
+      .select("id", { count: "exact", head: true });
+
+    if (error) {
+      checks.db = `fail: ${error.message}`;
+      allOk = false;
+    } else {
+      checks.db = "ok";
+    }
+  } catch (err) {
+    checks.db = `fail: ${err instanceof Error ? err.message : "unknown"}`;
+    allOk = false;
+  }
+
+  // ── Resend API key presence ─────────────────────────────────────────
+  const hasResendKey = !!process.env.RESEND_API_KEY;
+  checks.email = hasResendKey ? "ok" : "missing_key";
+  if (!hasResendKey) allOk = false;
+
   return NextResponse.json({
-    ok: true,
+    ok: allOk,
     ts: new Date().toISOString(),
     commit: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
     env: process.env.VERCEL_ENV ?? "development",
+    ...checks,
   });
 }


### PR DESCRIPTION
## Summary

Reise-Härtung Session 1: Sichtbarkeit bei Founder-Abwesenheit (3-4 Tage offline).

- **H1 Morning Report Cron** — `.github/workflows/morning-report.yml`
  - Daily 07:30 UTC (30 Min nach Lifecycle Tick)
  - Checkout → npm ci → run morning_report.mjs → parse severity
  - Always: Telegram notification with full report
  - RED/YELLOW: Email via Resend to Founder (Outlook — täglich erreichbar auf Reise)
  - Needs GH Secrets: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `APP_URL`, `RESEND_API_KEY`, `FOUNDER_EMAIL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`

- **H2 Lifecycle Tick Failure Alert** — `.github/workflows/lifecycle-tick.yml`
  - Added `notify` job (runs on success AND failure)
  - Telegram: ✅/🔴 + summary + workflow link
  - Before: silent failure — cron exits 1, nobody knows

- **H3 Health Check** — `src/web/app/api/health/route.ts`
  - Was: static `{ ok: true }` (lied about system health)
  - Now: DB connectivity ping (Supabase count query) + Resend API key presence check
  - Returns `{ ok, db: "ok"|"fail", email: "ok"|"missing_key" }`
  - Morning Report uses this for the `health` line

## Signal Flow After This PR

```
07:00 UTC  Lifecycle Tick fires
           → Success: ✅ Telegram
           → Failure: 🔴 Telegram (immediate visibility)

07:30 UTC  Morning Report fires
           → Always: Telegram with full KPIs + trial status
           → RED/YELLOW: Email to Founder Outlook
           → Health check now validates DB + email system
```

## Founder Action Required (GitHub Actions Secrets)

| Secret | Source | Already Set? |
|--------|--------|-------------|
| `SUPABASE_URL` | Supabase Project Settings | Nein — NEU |
| `SUPABASE_SERVICE_ROLE_KEY` | Supabase API Keys | Nein — NEU |
| `RESEND_API_KEY` | Resend Dashboard | Nein — NEU |
| `FOUNDER_EMAIL` | Outlook-Adresse | Nein — NEU |
| `APP_URL` | `https://flowsight-mvp.vercel.app` | Prüfen (war für lifecycle-tick) |
| `LIFECYCLE_TICK_SECRET` | Bitwarden (self-generated) | Prüfen |
| `TELEGRAM_BOT_TOKEN` | BotFather | Ja ✅ |
| `TELEGRAM_CHAT_ID` | Telegram Ops Channel | Ja ✅ |

## Test plan

- [ ] CI passes (lint + build)
- [ ] Set all GitHub Actions Secrets
- [ ] Manual trigger: `gh workflow run morning-report.yml` → Telegram message arrives
- [ ] Verify `/api/health` returns `{ ok: true, db: "ok", email: "ok" }`
- [ ] Verify RED report triggers email to Founder Outlook

🤖 Generated with [Claude Code](https://claude.com/claude-code)