### PR TITLE
docs: GTM SSOT hygiene — B-Quick elimination, tracker update, ICP alignment

### DIFF
--- a/docs/gtm/einsatzlogik.md
+++ b/docs/gtm/einsatzlogik.md
@@ -24,30 +24,32 @@
 | HOT (8-10) | A+B-Full+C+D | Video + eigener Agent + E2E Proof + Website |
 | WARM (6-7) | B-Full+D | Eigener Agent + Website |
 
-### Schritt 2b: Website-Modus bestimmen (NEU seit 10.03.)
+### Schritt 2b: Website-Modus bestimmen
 
-| Kriterium | Modus 1: Full | Modus 2: Extend | Modus 3: Pure System |
-|-----------|--------------|-----------------|---------------------|
-| Eigene Website? | Nein / nur Verzeichnis | Ja, funktional | Ja, stark + gepflegt |
-| Website-Qualität | ≤ 3/10 | 4–7/10 | 8+/10 |
-| FlowSight liefert | Komplette Website + Voice + Ops | Wizard-CTA + Voice + Ops | Nur Voice + Ops |
-| Leckerli D | Volle Demo-Website | Landing/Demo mit Wizard + CTA-Vorschlag | Kein D nötig |
-| Botschaft | "Wir digitalisieren deinen Betrieb" | "Wir erweitern dein System" | "Dein unsichtbares Leitsystem" |
+| Kriterium | Modus 1: Full | Modus 2: Extend |
+|-----------|--------------|-----------------|
+| Eigene Website? | Nein / nur Verzeichnis | Ja, funktional |
+| Website-Qualität | ≤ 5/10 | 6+/10 |
+| FlowSight liefert | Komplette Website + Voice + Ops | Wizard-CTA + Voice + Ops |
+| Leckerli D | Volle Demo-Website | Landing/Demo mit Wizard + CTA-Vorschlag |
+| Botschaft | "Wir digitalisieren deinen Betrieb" | "Wir erweitern dein System" |
 
 **Schnelltest für Founder (5 Sekunden):**
 1. Hat der Betrieb eine Website? → NEIN → Modus 1
-2. Würdest du dort als Endkunde anfragen? → NEIN → Modus 1, JA aber umständlich → Modus 2, JA → Modus 3
+2. Würdest du dort als Endkunde anfragen? → NEIN → Modus 1, JA → Modus 2
 
-**Beispiele:** Dörfler AG = Modus 1 (keine Website). Weinberger AG = Modus 2 (Website ok, kein Wizard). Betrieb mit perfekter Website + Kontaktformular = Modus 3.
+**Beispiele:** Dörfler AG = Modus 1 (keine Website). Weinberger AG = Modus 2 (Website ok, kein Wizard).
 
-**Encoding:** `"modus": 1|2|3` im `prospect_card.json` → Einsatzlogik liest Modus → passt Leckerli-Paket an.
+**Encoding:** `"modus": 1|2` im `prospect_card.json` → Einsatzlogik liest Modus → passt Leckerli-Paket an.
+
+> **Modus 3 (Pure System):** Zurückgestellt. Betriebe mit perfekter Website (8+/10) sind aktuell kein Fokus-ICP. Falls relevant → später definieren.
 
 ### Schritt 3: Sonderfälle
 
 | Bedingung | Override |
 |-----------|---------|
 | Website bereits live (Leuthold, Orlandini, Widmer) | D entfällt → nur fehlende Leckerli |
-| Modus 2/3 (starke bestehende Website) | D = Wizard-Landing statt Full Website |
+| Modus 2 (starke bestehende Website) | D = Wizard-Landing statt Full Website |
 | Kein Notdienst | Demo-Fall = "Anfrage" statt "Notfall" |
 | Nur 1 Gewerk (z.B. nur Heizung) | Vereinfachte Lisa (weniger Kategorien) |
 | Bestehender Kunde mit Voice | B entfällt → nur fehlende Leckerli |
@@ -71,43 +73,33 @@
 
 **Pipeline-Update:** `status=DEMO`, `leckerli_paket=A+B-Full+C+D`, alle Status-Felder
 
-### A+B-Quick+D (Gut, ~20 Min)
+### B-Full+D (WARM, ~35 Min)
 
 | # | Asset | Provisioning-Schritt | Zeit |
 |---|-------|---------------------|------|
 | 1 | `prospect_card.json` | Manuell oder aus Scout | 5 Min |
 | 2 | Website (`/kunden/{slug}`) | `prospect_pipeline.mjs` oder manuell | 15 Min |
-| 3 | B-Quick Agent-Variablen | Dynamic Variables setzen | 2 Min |
-| 4 | Video (Szenen 1-5) | Founder aufnimmt nach Template | 15 Min |
-| 5 | Outreach-E-Mail (Template 2) | Founder sendet | 3 Min |
+| 3 | Voice Agent DE + INTL | Template → retell_sync.mjs | 10 Min |
+| 4 | Twilio-Nummer | Console oder API | 2 Min |
+| 5 | Supabase Tenant | `onboard_tenant.mjs` | 3 Min |
+| 6 | Outreach-E-Mail (Template 2) | Founder sendet | 3 Min |
 
-**Pipeline-Update:** `status=DEMO`, `leckerli_paket=A+B-Quick+D`
-
-### B-Quick+D (Solide, ~12 Min)
-
-| # | Asset | Provisioning-Schritt | Zeit |
-|---|-------|---------------------|------|
-| 1 | `prospect_card.json` | Manuell oder aus Scout | 3 Min |
-| 2 | Website (`/kunden/{slug}`) | `prospect_pipeline.mjs` oder manuell | 15 Min |
-| 3 | B-Quick Agent-Variablen | Dynamic Variables setzen | 2 Min |
-| 4 | Outreach-E-Mail (Template 3) | Founder sendet | 2 Min |
-
-**Pipeline-Update:** `status=DEMO`, `leckerli_paket=B-Quick+D`
+**Pipeline-Update:** `status=DEMO`, `leckerli_paket=B-Full+D`
 
 ---
 
 ## Quick Wins: Bestehende Kunden-Websites
 
-Diese Kunden haben bereits Leckerli D (Website). Nur B + A fehlen:
+Diese Kunden haben bereits Leckerli D (Website). Nur B-Full + A fehlen:
 
 | Kunde | Slug | Fehlend | Aufwand |
 |-------|------|---------|---------|
-| Walter Leuthold | walter-leuthold | B-Quick + A (Video) | ~20 Min |
-| Orlandini | orlandini | B-Quick + A (Video) | ~20 Min |
-| Widmer Sanitär | widmer-sanitaer | B-Quick + A (Video) | ~20 Min |
-| Dörfler AG | doerfler-ag | A (Video) + Go-Live | ~15 Min |
+| Walter Leuthold | walter-leuthold | B-Full + A (Video) | ~25 Min |
+| Orlandini | orlandini | B-Full + A (Video) | ~25 Min |
+| Widmer Sanitär | widmer-sanitaer | B-Full + A (Video) | ~25 Min |
+| Dörfler AG | doerfler-ag | A (Video) + Trial Go-Live (Modus 1, persönlich) | ~15 Min |
 
-**Nach G2 (B-Quick Demo-Agent):** Alle 4 in <2h ergänzbar.
+**Hinweis:** Dörfler AG = erster Trial-Kunde. Persönlicher Start (Founder wohnt um die Ecke). Immer B-Full.
 
 ---
 
@@ -118,14 +110,12 @@ function bestimmeLeckerli(card: ProspectCard): LeckerliPaket {
   // Schritt 1: Score prüfen
   if (card.scoring.icp_score < 6) return { paket: "SKIP", assets: [] };
 
-  // Schritt 2: Tier → Paket
+  // Schritt 2: Tier → Paket (immer B-Full, kein B-Quick)
   let paket: string;
-  if (card.scoring.icp_score >= 9) {
-    paket = "A+B-Full+C+D";
-  } else if (card.scoring.icp_score >= 7) {
-    paket = "A+B-Quick+D";
+  if (card.scoring.icp_score >= 8) {
+    paket = "A+B-Full+C+D";  // HOT
   } else {
-    paket = "B-Quick+D";
+    paket = "B-Full+D";       // WARM (6-7)
   }
 
   // Schritt 3: Sonderfälle
@@ -133,7 +123,7 @@ function bestimmeLeckerli(card: ProspectCard): LeckerliPaket {
   const hatVoice = card.provisioning_status?.leckerli_b_lisa === "DONE";
 
   if (hatWebsite) paket = paket.replace("+D", "");
-  if (hatVoice) paket = paket.replace("+B-Full", "").replace("+B-Quick", "");
+  if (hatVoice) paket = paket.replace("+B-Full", "");
 
   // Schritt 4: Asset-Liste
   const assets = paketZuAssets(paket);
@@ -169,7 +159,7 @@ function besteDemoFall(card: ProspectCard): string {
 | Baustein | Status | Blockiert |
 |----------|--------|-----------|
 | G1 Prospect Card | **DONE** ✅ | — |
-| G2 B-Quick Demo-Agent | OFFEN | B-Quick Varianten |
+| G2 B-Quick Demo-Agent | **ELIMINIERT** — immer B-Full | — |
 | G3 Provisioning Runbook | **DONE** ✅ | — |
 | G4 Video-Template | **DONE** ✅ | — |
 | G5 Outreach-Templates | **DONE** ✅ | — |

--- a/docs/gtm/gtm_tracker.md
+++ b/docs/gtm/gtm_tracker.md
@@ -1,6 +1,6 @@
 # GTM Pipeline — Execution Tracker
 
-**Erstellt:** 2026-03-09 | **Owner:** CC + Founder
+**Erstellt:** 2026-03-09 | **Aktualisiert:** 2026-03-11 | **Owner:** CC + Founder
 **Referenz:** `docs/gtm/operating_model.md`
 **Regel:** CC aktualisiert nach jedem Deliverable. Founder reviewed wöchentlich.
 
@@ -8,40 +8,40 @@
 
 ## Status Snapshot
 
-- **Phase:** Woche 1 — Foundation + Weinberger + Quality Wave
+- **Phase:** Trial Machine complete — System läuft founder-arm (Monitoring, Lifecycle, Alerting)
 - **Goldstandard:** Jul. Weinberger AG, Thalwil (ICP 90+, A+B+C+D)
-- **Bausteine:** 9/10 done (G1, G3, G4, G5, G6, G7, G8, G9a, G9b, G10)
-- **Prospects provisioniert:** 0/5 Ziel
+- **Bausteine:** 10/10 done (G2 eliminiert — immer B-Full). G11+G12 DONE.
 - **Weinberger Website:** LIVE ✅ (PR #116)
-- **Weinberger Lisa:** PUBLISHED ✅ (PR #118) — Quality Wave v2 (PRs #126+#127): Closing Fix, FAQ-safe, Grüezi, PLZ Lookup
-- **Weinberger C (E2E):** BLOCKED auf Founder-Env-Check (DEMO_SIP_CALLER_ID + google_review_url)
+- **Weinberger Lisa:** PUBLISHED ✅ (PR #118) — Quality Wave v2 (PRs #126+#127)
+- **Weinberger C (E2E):** TESTBAR ✅ — Founder kann jederzeit E2E durchspielen
+- **Nächster Schritt:** Founder-Actions (Video, Outreach, Dörfler Trial) — siehe `docs/runbooks/reise_checklist.md`
 
 ---
 
-## Building Blocks (G1–G10)
+## Building Blocks (G1–G12)
 
 ### Kritischer Pfad (für ersten Prospect-Durchlauf)
 
-| # | Baustein | Owner | Status | Abhängigkeit | Aufwand |
-|---|---------|-------|--------|-------------|---------|
-| G10 | **GTM SSOT Docs** — Plan v2 + Tracker im Repo | CC | **DONE** ✅ | — | ~1h |
-| G1 | **Prospect Card Format** — Strukturiertes JSON (Firma, Gewerk, Region, Services, ICP, Leckerli-Empfehlung, bester Demo-Fall) | CC | **DONE** ✅ | scout.mjs + crawl | ~3h |
-| G9a | **Weinberger Website** (Leckerli D) — Crawl → Config → Deploy | CC | **DONE** ✅ (PR #116) | G1 | ~4h |
-| G9b | **Weinberger Lisa** (Leckerli B-Full) — Agent → retell_sync → publish | CC | **DONE** ✅ (PR #118) | G9a | ~2h |
-| G4 | **Video-Template** — 5-Szenen-Skript, OBS/Loom Setup, Variablen | CC + ChatGPT | **DONE** ✅ | B+D müssen stehen | ~2h |
-| G5 | **Premium Outreach-Templates** — Email/Call-Script, Leckerli A-D Varianten | ChatGPT → CC | **DONE** ✅ | ChatGPT-Messaging | ~1h |
-| G3 | **Provisioning Runbook (<25 Min)** — Step-by-Step mit Quality Gates | CC | **DONE** ✅ | G1, G2 | ~2h |
-| G8 | **Quality Gates Checklist** — Pro Prospect: 5 Gates (Card, Website, Lisa, Video, Outreach) | CC | **DONE** ✅ | G3 | ~1h |
+| # | Baustein | Owner | Status | Aufwand |
+|---|---------|-------|--------|---------|
+| G10 | **GTM SSOT Docs** — Plan v2 + Tracker im Repo | CC | **DONE** ✅ | ~1h |
+| G1 | **Prospect Card Format** — Strukturiertes JSON | CC | **DONE** ✅ | ~3h |
+| G9a | **Weinberger Website** (Leckerli D) | CC | **DONE** ✅ (PR #116) | ~4h |
+| G9b | **Weinberger Lisa** (Leckerli B-Full) | CC | **DONE** ✅ (PR #118 + #126+#127) | ~2h |
+| G4 | **Video-Template** — 5-Szenen-Skript | CC + ChatGPT | **DONE** ✅ | ~2h |
+| G5 | **Premium Outreach-Templates** — Email/Call-Script, 2 Tiers (HOT/WARM) | CC | **DONE** ✅ | ~1h |
+| G3 | **Provisioning Runbook (<25 Min)** | CC | **DONE** ✅ | ~2h |
+| G8 | **Quality Gates Checklist** | CC | **DONE** ✅ | ~1h |
 
-### Skalierung (nach Weinberger)
+### Skalierung + Ops
 
-| # | Baustein | Owner | Status | Abhängigkeit | Aufwand |
-|---|---------|-------|--------|-------------|---------|
-| G2 | **B-Quick Demo-Agent** — 1 parametrisierter Agent mit Variablen-Slots, shared Testnummer | CC | OFFEN | Retell Dynamic Variables | ~4h |
-| G6 | **Einsatzlogik-Engine** — ICP Score → Leckerli-Paket → Asset-Liste → Steps | CC | **DONE** ✅ | G1 | ~1h |
-| G7 | **Pipeline Tracker Upgrade** — pipeline.csv + leckerli_paket, lisa_status, video_status, website_status, testnummer | CC | **DONE** ✅ | promote.mjs | ~2h |
-
-**Gesamt: ~20h CC-Arbeit über 4 Wochen**
+| # | Baustein | Owner | Status | Aufwand |
+|---|---------|-------|--------|---------|
+| ~~G2~~ | ~~B-Quick Demo-Agent~~ | — | **ELIMINIERT** — immer B-Full (PR #131) | — |
+| G6 | **Einsatzlogik-Engine** — ICP → Leckerli-Paket | CC | **DONE** ✅ | ~1h |
+| G7 | **Pipeline Tracker Upgrade** — pipeline.csv + Felder | CC | **DONE** ✅ | ~2h |
+| G11 | **Trial Lifecycle Runner** — Idempotent Tick, Day 7-14 Milestones | CC | **DONE** ✅ (PR #136) | ~4h |
+| G12 | **Monitoring-Härtung** — Morning Report Cron, Tick Alerts, Deep Health | CC | **DONE** ✅ (PRs #138+#139) | ~3h |
 
 ---
 
@@ -49,56 +49,43 @@
 
 | Leckerli | Was | Status | Evidence |
 |----------|-----|--------|----------|
-| **D** | Website (Services, Team, Reviews, Notdienst, Galerie, Wizard) | **DONE** ✅ | PR #116 — 5 Services, 17 Bilder, 24h Notdienst, 4.4★/20 Reviews, Brand #004994 |
-| **B-Full** | Eigener Voice Agent (Lisa, Greeting, Triage, Kategorien) | **DONE** ✅ | PR #118 + Quality Wave PRs #126+#127 — Closing Fix, FAQ-safe, Grüezi, PLZ→City (24 Orte), Notfall-Empathie v2 |
-| **C** | E2E Proof (Tenant, SMS, Ops-Fall, Samstag-Nacht-Test) | **BLOCKED** ⏳ | Founder muss prüfen: DEMO_SIP_CALLER_ID + google_review_url in Supabase. Review Surface ready. |
+| **D** | Website (Services, Team, Reviews, Notdienst, Galerie, Wizard) | **DONE** ✅ | PR #116 — 5 Services, 17 Bilder, 24h Notdienst, 4.4★/20 Reviews |
+| **B-Full** | Eigener Voice Agent (Lisa, Greeting, Triage, Kategorien) | **DONE** ✅ | PR #118 + Quality Wave #126+#127 — PLZ→City, Notfall-Empathie v2 |
+| **C** | E2E Proof (Tenant, SMS, Ops-Fall, Samstag-Nacht-Test) | **TESTBAR** ✅ | Review Surface ready. Founder kann jederzeit E2E durchspielen. |
 | **A** | Video (5 Szenen, 45-60s, Founder-Aufnahme) | OFFEN | Founder |
 | **Outreach** | Email + Testnummer + URL + Video | OFFEN | Founder |
 
 ---
 
-## Woche 1 Plan (09.03.–14.03.)
-
-| Tag | CC | Founder | ChatGPT |
-|-----|-----|---------|---------|
-| So 09.03. | G10 ✅ + Wizard ✅ + Weinberger D ✅ + B-Full ✅ + G1 ✅ + G3 ✅ + G8 ✅ + G4 ✅ + G5 ✅ + G6 ✅ | Review GTM Plan v2 | — |
-| Mo 10.03. | G7: Pipeline Tracker Upgrade + G2: B-Quick Demo-Agent | Freigabe GTM Plan + Review Website + Lisa | — |
-| Di 11.03. | Weinberger C (E2E Proof) | — | — |
-| Mi 12.03. | Quick Wins: Leuthold + Orlandini + Widmer (B-Quick) | Review: Lisa glaubwürdig? | — |
-| Do 13.03. | Weinberger A (Video) — Skript + Founder-Aufnahme | Review (Handy + Desktop) | — |
-| Fr 14.03. | Buffer / Iteration / Erster Outreach | Feedback | — |
-
-**Woche 1 Ziel:** Weinberger D ✅ + B-Full ✅ + Foundation 8/10 ✅ — MASSIV VORAUS
-
----
-
 ## Downstream Impact Tracker
 
-Welche bestehenden Systeme werden durch GTM verändert:
-
-| System | Änderung | Wann | Status |
-|--------|---------|------|--------|
-| **Wizard** | "Anliegen" statt "Schaden", Top-3 + fixed row | Sofort | **DONE** ✅ (PR #113) |
-| **prospect_pipeline.mjs** | + Prospect Card Output, + --demo-only, + --lisa-quick | G1 | OFFEN |
-| **scout.mjs** | + leckerli_recommendation, + best_demo_case | G6/G7 | OFFEN |
-| **retell_sync.mjs** | Keine Änderung nötig | — | ✅ |
-| **Kunden-Template** | Keine Änderung nötig | — | ✅ |
-| **FlowSight Website** | CTA-Anpassung → NIEDRIG, nach Weinberger | Woche 4+ | PAUSED |
-| **Sales Agent Lisa** | Bleibt separat (kein Prospect-Entry-Point) | — | ✅ Entschieden |
-| **pipeline.csv** | + leckerli_paket, lisa_status, video_status, website_status, testnummer | G7 | **DONE** ✅ |
-| **Email-System** | Outreach bleibt manuell (Founder sendet) | — | ✅ Entschieden |
-| **Supabase** | Keine prospects-Tabelle nötig (bis >30 Prospects) | — | ✅ Entschieden |
+| System | Änderung | Status |
+|--------|---------|--------|
+| **Wizard** | "Anliegen" statt "Schaden", Top-3 + fixed row | **DONE** ✅ (PR #113) |
+| **pipeline.csv** | + leckerli_paket, lisa_status, video_status, website_status, testnummer | **DONE** ✅ |
+| **Trial Lifecycle** | provision_trial.mjs, offboard_tenant.mjs, tick route, Welcome Page | **DONE** ✅ (PR #136) |
+| **Monitoring** | Morning Report Cron, Tick Alerts, Deep Health, Reise-Checklist | **DONE** ✅ (PRs #138+#139) |
+| **retell_sync.mjs** | Keine Änderung nötig | ✅ |
+| **Kunden-Template** | Keine Änderung nötig | ✅ |
+| **prospect_pipeline.mjs** | + Prospect Card Output, + --demo-only | OFFEN |
+| **scout.mjs** | + leckerli_recommendation, + best_demo_case | OFFEN |
+| **FlowSight Website** | CTA-Anpassung → nach Weinberger | PAUSED |
+| **Sales Agent Lisa** | Bleibt separat (kein Prospect-Entry-Point) | ✅ Entschieden |
+| **Email-System** | Outreach bleibt manuell (Founder sendet) | ✅ Entschieden |
+| **Supabase** | Keine prospects-Tabelle nötig (bis >30 Prospects) | ✅ Entschieden |
 
 ---
 
-## Quick Wins (nach B-Quick in Woche 2)
+## Quick Wins (bestehende Kunden-Websites)
 
 | Kunde | Existiert | Fehlt | Aufwand |
 |-------|-----------|-------|---------|
-| Walter Leuthold | Website (D) | Lisa (B-Quick), Video (A) | ~20 Min |
-| Orlandini | Website (D) | Lisa (B-Quick), Video (A) | ~20 Min |
-| Widmer Sanitär | Website (D) | Lisa (B-Quick), Video (A) | ~20 Min |
-| Dörfler AG | Website + Voice + Ops (B+C+D) | Video (A), Go-Live | ~15 Min |
+| Walter Leuthold | Website (D) | Lisa (B-Full), Video (A) | ~25 Min |
+| Orlandini | Website (D) | Lisa (B-Full), Video (A) | ~25 Min |
+| Widmer Sanitär | Website (D) | Lisa (B-Full), Video (A) | ~25 Min |
+| Dörfler AG | Website + Voice + Ops (B+C+D) | Video (A), Trial Go-Live | ~15 Min |
+
+**Dörfler AG:** Erster Trial-Kunde. Persönlicher Start (Founder wohnt um die Ecke, Modus 1). Immer B-Full.
 
 ---
 
@@ -108,16 +95,13 @@ Welche bestehenden Systeme werden durch GTM verändert:
 |-------|-------------|-----|
 | 2026-03-09 | GTM Pipeline v2 als Steuerungsdokument angenommen | Founder |
 | 2026-03-09 | Wizard = universeller Intake (Anliegen statt Schaden) | Founder + CC |
-| 2026-03-09 | Eigener Tracker `gtm_tracker.md`, OPS_BOARD verweist darauf | CC |
 | 2026-03-09 | Email-Outreach bleibt manuell (Founder aus eigenem Mail) | Plan v2 |
 | 2026-03-09 | Sales-Lisa bleibt separat, kein Prospect-Entry-Point | Plan v2 |
 | 2026-03-09 | Keine Supabase prospects-Tabelle bis >30 Prospects | Plan v2 |
-| 2026-03-09 | G1 Prospect Card: JSON-Schema v1.0 definiert, Weinberger als erste Instanz | CC |
-| 2026-03-09 | G3 Provisioning Runbook: <25 Min Flow basierend auf Weinberger-Erfahrung | CC |
-| 2026-03-09 | G8 Quality Gates: 5 Gates mit je 7-10 Checks, Gate-Matrix pro Paket | CC |
-| 2026-03-09 | G4 Video-Template: 5-Szenen-Dramaturgie, Variablen, Loom/OBS Setup, Gewerk-Varianten | CC |
-| 2026-03-09 | G5 Outreach-Templates: 3 E-Mail-Templates (nach ICP), Anruf-Script, Touch-Kadenz | CC |
-| 2026-03-09 | G6 Einsatzlogik: Entscheidungstabelle + Pseudocode + Quick Wins Übersicht | CC |
-| 2026-03-09 | G7 Pipeline Upgrade: 5 neue Spalten, Weinberger als erstes Entry, Leckerli-Empfehlung für alle Prospects | CC |
-| 2026-03-10 | Quality Wave: Voice Closing Fix + FAQ-safe Edge + Grüezi + PLZ Lookup + Review Surface + SMS Review + Dashboard Branding (PRs #126+#127) | CC |
-| 2026-03-10 | Modus 1/2 Logik erkannt: Modus 1 = volle Website (schwache bestehende), Modus 2 = Extend (starke bestehende). Weinberger = Modus 2. | Founder + CC |
+| 2026-03-09 | G1–G8 Foundation komplett an einem Tag (9/10 Building Blocks) | CC |
+| 2026-03-10 | Modus 1/2 Logik: Modus 1 = volle Website, Modus 2 = Extend. Modus 3 zurückgestellt. | Founder + CC |
+| 2026-03-10 | Quality Wave: Voice Closing Fix + PLZ Lookup + Review Surface + Dashboard Branding | CC |
+| 2026-03-11 | B-Quick eliminiert — immer B-Full (Operating Model PR #131) | Founder + CC |
+| 2026-03-11 | Trial Machine: Lifecycle Runner + Monitoring-Härtung + Reise-Checklist (PRs #136–#139) | CC |
+| 2026-03-11 | G11 + G12 als neue Bausteine definiert und abgeschlossen | CC |
+| 2026-03-11 | Dörfler AG = erster Trial-Kunde, persönlicher Touch, Modus 1 | Founder |

--- a/docs/gtm/outreach_templates.md
+++ b/docs/gtm/outreach_templates.md
@@ -30,7 +30,7 @@ Der Outreach führt den Prospect zum Testen, nicht zum Kaufen. Die Templates spi
 
 ---
 
-## Template 1: A+B-Full+C+D (ICP 90+, Top-Prospects)
+## Template 1: A+B-Full+C+D (HOT, ICP ≥8)
 
 **Betreff:** {FIRMA} — ich habe etwas für Sie gebaut
 
@@ -57,7 +57,7 @@ Der Outreach führt den Prospect zum Testen, nicht zum Kaufen. Die Templates spi
 
 ---
 
-## Template 2: A+B-Full+D (ICP 75-89, gute Prospects)
+## Template 2: B-Full+D (WARM, ICP 6-7)
 
 **Betreff:** {FIRMA} — Ihre eigene Lisa wartet
 
@@ -81,30 +81,7 @@ Der Outreach führt den Prospect zum Testen, nicht zum Kaufen. Die Templates spi
 
 ---
 
-## Template 3: B-Full+D (ICP 60-74, solide Prospects)
-
-**Betreff:** Kein verpasster Anruf mehr — Demo für {FIRMA}
-
-**Body:**
-
-> Guten Tag,
->
-> ich bin Gunnar Wende von FlowSight. Wir haben eine KI-Assistentin gebaut, die Anrufe für {GEWERK}-Betriebe entgegennimmt — rund um die Uhr.
->
-> Ich habe eine kurze Demo für Sie vorbereitet:
->
-> **Testen Sie es selbst:** Rufen Sie {TESTNUMMER} an.
-> **Website-Vorschau:** {WEBSITE_URL}
->
-> Kein Abo, kein Termin. Einfach anrufen und testen.
->
-> Grüsse
-> Gunnar Wende
-> FlowSight — flowsight.ch
-
----
-
-## Template 4: Trial-Einladung (nach Provision)
+## Template 3: Trial-Einladung (nach Provision)
 
 **Trigger:** Prospect hat Interesse gezeigt → Trial provisioniert → Welcome-Mail geht automatisch via `provision_trial.mjs`.
 
@@ -188,8 +165,8 @@ Vor jedem Versand:
 
 | Touch | Kanal | Timing | Template |
 |-------|-------|--------|----------|
-| 0 | E-Mail (auto) | Nach Provision | Template 4 (automatisch via provision_trial.mjs) |
-| 1 | E-Mail | Tag 0 | Template 1/2/3 (nach ICP) |
+| 0 | E-Mail (auto) | Nach Provision | Template 3 (automatisch via provision_trial.mjs) |
+| 1 | E-Mail | Tag 0 | Template 1 (HOT) oder Template 2 (WARM) |
 | 2 | Anruf | Tag 2 | Anruf-Script |
 | 3 | E-Mail | Tag 7 | Kurzer Follow-up ("Hatten Sie Zeit zum Testen?") |
 | — | Pause | Danach | Kein weiterer Kontakt. Prospect ruht. |


### PR DESCRIPTION
## Summary
- **Einsatzlogik:** Remove all B-Quick remnants (asset lists, pseudocode, Quick Wins). Eliminate Modus 3 (→ Later). Align to 2-tier system (HOT ≥8 / WARM 6-7). Add Dörfler AG as first trial customer context.
- **GTM Tracker:** Full update — G2 eliminated, G11+G12 DONE, Weinberger B=DONE C=testable, Trial Machine phase complete. Remove stale Woche 1 plan.
- **Outreach Templates:** Align ICP from percentage (90+/75-89/60-74) to 0-11 scale. Remove redundant Template 3 (old COLD tier). Renumber Trial template. Fix touch cadence.

## Test plan
- [ ] Verify no B-Quick references remain in any GTM doc
- [ ] Verify Weinberger status matches reality (B=DONE, C=testable)
- [ ] Verify ICP scoring is consistent across einsatzlogik + outreach_templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)