### PR TITLE
feat: reise-hardening session 2 — runbook + deep health

### DIFF
--- a/docs/OPS_BOARD.md
+++ b/docs/OPS_BOARD.md
@@ -1,6 +1,6 @@
 # OPS Board — FlowSight Roadmap (SSOT)
 
-**Updated:** 2026-03-11 (PR #138: Monitoring-Härtung — Reise-Readiness)
+**Updated:** 2026-03-11 (PR #139: Reise-Härtung Session 2)
 **Rule:** CC updates with every deliverable. Founder reviews weekly.
 **Einziger Task-Tracker.** Alle offenen Tasks leben hier.
 
@@ -193,6 +193,7 @@
 | 2026-03-11 | Prospect Welcome Page — /ops/welcome, Primary CTA = Testnummer, Admin bypass, Trial info | PR #136 |
 | 2026-03-11 | Morning Report — tick_stale detection for missed lifecycle events | PR #136 |
 | 2026-03-11 | Monitoring-Härtung — Morning Report Cron (GH Actions, Telegram + E-Mail), Tick-Failure Telegram, Health Check DB+Resend | PR #138 |
+| 2026-03-11 | Reise-Härtung — Runbook (Vor/Während/Nach), Trial-Timing-Regel, Morning Report Deep Health + Resend API Validation | PR #139 |
 
 **Ältere Completed (vor 04.03.):** Siehe `docs/archive/wave_log.md`
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # FlowSight — STATUS (Company SSOT)
 
-**Datum:** 2026-03-11 (PR #138: Monitoring-Härtung — Reise-Readiness)
+**Datum:** 2026-03-11 (PR #139: Reise-Härtung Session 2 — Runbook + Morning Report Deep Health)
 **Owner:** Founder + CC (Head Ops)
 
 ## Was ist FlowSight?
@@ -70,8 +70,9 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 - **Scout v3 (11.03.):** PR #135. Module 2 (Voice Fit) Scoring: Emergency + Hours Gap + Service Breadth. Tier-Thresholds mit Einsatzlogik aligned (HOT >= 8, WARM >= 6).
 - **Trial Lifecycle Runner (11.03.):** PR #136. Idempotent Tick-Route (`/api/lifecycle/tick`), per-Milestone Timestamps (day7/10/13/14), Day 13 Trial-Expiry E-Mail, GitHub Actions Cron (daily 07:00 UTC), Morning Report tick_stale detection. Prospect Welcome Page (`/ops/welcome`) mit Primary CTA = Testnummer anrufen.
 - **Monitoring-Härtung (11.03.):** PR #138. Morning Report als GH Actions Cron (daily 07:30 UTC, Telegram + E-Mail bei RED/YELLOW). Lifecycle-Tick Failure → Telegram-Alert. Health Check mit DB-Ping + Resend-Key-Validation.
+- **Reise-Härtung (11.03.):** PR #139. Reise-Runbook (Vor/Während/Nach Checkliste, Trial-Timing-Regel, Signal-Übersicht). Morning Report Deep Health (DB/Email/Resend-API-Status einzeln sichtbar). Resend API Key Validation im Morning Report.
 - **BLOCKER:** Keine. Go-Live möglich.
-- **Nächster Schritt:** Founder-Actions: (1) GitHub Secrets setzen (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, RESEND_API_KEY, FOUNDER_EMAIL, LIFECYCLE_TICK_SECRET, APP_URL), (2) DEMO_SIP_CALLER_ID auf Vercel prüfen, (3) Sentry Alert Rules einrichten. Reise-Runbook erstellen.
+- **Nächster Schritt:** Founder-Actions vor Reise — siehe `docs/runbooks/reise_checklist.md`.
 
 ## Fixe Entscheidungen (No Drift)
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,8 +1,8 @@
 # Runbooks Index
 
-**33 runbooks. Find the right one in 10 seconds.**
+**34 runbooks. Find the right one in 10 seconds.**
 
-Last updated: 2026-03-10
+Last updated: 2026-03-11
 
 ---
 
@@ -18,6 +18,7 @@ Last updated: 2026-03-10
 | `phone_routing_registry.md` | SSOT for all phone numbers, providers, Retell agent assignments | Need to check which number routes where |
 | `release_checklist.md` | Pre-push gates: lint, build, diff review, deploy verification | About to ship code to production |
 | `mobile_qa.md` | 30-min manual smartphone test for /ops/cases workflow | Before go-live or after major UI change |
+| `reise_checklist.md` | Founder-Abwesenheit: Vor/Während/Nach Checkliste, Trial-Timing, Signal-Übersicht | Before extended travel, 3-4 day offline planning |
 
 ## Setup / Onboarding
 

--- a/docs/runbooks/reise_checklist.md
+++ b/docs/runbooks/reise_checklist.md
@@ -1,0 +1,200 @@
+# Reise-Checklist — Founder-Abwesenheit
+
+**Erstellt:** 2026-03-11 | **Owner:** Founder + CC
+**Kontext:** Philippinen-Reise (~25 Tage, davon 3-4 Tage ohne WLAN/Strom). Mobile Daten vorhanden → E-Mail (Outlook) täglich erreichbar.
+
+---
+
+## Vor Abflug (1-2 Tage vorher)
+
+### GitHub Actions Secrets setzen/prüfen
+
+| Secret | Quelle | Prüfen |
+|--------|--------|--------|
+| `SUPABASE_URL` | Supabase Project Settings | `gh secret list` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase API Keys (service-role) | |
+| `RESEND_API_KEY` | Resend Dashboard | |
+| `FOUNDER_EMAIL` | Outlook-Adresse | |
+| `APP_URL` | `https://flowsight-mvp.vercel.app` | |
+| `LIFECYCLE_TICK_SECRET` | Bitwarden (self-generated, 32+ chars) | |
+| `TELEGRAM_BOT_TOKEN` | BotFather (bereits gesetzt ✅) | |
+| `TELEGRAM_CHAT_ID` | Telegram Ops Channel (bereits gesetzt ✅) | |
+
+### Vercel Env Vars prüfen
+
+- [ ] `LIFECYCLE_TICK_SECRET` — gleicher Wert wie GitHub Secret
+- [ ] `DEMO_SIP_CALLER_ID` — persönliche Handynummer in E.164 (z.B. +41791234567)
+- [ ] `RESEND_API_KEY` — gültig (nicht abgelaufen)
+
+### Sentry Alert Rules einrichten (einmalig)
+
+1. **CASE_CREATE_FAILED** — Alert on `error_code:DB_INSERT_ERROR` → E-Mail
+2. **EMAIL_DISPATCH_FAILED** — Alert on `error_code:RESEND_API_ERROR` → E-Mail
+3. **RESEND_EXCEPTION** — Alert on `error_code:RESEND_EXCEPTION` → E-Mail
+
+Ziel: Sentry → E-Mail → Outlook → sichtbar auf Reise.
+
+### System-Smoke-Test
+
+```bash
+# 1. Health Check
+curl https://flowsight-mvp.vercel.app/api/health
+# Erwartung: { "ok": true, "db": "ok", "email": "ok" }
+
+# 2. Morning Report manuell triggern
+gh workflow run morning-report.yml
+# Erwartung: Telegram + (bei RED/YELLOW) E-Mail
+
+# 3. Lifecycle Tick manuell triggern
+gh workflow run lifecycle-tick.yml
+# Erwartung: Telegram ✅
+
+# 4. Test-Anruf auf Weinberger-Nummer
+# → Lisa antwortet → SMS kommt → Fall im Dashboard
+```
+
+### Trial-Timing-Regel (H8)
+
+**Regel:** Keine neuen Trials starten, deren Day 10 (Follow-up Call) in ein geplantes Offline-Fenster fällt.
+
+**Berechnung:**
+- Trial Start = Tag X
+- Day 10 = Tag X + 10
+- Day 13 = Tag X + 13 (Auto-Email — kein Problem)
+- Day 14 = Tag X + 14 (Auto-Status → decision_pending — kein Problem)
+- **Kritisch:** Day 10 braucht persönlichen Anruf
+
+**Vor der Reise:**
+- Prüfe: Gibt es aktive Trials, deren Day 10 in die Offline-Fenster fällt?
+- Wenn ja: Follow-up Call VOR Abflug vorziehen
+- Keine neuen Trials starten, die Day 10 während Offline haben
+
+**Während der Reise (Hotel-Tage mit WLAN):**
+- Neue Trials nur starten, wenn Day 10 auf einen Hotel-Tag fällt
+- Im Zweifel: Trial-Start verschieben auf nach Rückkehr
+
+### Letzte Checks
+
+- [ ] `git stash` / `git status` — kein offener Branch
+- [ ] Vercel: letzte Deployment-Status = OK (Dashboard prüfen)
+- [ ] Telegram Ops Channel: letzte Nachricht = grün
+- [ ] Bitwarden: alle kritischen Zugänge dokumentiert (Supabase, Vercel, Retell, Twilio, Resend, GitHub)
+
+---
+
+## Während der Reise
+
+### Tägliche Routine (2 Minuten, Mobile)
+
+1. **Outlook prüfen** — Morning Report kommt bei RED/YELLOW als E-Mail
+   - GREEN = alles läuft → nichts tun
+   - YELLOW = Follow-up fällig oder Backlog → wenn möglich handeln, sonst ignorieren
+   - RED = System-Problem → Telegram prüfen für Details
+2. **Telegram prüfen** — Lifecycle Tick Status (✅ oder 🔴)
+
+### Was läuft automatisch (kein Eingriff nötig)
+
+| System | Frequenz | Was passiert |
+|--------|----------|-------------|
+| Voice Intake (Lisa) | 24/7 | Anruf → Case → E-Mail → SMS |
+| Wizard Intake | 24/7 | Formular → Case → E-Mail |
+| Lifecycle Tick | Täglich 07:00 UTC | Day 7/10/13/14 Milestones |
+| Morning Report | Täglich 07:30 UTC | KPIs → Telegram + E-Mail |
+| Vercel Deploy | Bei Merge | Auto-deploy |
+| Review Engine | Bei Trigger | Review-Link → E-Mail/SMS |
+
+### Was NICHT automatisch läuft (bewusst akzeptiert)
+
+| Aktion | Timing | Risiko bei Ausfall | Akzeptabel? |
+|--------|--------|-------------------|-------------|
+| Follow-up Call (Day 10) | Per Trial | Trial-Conversion sinkt | JA — nachholen nach Rückkehr |
+| Trial Decision (Day 14) | Per Trial | Zombie in decision_pending | JA — System macht nichts Destruktives |
+| Trial Offboarding | Nach Decision | Zombie bleibt aktiv | JA — kein Schaden, nur Kosten (minimal) |
+| Trial Provisioning | Per neuer Prospect | Kein neuer Trial gestartet | JA — Akquise pausiert |
+| Retell Agent Changes | Bei Bedarf | Alter Agent läuft weiter | JA — kein Change nötig |
+
+### Offline-Fenster (3-4 Tage ohne WLAN)
+
+**Was passiert:**
+- Morning Report E-Mail kommt an → du siehst sie erst nach Offline-Fenster
+- Lifecycle Tick läuft weiterhin (GitHub Actions braucht kein Founder-Input)
+- Cases werden erstellt, E-Mails gesendet, SMS verschickt — alles automatisch
+- Falls System bricht: Sentry + Morning Report loggen alles → du siehst es nach Rückkehr online
+
+**Worst Case (System bricht während Offline):**
+1. Supabase kurzzeitig down → Cases gehen verloren (kein Retry)
+2. Resend down → E-Mails gehen nicht raus (Sentry loggt)
+3. Lifecycle Tick failed → Milestones verspätet (Catch-up beim nächsten Tick)
+4. Voice/Twilio Outage → Anrufe scheitern (Peoplefone Voicemail als Fallback)
+
+**Recovery nach Offline:**
+- Morning Report Backlog durchgehen (Telegram oder E-Mail)
+- Health Check: `curl .../api/health`
+- Falls RED: Sentry Dashboard prüfen
+- Falls Tick ausgefallen: `gh workflow run lifecycle-tick.yml` manuell triggern
+- Verpasste Follow-up Calls nachholen
+
+---
+
+## Nach Rückkehr
+
+### Sofort (erste 30 Minuten)
+
+1. **Health Check:** `curl https://flowsight-mvp.vercel.app/api/health`
+2. **Morning Report:** `gh workflow run morning-report.yml` — manuell triggern
+3. **Ops Dashboard:** `/ops/cases` öffnen — Backlog prüfen
+4. **Sentry:** Dashboard öffnen — Errors der letzten Wochen prüfen
+5. **Trial Status:** Morning Report zeigt active_trials, zombies, decision_pending
+
+### Erste Woche
+
+- [ ] Alle `decision_pending` Trials reviewen → convert oder offboard
+- [ ] Verpasste Follow-up Calls nachholen
+- [ ] GitHub Issues prüfen (CoreBot → Telegram → Issues)
+- [ ] Pipeline CSV aktualisieren (`docs/sales/pipeline.csv`)
+- [ ] Resend Usage prüfen (Dashboard → sind wir nahe 100/Tag?)
+
+---
+
+## Upgrade-Empfehlungen vor Reise
+
+| Service | Aktuell | Empfehlung | Kosten | Grund |
+|---------|---------|------------|--------|-------|
+| **Supabase** | Free | **Pro** | $25/Mo | Automatische Backups. Ohne: Datenverlust bei DB-Corruption nicht recoverable. |
+| **Vercel** | Hobby | **Pro** | $20/Mo | 30s Function Timeout (statt 10s), bessere Analytics. Verhindert Timeout bei langsamen Email-Sends. |
+| Resend | Free (100/Tag) | Free reicht | $0 | 100/Tag reicht für aktuelle Last (~15-20/Tag). |
+| Twilio | Pay-as-you-go | Reicht | ~$5/Mo | Voice + SMS funktioniert. |
+| Retell | Pay-as-you-go | Reicht | ~$10/Mo | Voice Agent läuft stabil. |
+
+**Priorität:** Supabase Pro > Vercel Pro. Supabase Pro eliminiert das Backup-Risiko komplett.
+
+---
+
+## Notfall-Kontakte
+
+| Wer | Wann | Wie |
+|-----|------|-----|
+| CC (Claude Code) | Jederzeit | Neue Session starten, Kontext aus MEMORY.md + STATUS.md |
+| Supabase Support | DB-Notfall | supabase.com/support (Pro-Plan = Priority) |
+| Vercel Support | Deploy-Notfall | vercel.com/support |
+| Retell Support | Voice-Notfall | retell.ai (Dashboard) |
+
+---
+
+## Signal-Übersicht
+
+```
+System OK:
+  07:00 UTC  ✅ Lifecycle tick OK (Telegram)
+  07:30 UTC  🟢 Morning Report (Telegram only, kein E-Mail)
+
+System WARNING:
+  07:30 UTC  🟡 Morning Report (Telegram + E-Mail an Outlook)
+  → Follow-up fällig oder Backlog > 5
+
+System ALARM:
+  07:00 UTC  🔴 Lifecycle tick FAILED (Telegram)
+  07:30 UTC  🔴 Morning Report (Telegram + E-Mail an Outlook)
+  Jederzeit   Sentry Alert → E-Mail an Outlook
+  → DB down, Health fail, Trial expired, Tick stale
+```

--- a/scripts/_ops/morning_report.mjs
+++ b/scripts/_ops/morning_report.mjs
@@ -182,21 +182,43 @@ if (eT5) console.error("Query stale lifecycle:", eT5.message);
 const staleCount = staleTrials?.length ?? 0;
 const staleNames = staleTrials?.map((t) => t.slug).join(", ") ?? "";
 
-// 8. Health check
+// 8. Health check (deep — DB + email via /api/health)
 let healthOk = false;
+let healthDb = "?";
+let healthEmail = "?";
 try {
   const baseUrl = process.env.APP_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? "https://flowsight-mvp.vercel.app";
   const res = await fetch(`${baseUrl}/api/health`, { signal: AbortSignal.timeout(5000) });
-  healthOk = res.ok;
+  if (res.ok) {
+    const body = await res.json();
+    healthOk = body.ok === true;
+    healthDb = body.db ?? "?";
+    healthEmail = body.email ?? "?";
+  }
 } catch {
   healthOk = false;
+}
+
+// 9. Resend API key validation (lightweight — call /domains, no quota cost)
+let resendOk = false;
+try {
+  const resendKey = process.env.RESEND_API_KEY;
+  if (resendKey) {
+    const rRes = await fetch("https://api.resend.com/domains", {
+      headers: { Authorization: `Bearer ${resendKey}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    resendOk = rRes.ok;
+  }
+} catch {
+  resendOk = false;
 }
 
 // ---------------------------------------------------------------------------
 // Severity
 // ---------------------------------------------------------------------------
 
-const isRed = (stuck48h ?? 0) > 0 || !healthOk || expiring24h.length > 0 || staleCount > 0;
+const isRed = (stuck48h ?? 0) > 0 || !healthOk || !resendOk || expiring24h.length > 0 || staleCount > 0;
 const isYellow = (backlogNew ?? 0) > 5 || notfallCount > 0 || followUpDueCount > 0;
 const severity = isRed ? "🔴" : isYellow ? "🟡" : "🟢";
 
@@ -227,7 +249,11 @@ const report = [
   `expiring_48h:   ${expiring48hCount}${expiringNames ? ` (${expiringNames})` : ""}`,
   `zombie_trials:  ${zombieCount}`,
   `tick_stale:     ${staleCount}${staleNames ? ` (${staleNames})` : ""}`,
-  `health:         ${healthOk ? "OK" : "FAIL"}`,
+  `━━━ HEALTH ━━━━━━━━━`,
+  `api:            ${healthOk ? "OK" : "FAIL"}`,
+  `db:             ${healthDb}`,
+  `email_key:      ${healthEmail}`,
+  `resend_api:     ${resendOk ? "OK" : "FAIL"}`,
   `━━━━━━━━━━━━━━━━━━━`,
 ].join("\n");
 


### PR DESCRIPTION
## Summary

Reise-Härtung Session 2: Dokumentation + Health-Visibility.

- **Reise-Runbook** (`docs/runbooks/reise_checklist.md`)
  - Vor Abflug: GitHub Secrets, Vercel Env, Sentry Rules, Smoke-Test
  - Trial-Timing-Regel: Keine Trials starten deren Day 10 in Offline-Fenster fällt
  - Während Reise: 2-Min tägliche Routine (Outlook + Telegram), was automatisch läuft vs nicht
  - Offline-Fenster: Was passiert, Worst Case, Recovery nach Rückkehr
  - Upgrade-Empfehlungen: Supabase Pro ($25) > Vercel Pro ($20)
  - Signal-Übersicht: GREEN/YELLOW/RED → welcher Kanal

- **Morning Report Deep Health**
  - Vorher: `health: OK` (eine Zeile)
  - Nachher: `api: OK`, `db: ok`, `email_key: ok`, `resend_api: OK` (4 Zeilen)
  - Sofort sichtbar WO das Problem liegt

- **Resend API Validation** (H10)
  - Calls `GET /domains` um API Key zu validieren (nicht nur Presence-Check)
  - RED severity wenn Resend API nicht erreichbar

## Test plan

- [ ] CI passes
- [ ] Morning Report output shows new HEALTH section with 4 lines
- [ ] Resend API check: if key invalid → `resend_api: FAIL` → severity RED

🤖 Generated with [Claude Code](https://claude.com/claude-code)