### PR TITLE
feat: 299 flat pricing model + pre-contact quality gate

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -31,7 +31,7 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 | **Peoplefone Front Door** | LIVE ✅ | Brand-Nr → Twilio → SIP → Retell |
 | **Morning Report** | LIVE ✅ | 15 KPIs + Trial Status + Deep Health, GH Actions Cron (daily 07:30 UTC), Telegram + E-Mail (RED/YELLOW) |
 | **Marketing Website** | LIVE ✅ | flowsight.ch (homepage, pricing, legal, demo booking) |
-| **Sales Voice Agent** | LIVE ✅ | "Lisa" auf 044 552 09 19, Pricing aktualisiert (Starter 199/Alltag 299/Wachstum 399) |
+| **Sales Voice Agent** | LIVE ✅ | "Lisa" auf 044 552 09 19 (Pricing-Update auf 299 flat ausstehend) |
 | **Customer Websites** | LIVE ✅ | /kunden/[slug] — SSG template (12 sections, ServiceDetailOverlay, lightbox, galleries) |
 | **Customer Links Page** | LIVE ✅ | /kunden/[slug]/links — SSG, alle Kunden-URLs auf einen Blick, noindex |
 | **Review Engine** | LIVE ✅ | Manual button, review_sent_at, tenant-scoped GOOGLE_REVIEW_URL, SMS fallback |

--- a/docs/brand/LinkedIn/LINKEDIN_SETUP_BRIEF.md
+++ b/docs/brand/LinkedIn/LINKEDIN_SETUP_BRIEF.md
@@ -1,0 +1,317 @@
+# FlowSight — LinkedIn Unternehmenskonto Setup-Brief
+
+> Dieses Dokument ist ein kompletter Brief für die Einrichtung des FlowSight LinkedIn-Unternehmensprofils. Kann 1:1 an ChatGPT oder einen Assistenten übergeben werden.
+
+---
+
+## 1. Grunddaten
+
+| Feld | Wert |
+|------|------|
+| **Unternehmensname** | FlowSight |
+| **LinkedIn-URL** | linkedin.com/company/flowsight |
+| **Website** | https://flowsight.ch |
+| **Branche** | Software Development / Technology, Information and Internet |
+| **Unternehmensgrösse** | 2–10 Mitarbeiter |
+| **Typ** | Privately Held |
+| **Gründungsjahr** | 2025 |
+| **Hauptsitz** | Zürich, Schweiz |
+| **Sprache** | Deutsch |
+
+---
+
+## 2. Tagline (max. 120 Zeichen)
+
+Die Tagline erscheint direkt unter dem Firmennamen. Muss sofort klar machen WAS + FÜR WEN.
+
+**Empfehlung:**
+```
+Das Leitsystem für Schweizer Sanitär- und Heizungsbetriebe.
+```
+(62 Zeichen — knapp, klar, positioniert)
+
+**Alternativen:**
+```
+Website · Telefonassistentin · Dashboard — alles aus einer Hand.
+```
+```
+Kein Anruf geht verloren. Kein Fall ohne Struktur.
+```
+```
+Digitale Anrufannahme, strukturierte Fälle, 5-Sterne-Bewertungen.
+```
+
+---
+
+## 3. Slogan-Vorschläge (für Posts, Banner, Kampagnen)
+
+FlowSight ist MEHR als ein Anrufbeantworter — es ist ein Leitsystem (Anruf + Website → Ticket → Einsatz → Review). Der Slogan muss das abbilden, ohne KI-Buzzwords.
+
+| Slogan | Stärke | Kontext |
+|--------|--------|---------|
+| **Alles im Fluss. Alles im Blick.** | Dekonstruiert den Namen Flow+Sight auf Deutsch. Eingängig, breit genug für alle Module. | Banner, Profil |
+| **Struktur für Ihr Handwerk.** | Spricht Sanitäre direkt an. Breit genug für Voice+Web+Dashboard. | Profil, Pitch |
+| **Vom Anruf bis zur 5-Sterne-Bewertung.** | Bildet den kompletten Kreislauf ab. Konkret, messbar. | Banner, Posts |
+| **Ihr Betrieb. Immer erreichbar. Immer strukturiert.** | Zwei Kernversprechen in einem Satz. | Profil, Pitch |
+| **Nichts geht verloren.** | Kürzester, universellster Slogan. Trifft den Kern (Signal Dot = Brand Promise). | Logo-Begleiter |
+| **Das Backoffice, das nie schläft.** | Bildhaft, verständlich für Handwerker. Betont 24/7. | Posts, Ads |
+
+---
+
+## 4. "Info" / About-Section (max. 2'600 Zeichen)
+
+Die About-Section ist SEO-relevant (LinkedIn-Suche + Google) und der erste Eindruck für Besucher. Struktur: Problem → Lösung → Warum anders → CTA.
+
+### Entwurf (Deutsch):
+
+```
+Ihr Sanitärbetrieb verpasst Anrufe, während das Team auf der Baustelle ist.
+Meldungen landen auf Zetteln, in WhatsApp-Gruppen oder gehen verloren.
+Kunden warten — und rufen beim nächsten Betrieb an.
+
+FlowSight löst genau dieses Problem.
+
+Wir sind das Leitsystem für Schweizer Sanitär- und Heizungsbetriebe:
+Von der ersten Kontaktaufnahme bis zur 5-Sterne-Google-Bewertung — strukturiert, digital, rund um die Uhr.
+
+Was FlowSight abdeckt:
+→ Professionelle Website mit Online-Schadensmeldung (Wizard)
+→ Digitale Telefonassistentin "Lisa" — nimmt Anrufe 24/7 entgegen, auf Deutsch und 3 weiteren Sprachen
+→ Strukturierte Tickets mit SMS-Bestätigung an den Melder (inkl. Foto-Upload)
+→ Ops-Dashboard für Ihr Team: Fälle, Termine, Export — alles an einem Ort
+→ Automatisierte Google-Bewertungsanfragen nach abgeschlossenen Einsätzen
+
+Keine Aufnahmen. Keine KI-Spielerei. Ein Werkzeug, das funktioniert.
+Daten auf Schweizer/EU-Servern (DSGVO-konform).
+
+CHF 299/Monat. Alles inklusive. 14 Tage kostenlos testen.
+
+→ Demo buchen: flowsight.ch
+→ Direkt erleben: +41 44 552 09 19 (Lisa nimmt ab)
+```
+
+(~1'050 Zeichen — bewusst kürzer als das Maximum. Weniger = mehr auf LinkedIn.)
+
+---
+
+## 5. Specialties / Spezialisierungen (max. 10)
+
+Diese Begriffe sind durchsuchbar auf LinkedIn. Mix aus Deutsch + Englisch für maximale Sichtbarkeit:
+
+```
+1. Digitale Anrufannahme
+2. Sanitär Software
+3. Heizung Software
+4. Handwerksbetrieb Digitalisierung
+5. Telefonassistentin
+6. Auftragsmanagement
+7. Google Bewertungen
+8. Schweizer Handwerk
+9. Field Service Management
+10. KMU Software
+```
+
+---
+
+## 6. CTA-Button
+
+LinkedIn bietet einen Button unter dem Firmennamen. Optionen:
+- **"Website besuchen"** → flowsight.ch *(Standard, sicher)*
+- **"Kontakt aufnehmen"** → flowsight.ch/demo *(besser für Conversion)*
+
+**Empfehlung:** "Kontakt aufnehmen" → Link zur Demo-Seite.
+
+---
+
+## 7. Hashtags (3–5 pro Post, konsistent)
+
+**Brand-Hashtag (immer):**
+- `#FlowSight`
+
+**Nischen-Hashtags (rotierend, 2-3 pro Post):**
+- `#Sanitär` / `#Heizung`
+- `#Handwerk` / `#Haustechnik`
+- `#KMUSchweiz`
+- `#Digitalisierung`
+- `#GoogleBewertungen`
+
+**Vermeiden:** `#KI`, `#AI`, `#Startup`, `#SaaS` — zu generisch, erreicht nicht die Zielgruppe.
+
+---
+
+## 8. Profilbilder (bereits erstellt)
+
+| Asset | Masse | Datei |
+|-------|-------|-------|
+| **Logo** | 400 × 400 px | `linkedin_export.html` → "Download PNG" |
+| **Cover** | 1584 × 396 px | `linkedin_export.html` → "Download PNG" |
+
+**Design-Sprache:** Navy (#0f1a2e) + Gold (#d4a843). Kein 3D, keine Cliparts, Swiss Minimalism.
+
+**Wichtig Cover:** Keine wichtigen Elemente im unteren linken Viertel platzieren — dort überlappt das Firmenlogo auf der LinkedIn-Seite.
+
+---
+
+## 9. Content-Strategie (erste 4 Wochen)
+
+### Posting-Rhythmus
+- **2–3 Posts pro Woche** (Di–Do, 7:00 oder 12:00 Uhr)
+- Qualität >> Quantität. 1 guter Post > 5 mittelmässige.
+- CEO-Posts erhalten **4× mehr Engagement** als Firmen-Posts → Founder sollte persönlich posten.
+
+### Content-Mix (40/30/20/10)
+
+| Anteil | Typ | Beispiel |
+|--------|-----|----------|
+| **40%** | Branchen-Wissen | "3 Gründe, warum Sanitärbetriebe Anrufe verlieren — und was dagegen hilft" |
+| **30%** | Kundengeschichten | "Wie Dörfler AG mit FlowSight keinen Anruf mehr verpasst" (mit Erlaubnis) |
+| **20%** | Produkt-Einblicke | "So sieht ein strukturierter Fall im Dashboard aus" (Screenshot) |
+| **10%** | Firmen-News | "Wir sind live — erste Kunden in der Region Zürich" |
+
+### Post-Formate die funktionieren
+1. **Karussell-Posts** (PDF-Slides): Höchstes Engagement auf LinkedIn
+2. **Kurze Text-Posts** mit einem konkreten Insight (max. 1'300 Zeichen)
+3. **Video** (60–90 Sek.): Demo-Ausschnitt, Lisa-Anruf-Aufnahme (simuliert), Dashboard-Tour
+4. **Polls**: "Wie viele Anrufe verpasst Ihr Betrieb pro Woche?" → Engagement + Insights
+
+### Erste 5 Posts (Vorschläge)
+
+**Post 1 — Launch-Ankündigung:**
+```
+Wir haben FlowSight gebaut, weil wir ein Problem gesehen haben:
+
+Schweizer Sanitärbetriebe verpassen Anrufe.
+Nicht weil sie schlechte Arbeit machen — sondern weil sie auf der Baustelle stehen.
+
+FlowSight nimmt Anrufe an, erstellt Tickets und schickt dem Melder eine SMS.
+24/7. Strukturiert. Ohne Aufnahmen.
+
+→ flowsight.ch
+
+#FlowSight #Sanitär #KMUSchweiz
+```
+
+**Post 2 — Problem-Post (kein Produkt-Pitch):**
+```
+Frage an Sanitärunternehmer:
+
+Was passiert bei euch, wenn um 19:30 ein Kunde mit Wasserrohrbruch anruft
+und niemand im Büro ist?
+
+a) Anrufbeantworter → Kunde ruft Konkurrenz an
+b) Weiterleitung aufs Privathandy → Feierabend ade
+c) Gar nichts → Kunde ist weg
+
+Es gibt eine vierte Option.
+Aber dazu ein andermal.
+
+#Handwerk #Sanitär #Erreichbarkeit
+```
+
+**Post 3 — Kundengeschichte:**
+```
+Letzte Woche hat ein Endkunde um 21:15 bei einem unserer Partnerbetriebe angerufen.
+
+Wasserfleck an der Decke. Panik.
+
+Was passiert ist:
+→ Lisa (unsere digitale Assistentin) hat den Anruf angenommen
+→ In 90 Sekunden: Name, Adresse, Problem erfasst
+→ SMS an den Kunden: "Ihre Meldung ist erfasst, prüfen Sie die Daten"
+→ Ticket im Dashboard des Betriebs — morgens um 7 war der Techniker informiert
+
+Kein Zettel. Kein verpasster Anruf. Kein Stress.
+
+#FlowSight #Haustechnik #Digitalisierung
+```
+
+**Post 4 — Behind the Scenes:**
+```
+Wir haben für einen Betrieb in 7 Tagen eine komplette Lösung aufgesetzt:
+
+✓ Professionelle Website mit Online-Schadensmeldung
+✓ Digitale Telefonassistentin (4 Sprachen)
+✓ Ops-Dashboard mit Ticket-System
+✓ SMS-Bestätigung an Melder
+✓ Google-Review-Automatisierung
+
+Alles aus einer Hand. Kein IT-Projekt. Kein 6-Monats-Rollout.
+
+Sanitärbetriebe brauchen Werkzeuge, nicht Projekte.
+
+#FlowSight #Sanitär #KMUSchweiz
+```
+
+**Post 5 — Poll:**
+```
+Frage an Handwerksbetriebe:
+
+Wie viele Kundenanrufe verpasst ihr schätzungsweise pro Woche?
+
+🔵 0 — wir sind immer erreichbar
+🟢 1–3
+🟡 4–10
+🔴 Keine Ahnung, wir tracken das nicht
+
+#Handwerk #Erreichbarkeit #Sanitär
+```
+
+---
+
+## 10. Sichtbarkeits-Tipps
+
+### SEO
+- **Headline + About + Specialties** werden von LinkedIn UND Google indexiert
+- Begriffe wie "Sanitär Software Schweiz", "digitale Anrufannahme" natürlich einbauen
+- Custom URL sichern: `linkedin.com/company/flowsight`
+
+### Engagement-Hacks
+- **Innerhalb 60 Min. nach Posting** auf jeden Kommentar antworten (Algorithm-Boost)
+- **Als Unternehmen auf andere Posts kommentieren** (LinkedIn Identitätswechsel nutzen)
+- **Mitarbeiter/Partner bitten**, Posts zu liken/teilen (erste 30 Min. entscheidend)
+- **Keine externen Links im Post-Text** — LinkedIn bestraft externe Links. Link in den ersten Kommentar.
+
+### Verifizierung
+- Unter Einstellungen → Verifizierung → "Jetzt verifizieren"
+- Verifizierte Seiten erhalten mehr Sichtbarkeit und Vertrauen
+
+### Profilvollständigkeit
+- **Vollständige Profile = 30% mehr Aufrufe pro Woche**
+- Jedes Feld ausfüllen: Logo, Cover, About, Website, Standort, Specialties, CTA-Button
+- "Life"-Tab mit Teamfotos/Büro aktivieren (optional, aber Vertrauenssignal)
+
+---
+
+## 11. DACH-spezifische Regeln
+
+| Regel | Warum |
+|-------|-------|
+| **Substanz > Style** | DACH-Käufer misstrauen Hype. Konkrete Zahlen und Ergebnisse statt Superlative. |
+| **Kein "KI" im Vordergrund** | Sanitäre wollen Ergebnisse, keine Technologie. "Digitale Assistentin" statt "KI-Agent". |
+| **Datenschutz betonen** | Schweizer/DACH-Markt reagiert stark auf DSGVO-Konformität, EU-Server, keine Aufnahmen. |
+| **Deutsch first** | Hauptsprache Deutsch. Gelegentlich English Summary für breitere Reichweite (+41% laut Studien). |
+| **"Hidden Champion"-Narrativ** | DACH liebt spezialisierte Nischenlösungen. "Gebaut für Sanitär" > "Für alle Branchen". |
+| **Keine Kaltakquise-Vibes** | Trust Engineering: Wert liefern → Vertrauen aufbauen → dann erst pitchen. |
+
+---
+
+## 12. Checkliste Einrichtung
+
+- [ ] Unternehmensseite erstellen (linkedin.com/company/setup)
+- [ ] Logo hochladen (400×400 PNG)
+- [ ] Cover hochladen (1584×396 PNG)
+- [ ] Tagline eintragen
+- [ ] About-Section ausfüllen
+- [ ] 10 Specialties eintragen
+- [ ] Website-URL hinterlegen
+- [ ] CTA-Button setzen ("Kontakt aufnehmen" → Demo-Link)
+- [ ] Custom URL sichern (/company/flowsight)
+- [ ] Standort, Branche, Grösse eintragen
+- [ ] Verifizierung beantragen
+- [ ] Founder als Admin hinzufügen
+- [ ] Ersten Post veröffentlichen
+- [ ] 5 Kontakte bitten, der Seite zu folgen
+
+---
+
+*Erstellt: 2026-03-04 | FlowSight Brand & Marketing*

--- a/docs/business_briefing.md
+++ b/docs/business_briefing.md
@@ -138,21 +138,20 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 - Auf Geschäftsnummer +41 44 552 09 19
 - DE + INTL (auto language swap)
 - Beantwortet Fragen zu FlowSight, sammelt Demo-Anfragen
-- **Pricing aktuell:** Starter CHF 199, Alltag CHF 299, Wachstum CHF 399
+- **Pricing aktuell:** CHF 299/Monat — ein Produkt, alles inklusive
 
 ---
 
-## 4. Pakete & Pricing
+## 4. Pricing
 
-| Paket | Inhalt | Preis |
-|-------|--------|-------|
-| **Starter** | Moderne Website + Online-Schadensmeldung + E-Mail-Benachrichtigung + Kunden-SMS + Persönliches Onboarding | CHF 199/Monat |
-| **Alltag** | + Digitaler Telefonassistent (24/7) + Fallübersicht + Bestätigungs-SMS + Foto-Upload + Mehrsprachig | CHF 299/Monat |
-| **Wachstum** | + Google Review-Anfragen + Priority Support + Stärkeres Google-Profil | CHF 399/Monat |
+**Ein Produkt. Ein Preis. CHF 299/Monat.**
+
+Alles inklusive: Website, Telefonassistentin Lisa (24/7), Dashboard, SMS, Bewertungs-Engine, Mehrsprachig.
 
 - Telefonminuten: pay-per-use, keine Grundgebühr. Typischer Anruf: 2-4 Minuten.
-- Monatlich kündbar, kein Lock-in.
+- 14 Tage kostenlos testen. Monatlich kündbar, kein Lock-in.
 - Setup in einer Woche, persönliches Onboarding. Keine Setup-Kosten während Pilotphase.
+- Spezielle Anforderungen (grössere Betriebe): Auf Anfrage.
 
 Live auf flowsight.ch/pricing.
 
@@ -301,7 +300,7 @@ Phase 5: Delivery      → Nur bei Conversion (Vertrag, Portierung)
 - Branchenspezifisch, nicht generisch
 - All-in-one statt 5 verschiedene Tools
 - In einer Woche live, kein IT-Projekt
-- Ab CHF 199/Monat statt CHF 10'000 einmalig
+- CHF 299/Monat statt CHF 10'000 einmalig
 - Schweizer Nummer, Schweizer Hosting, Deutsch
 
 ---

--- a/docs/gtm/gold_contact.md
+++ b/docs/gtm/gold_contact.md
@@ -11,6 +11,7 @@
 - Kontrollierter Echt-Moment mit Endkunden: ja, aber erst nach E2E + Selbsttest
 - Zwei Profile: Meister (2-8 Mann) / Betrieb (8-30 Mann), Prospect Card als Router
 - Ebene 1 = maximales Kundenerlebnis. Ebene 2 = Kaufmechanik darunter.
+- **Ein Produkt, ein Preis: CHF 299/Monat.** Kein Paketmodell. Was der Betrieb im Trial erlebt = was er kauft. 14 Tage kostenlos, monatlich kündbar.
 
 ---
 
@@ -352,7 +353,7 @@ Jeder Punkt ist ein sofortiger Abbruch. Der Betrieb testet nicht zweimal.
 |---|-----------|---------------|------------|
 | 1 | **Lisa sagt den falschen Firmennamen** | "Die kennen mich gar nicht." Alles danach kontaminiert. | E2E-Test als Quality Gate. Kein Kontakt bevor CC getestet hat. |
 | 2 | **Lisa gibt falsche Infos** (Preise, Zeiten, Team) | "Erzählt Quatsch über meine Firma." Schlimmer als kein System. | Nur verifizierte Crawl-Daten. Lieber "Das müsste ich prüfen." |
-| 3 | **SMS kommt nicht** | Stärkster WOW-Moment stirbt. "Funktioniert nicht." | SMS-Whitelist. Smoke-Test vor Kontakt. |
+| 3 | **SMS kommt nicht** | Stärkster WOW-Moment stirbt. "Funktioniert nicht." | SMS-Whitelist. `pre_contact_check.mjs` vor jedem Kontakt (automatisiert). |
 | 4 | **Website zeigt 404, fremde Firma, kaputtes Layout** | "Unprofessionell." Sofortiger Abbruch. | Mobile + Desktop QA als Gate. |
 | 5 | **SMS an falsche Nummer** | Datenschutz-Verstoss. Sofort Vertrauensverlust. Potentiell rechtlich. | 3-Tier SMS Routing. Whitelist-Guard. E2E-Test. |
 
@@ -434,7 +435,7 @@ Bei Modus 2 (Web ok, z.B. Weinberger): Anruf + E-Mail. "Ich habe Lisa für Sie g
 - Day 10: Founder ruft an. "Wie war's? Hat Lisa funktioniert?"
 - Natürliche Folgefrage: "Hat Ihre Frau / Ihr Partner es auch gesehen?"
 - Preis nur bei klarem Interesse oder auf direkte Frage.
-- Wenn er fragt: "199 im Monat. Sie bekommen Lisa, SMS, Dashboard — alles was Sie getestet haben."
+- Wenn er fragt: "299 im Monat. Alles, was Sie getestet haben, bleibt aktiv."
 
 ---
 
@@ -489,7 +490,7 @@ Einstieg: "Ich habe für die Jul. Weinberger AG eine eigene Assistentin gebaut �
 - Day 10: Founder ruft den Chef an. "Wie war's? Hat Ihre Bürokraft es auch gesehen?"
 - Natürliche Folgefrage: "Soll ich Ihrer Disponentin kurz zeigen, wie die Übersicht funktioniert?"
 - Wenn Disponentin eingebunden wird und positiv reagiert → fast sicher.
-- Preis: "299 im Monat für den Alltag-Plan. Dashboard, Lisa, SMS, alles drin."
+- Preis: "299 im Monat. Alles, was Sie getestet haben, bleibt aktiv."
 
 ---
 
@@ -512,8 +513,8 @@ Die Prospect Card enthält bereits: Teamgrösse, Kontaktperson, Website-Qualitä
 
 | | Modus 1 (Full) | Modus 2 (Extend) |
 |---|----------------|-------------------|
-| **Meister** | Dörfler AG: Persönlich, vor Ort. "Ich habe Ihnen eine Website + Lisa gebaut." Website + Voice = maximales Geschenk. | Selten — Meister haben meist schwache/keine Website. |
-| **Betrieb** | Möglich, aber unwahrscheinlich — grössere Betriebe haben meist eine Website. | Weinberger AG: E-Mail an Chef. "Ich habe Lisa gebaut." Website als Ergänzung, nicht als Hauptargument. |
+| **Meister** | Dörfler AG: Persönlich, vor Ort. "Ich habe Ihnen eine Website + Lisa gebaut." Website + Voice = maximales Geschenk. | Selten — Meister haben meist schwache/keine Website. Falls doch: Modus 2 (Extend) greift unabhängig vom Profil. |
+| **Betrieb** | Falls kein Web: Modus 1 (Full) greift. Profil bleibt Betrieb. | Weinberger AG: E-Mail an Chef. "Ich habe Lisa gebaut." Website als Ergänzung, nicht als Hauptargument. |
 
 **Fallback:** Im Zweifel → Meister. Lieber zu persönlich als zu formal.
 
@@ -596,7 +597,7 @@ Kein Vertrag. Kein Preis. Kein "Testzeitraum". Keine Feature-Liste. Drei konkret
 | Hochwertig | Personalisierte Website, eigene Nummer | "Hier ist unser Demolink" |
 | Glaubwürdig | "Ich habe das gebaut" (Founder, nicht Marketing) | "Unser Team hat für Sie..." |
 | Sofort erlebbar | "Rufen Sie an. 30 Sekunden." | "Buchen Sie einen Termin." |
-| Risikofrei | Kein Preis, kein Vertrag, kein Setup | "Starter-Paket nur 199/Mo" |
+| Risikofrei | Kein Preis, kein Vertrag, kein Setup | "Nur 299/Mo — welches Paket brauchen Sie?" |
 | Knapp | 3 Elemente: Nummer, Website, Anleitung | Feature-Tabelle, Comparison Chart |
 
 ### Was im Betrieb intern weitergezeigt werden kann
@@ -675,7 +676,7 @@ Betrieb: "Wollen Sie mal einen Abend-Anruf über Lisa laufen lassen? Ihre Dispon
 
 ### Day 10: Der persönliche Anruf
 
-Nicht verkaufen. Fragen.
+Nicht verkaufen. Fragen. *Skalierungs-Hinweis: Ab 5+ parallelen Trials → Day-10-Call standardisieren oder teilautomatisieren. Bis dahin: Founder persönlich.*
 
 Meister:
 > "Herr Dörfler, wie war Ihr Eindruck? Hat Lisa funktioniert? Hat Ihre Frau es gesehen?"
@@ -685,12 +686,12 @@ Betrieb:
 
 **Zuhören.** Dann, nur wenn der Moment stimmt oder er fragt:
 
-> "Die Testnummer ist noch 4 Tage für Sie reserviert. Wenn's passt, aktivieren wir Lisa dauerhaft. Starter-Paket: 199 im Monat."
+> "Die Testnummer ist noch 4 Tage für Sie reserviert. Wenn's passt, aktivieren wir Lisa dauerhaft. 299 im Monat — alles bleibt."
 
 ### Wann Preis, wer bringt es zur Sprache
 
 - **Betrieb fragt direkt** ("Was kostet das?") → Sofort antworten. Klar, kurz, keine Verhandlung.
-- **Betrieb fragt nicht** → Founder bringt es beiläufig ein: "Wenn Sie Lisa behalten möchten: 199/Mo, alles inklusive was Sie getestet haben."
+- **Betrieb fragt nicht** → Founder bringt es beiläufig ein: "Wenn Sie Lisa behalten möchten: 299 im Monat, alles was Sie getestet haben bleibt aktiv."
 - **Nie:** Preis per E-Mail ohne vorheriges Gespräch. Nie: Preisvergleichs-PDF.
 
 ### Day 13: Erinnerung (automatisch)
@@ -741,7 +742,7 @@ Tag 7:  Echter Kundenanruf über Lisa.
 
 Tag 10: Founder ruft an. "Wie war's?"
         → "Das ist das Erste, was funktioniert hat."
-        → "199 im Monat."
+        → "299 im Monat. Alles bleibt."
         → "Machen wir."
 
 Tag 30: Erster echter Fall gelöst. Review-Anfrage. 5 Sterne.

--- a/docs/gtm/operating_model.md
+++ b/docs/gtm/operating_model.md
@@ -140,7 +140,7 @@ Phase 5: Delivery      → Nur bei Conversion (Vertrag, Portierung)
 
 | Schritt | Detail |
 |---------|--------|
-| Vertrag | Founder sendet SaaS-Vertrag (Starter 199/Alltag 299/Wachstum 399) |
+| Vertrag | Founder sendet SaaS-Vertrag (CHF 299/Monat, ein Produkt, alles inklusive) |
 | Nummer | Peoplefone-Portierung oder Weiterleitung auf Twilio-Nummer |
 | Agent | Finalisierung (letzte Anpassungen nach Feedback) |
 | Offboarding Demo | `is_demo` Cases löschen, echte Daten beginnen |

--- a/docs/runbooks/demo_script.md
+++ b/docs/runbooks/demo_script.md
@@ -176,17 +176,16 @@
 
 > "Was kostet das?"
 
-**Preise nennen:**
-- **Starter** (ab CHF 99/Mt.): Website + Wizard + Bestätigungs-E-Mail + persönliches Onboarding
-- **Professional** (ab CHF 249/Mt.): + KI-Telefonassistent Lisa + Ops Dashboard + Foto-Anhänge
-- **Premium** (ab CHF 349/Mt.): + Google Reviews + Morning Report + Prioritäts-Support
+**Preis nennen:**
+- **CHF 299/Monat.** Alles inklusive: Website, Lisa (24/7), Dashboard, SMS, Bewertungen, Mehrsprachig.
+- Kein Paketmodell. Was Sie im Test erlebt haben = was Sie bekommen.
 
 **Zusatz-Infos (bei Nachfrage):**
 - Voice-Minuten: Abrechnung nach Verbrauch, kein Grundpreis für Minuten
 - Setup kostenfrei
 - Monatlich kündbar, keine Bindung
 
-> "Und unser 30-Tage-Versprechen: Wenn Sie nach 30 Tagen nicht mindestens 10 strukturierte Fälle im Dashboard haben und Ihre erste 5-Sterne-Google-Bewertung — ist der gesamte erste Monat kostenfrei. Null Risiko."
+> "14 Tage kostenlos testen. Kein Vertrag. Kein Setup. Was Sie im Test erlebt haben, bleibt danach aktiv — für 299 im Monat. Monatlich kündbar."
 
 ### Min 14–15: Close
 

--- a/docs/runbooks/sales_agent.md
+++ b/docs/runbooks/sales_agent.md
@@ -35,7 +35,7 @@ The Sales Voice Agent handles inbound calls on FlowSight's business number. It a
 
 The agent's knowledge is embedded in the conversation flow prompt (no external KB). Content sources:
 - Marketing website (flowsight.ch)
-- 3-tier pricing: Starter (CHF 99), Professional (CHF 249), Premium (CHF 349)
+- Flat pricing: CHF 299/month, everything included (Website, Lisa 24/7, Dashboard, SMS, Reviews)
 - Key facts: Swiss company, DSGVO-konform, no recordings, monthly cancellation
 
 ## Post-Call Analysis Schema

--- a/docs/sales/pitch_deck.html
+++ b/docs/sales/pitch_deck.html
@@ -477,44 +477,20 @@
   <div class="logo">FlowSight</div>
   <h2 style="margin-top:24px; text-align:center;">Transparente Preise. Kein Risiko.</h2>
 
-  <div class="grid-3" style="margin-top:8px;">
-    <!-- Starter -->
-    <div class="card" style="text-align:center; padding:32px 24px;">
-      <h3 style="font-size:14px; text-transform:uppercase; letter-spacing:1px; opacity:0.6; margin-bottom:16px;">Starter</h3>
-      <div class="price" style="color:var(--white);">CHF 99</div>
-      <div class="price-suffix">pro Monat</div>
-      <ul class="feature-list" style="text-align:left; margin-top:24px;">
-        <li>Professionelle Website</li>
-        <li>Online-Schadenformular</li>
-        <li>E-Mail-Benachrichtigungen</li>
-        <li>Persoenliches Onboarding</li>
-      </ul>
-    </div>
-
-    <!-- Professional -->
+  <div style="max-width:400px; margin:8px auto 0;">
     <div class="card card-highlight" style="text-align:center; padding:32px 24px;">
-      <div class="badge">Beliebteste Wahl</div>
-      <h3 style="font-size:14px; text-transform:uppercase; letter-spacing:1px; color:var(--gold-400); margin-bottom:16px;">Professional</h3>
-      <div class="price" style="color:var(--gold-400);">CHF 249</div>
+      <div class="badge">Alles inklusive</div>
+      <h3 style="font-size:14px; text-transform:uppercase; letter-spacing:1px; color:var(--gold-400); margin-bottom:16px;">FlowSight</h3>
+      <div class="price" style="color:var(--gold-400);">CHF 299</div>
       <div class="price-suffix">pro Monat</div>
       <ul class="feature-list" style="text-align:left; margin-top:24px;">
-        <li>Alles aus Starter</li>
-        <li>KI-Telefonassistentin Lisa</li>
-        <li>Ops Dashboard</li>
-        <li>Terminbestaetigung per E-Mail</li>
-      </ul>
-    </div>
-
-    <!-- Premium -->
-    <div class="card" style="text-align:center; padding:32px 24px;">
-      <h3 style="font-size:14px; text-transform:uppercase; letter-spacing:1px; opacity:0.6; margin-bottom:16px;">Premium</h3>
-      <div class="price" style="color:var(--white);">CHF 349</div>
-      <div class="price-suffix">pro Monat</div>
-      <ul class="feature-list" style="text-align:left; margin-top:24px;">
-        <li>Alles aus Professional</li>
-        <li>Google Review Engine</li>
-        <li>Morgenreport (KPIs)</li>
-        <li>Priority Support</li>
+        <li>Professionelle Website im Firmenlook</li>
+        <li>KI-Telefonassistentin Lisa (24/7)</li>
+        <li>Online-Schadenmeldung in 3 Schritten</li>
+        <li>SMS-Bestaetigung + Foto-Upload</li>
+        <li>Falluebersicht (Dashboard)</li>
+        <li>Google-Bewertungen anfragen</li>
+        <li>Persoenliches Onboarding inklusive</li>
       </ul>
     </div>
   </div>
@@ -526,11 +502,11 @@
     </div>
     <div style="display:flex; align-items:center; gap:8px;">
       <span style="color:var(--gold-400); font-size:18px;">&#10003;</span>
-      <span>Erster Monat gratis</span>
+      <span>14 Tage kostenlos testen</span>
     </div>
     <div style="display:flex; align-items:center; gap:8px;">
       <span style="color:var(--gold-400); font-size:18px;">&#10003;</span>
-      <span>30-Tage-Versprechen</span>
+      <span>Monatlich kuendbar</span>
     </div>
   </div>
   <span class="slide-number">5 / 7</span>
@@ -587,7 +563,7 @@
           </tr>
           <tr>
             <td style="padding:10px 0;">Kosten</td>
-            <td style="padding:10px 16px; color:var(--teal-600); font-weight:700;">ab CHF 99/Mt.</td>
+            <td style="padding:10px 16px; color:var(--teal-600); font-weight:700;">CHF 299/Mt.</td>
             <td style="padding:10px 16px;">CHF 10&apos;000+</td>
             <td style="padding:10px 16px;">Unberechenbar</td>
           </tr>

--- a/scripts/_ops/pre_contact_check.mjs
+++ b/scripts/_ops/pre_contact_check.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * Pre-Contact Quality Gate — verifies everything a prospect will see.
+ *
+ * Maps to §14 Pflichtbestandteile-Checkliste (gold_contact.md).
+ * Prevents the 5 "Vertrauensbruch" Kill-Points.
+ *
+ * Usage:
+ *   node --env-file=src/web/.env.local scripts/_ops/pre_contact_check.mjs --slug=weinberger-ag
+ */
+
+import { createRequire } from "node:module";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const { createClient } = require("../../src/web/node_modules/@supabase/supabase-js/dist/index.cjs");
+
+// ── Parse args ──────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+function getArg(name) {
+  const prefix = `--${name}=`;
+  const arg = args.find((a) => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : undefined;
+}
+
+const slug = getArg("slug");
+if (!slug) {
+  console.error(`
+Usage:
+  node --env-file=src/web/.env.local scripts/_ops/pre_contact_check.mjs --slug=weinberger-ag
+`);
+  process.exit(1);
+}
+
+// ── ENV ─────────────────────────────────────────────────────────────────────
+const supaUrl = process.env.SUPABASE_URL;
+const supaKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!supaUrl || !supaKey) {
+  console.error("FATAL: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set.");
+  process.exit(1);
+}
+
+const supabase = createClient(supaUrl, supaKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const appUrl =
+  process.env.APP_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  "https://flowsight-mvp.vercel.app";
+
+// ── Report state ────────────────────────────────────────────────────────────
+const checks = [];
+
+function pass(name, detail) {
+  checks.push({ status: "pass", name, detail });
+  console.log(`  ✅  ${name} — ${detail}`);
+}
+function fail(name, detail) {
+  checks.push({ status: "fail", name, detail });
+  console.log(`  ❌  ${name} — ${detail}`);
+}
+function warn(name, detail) {
+  checks.push({ status: "warn", name, detail });
+  console.log(`  ⚠️  ${name} — ${detail}`);
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+async function main() {
+  console.log("=".repeat(60));
+  console.log("  FlowSight — Pre-Contact Quality Gate");
+  console.log("=".repeat(60));
+  console.log(`  Slug: ${slug}`);
+  console.log(`  Date: ${new Date().toISOString().slice(0, 10)}`);
+  console.log();
+
+  // ── 0. Resolve tenant ─────────────────────────────────────────────────
+  const { data: tenant, error: tenantErr } = await supabase
+    .from("tenants")
+    .select("id, slug, name, modules")
+    .eq("slug", slug)
+    .single();
+
+  if (tenantErr || !tenant) {
+    console.error(`  FATAL: Tenant '${slug}' not found in Supabase.`);
+    process.exit(1);
+  }
+  console.log(`  Tenant: ${tenant.name} (${tenant.id})\n`);
+
+  // ── 1. Website 200 OK ────────────────────────────────────────────────
+  const websiteUrl = `${appUrl}/kunden/${slug}`;
+  try {
+    const r = await fetch(websiteUrl, { signal: AbortSignal.timeout(10000) });
+    if (r.ok) {
+      pass("Website", `${websiteUrl} → ${r.status}`);
+    } else {
+      fail("Website", `${websiteUrl} → ${r.status}`);
+    }
+  } catch (e) {
+    fail("Website", `${websiteUrl} → ${e.message}`);
+  }
+
+  // ── 2. Wizard 200 OK ─────────────────────────────────────────────────
+  const wizardUrl = `${appUrl}/kunden/${slug}/meldung`;
+  try {
+    const r = await fetch(wizardUrl, { signal: AbortSignal.timeout(10000) });
+    if (r.ok) {
+      pass("Wizard", `${wizardUrl} → ${r.status}`);
+    } else {
+      fail("Wizard", `${wizardUrl} → ${r.status}`);
+    }
+  } catch (e) {
+    fail("Wizard", `${wizardUrl} → ${e.message}`);
+  }
+
+  // ── 3. SMS Config ────────────────────────────────────────────────────
+  const modules = tenant.modules || {};
+  if (modules.sms === true && modules.sms_sender_name) {
+    pass("SMS Config", `sms=true, sender="${modules.sms_sender_name}"`);
+  } else if (modules.sms === true && !modules.sms_sender_name) {
+    fail("SMS Config", "sms=true but sms_sender_name is missing");
+  } else {
+    fail("SMS Config", "sms module not enabled");
+  }
+
+  // ── 4. Voice Agent Published (config check) ──────────────────────────
+  const agentIdsPath = resolve("retell/agent_ids.json");
+  try {
+    const agentIds = JSON.parse(readFileSync(agentIdsPath, "utf-8"));
+    const entry = agentIds[slug];
+    if (entry && entry.de_agent_id) {
+      pass("Voice Agent", `de_agent_id=${entry.de_agent_id.slice(0, 20)}…`);
+    } else {
+      fail("Voice Agent", `No entry for '${slug}' in agent_ids.json`);
+    }
+  } catch (e) {
+    fail("Voice Agent", `Cannot read agent_ids.json: ${e.message}`);
+  }
+
+  // ── 5. Phone Number Assigned ─────────────────────────────────────────
+  const { data: numbers, error: numErr } = await supabase
+    .from("tenant_numbers")
+    .select("phone_number, active")
+    .eq("tenant_id", tenant.id);
+
+  if (numErr) {
+    fail("Phone Number", `Query error: ${numErr.message}`);
+  } else if (!numbers || numbers.length === 0) {
+    fail("Phone Number", "No phone number assigned");
+  } else {
+    const active = numbers.filter((n) => n.active);
+    if (active.length > 0) {
+      pass("Phone Number", `${active.length} active: ${active.map((n) => n.phone_number).join(", ")}`);
+    } else {
+      fail("Phone Number", `${numbers.length} number(s) found but none active`);
+    }
+  }
+
+  // ── 6. Demo Cases Count ──────────────────────────────────────────────
+  const { count: caseCount, error: caseErr } = await supabase
+    .from("cases")
+    .select("id", { count: "exact", head: true })
+    .eq("tenant_id", tenant.id);
+
+  if (caseErr) {
+    fail("Demo Cases", `Query error: ${caseErr.message}`);
+  } else {
+    // Load prospect_card.json for team_size heuristic
+    let recommendation = "";
+    const cardPath = resolve(`docs/customers/${slug}/prospect_card.json`);
+    try {
+      if (existsSync(cardPath)) {
+        const card = JSON.parse(readFileSync(cardPath, "utf-8"));
+        const teamSize = card.company?.employees_estimate || card.team?.length || null;
+        if (teamSize && teamSize <= 8) {
+          recommendation = ` (Meister-Betrieb ≤8 → 0-2 OK)`;
+        } else if (teamSize && teamSize > 8) {
+          recommendation = ` (Betrieb >8 → recommend 3-5)`;
+        }
+      }
+    } catch { /* skip */ }
+
+    if (caseCount > 0) {
+      pass("Demo Cases", `${caseCount} cases${recommendation}`);
+    } else {
+      warn("Demo Cases", `0 cases — consider seeding demo data${recommendation}`);
+    }
+  }
+
+  // ── 7. Magic Link ────────────────────────────────────────────────────
+  const { data: accessRows, error: accessErr } = await supabase
+    .from("prospect_access")
+    .select("id, magic_token")
+    .eq("tenant_id", tenant.id);
+
+  if (accessErr) {
+    // prospect_access table might not exist — treat as warning
+    warn("Magic Link", `Query error: ${accessErr.message}`);
+  } else if (!accessRows || accessRows.length === 0) {
+    fail("Magic Link", "No prospect_access row found");
+  } else {
+    const withToken = accessRows.filter((r) => r.magic_token);
+    if (withToken.length > 0) {
+      pass("Magic Link", `${withToken.length} magic token(s) found`);
+    } else {
+      fail("Magic Link", "prospect_access row exists but magic_token is null");
+    }
+  }
+
+  // ── 8. Review URL ────────────────────────────────────────────────────
+  if (modules.google_review_url) {
+    pass("Review URL", modules.google_review_url.slice(0, 60) + "…");
+  } else {
+    fail("Review URL", "modules.google_review_url not set");
+  }
+
+  // ── 9. Links Page ────────────────────────────────────────────────────
+  const linksPath = resolve(`docs/customers/${slug}/links.md`);
+  if (existsSync(linksPath)) {
+    pass("Links Page", linksPath);
+  } else {
+    fail("Links Page", `Missing: docs/customers/${slug}/links.md`);
+  }
+
+  // ── Verdict ───────────────────────────────────────────────────────────
+  const fails = checks.filter((c) => c.status === "fail").length;
+  const warns = checks.filter((c) => c.status === "warn").length;
+
+  console.log(`\n${"=".repeat(60)}`);
+  if (fails > 0) {
+    console.log(`  ❌  NO-GO  —  ${fails} check(s) failed, ${warns} warning(s)`);
+    console.log("=".repeat(60));
+    console.log("\n  Fix the ❌ items above before contacting the prospect.\n");
+    process.exitCode = 1;
+  } else if (warns > 0) {
+    console.log(`  ⚠️  GO (with ${warns} warning(s))`);
+    console.log("=".repeat(60));
+    console.log("\n  All critical checks passed. Review ⚠️ items above.\n");
+  } else {
+    console.log("  ✅  GO  —  All checks passed");
+    console.log("=".repeat(60));
+    console.log("\n  Ready to contact the prospect.\n");
+  }
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});

--- a/src/web/app/(marketing)/page.tsx
+++ b/src/web/app/(marketing)/page.tsx
@@ -404,63 +404,30 @@ export default function HomePage() {
             </p>
           </div>
 
-          <div className="mx-auto mt-16 grid max-w-5xl gap-6 lg:grid-cols-3">
-            {/* Starter */}
-            <div className="rounded-2xl border border-navy-200 bg-white p-8 shadow-sm transition-shadow hover:shadow-md">
-              <p className="text-sm font-semibold uppercase tracking-wider text-navy-400">
-                Starter
+          <div className="mx-auto mt-16 max-w-xl">
+            <div className="relative rounded-2xl border-2 border-gold-500 bg-white p-8 shadow-md">
+              <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-gold-500 px-4 py-1 text-xs font-bold uppercase tracking-wider text-navy-950">
+                Alles inklusive
+              </span>
+              <p className="text-sm font-semibold uppercase tracking-wider text-gold-600">
+                FlowSight
               </p>
               <p className="mt-4">
-                <span className="text-3xl font-bold text-navy-900">CHF 199</span>
+                <span className="text-4xl font-bold text-navy-900">CHF 299</span>
                 <span className="ml-1 text-base text-navy-400">/ Monat</span>
               </p>
               <p className="mt-2 text-sm text-navy-900/70">
-                Website + Online-Schadenmeldung
+                Website, Telefonassistentin, Dashboard, SMS, Bewertungen — ein Preis für alles.
               </p>
               <ul className="mt-6 space-y-3">
                 {[
                   "Moderne Website im Firmenlook (mobiloptimiert)",
                   "Online-Schadenmeldung in 3 Schritten",
-                  "Betriebsinfo per E-Mail bei neuer Meldung",
-                  "Kunden-SMS: Bestätigung + Foto-Upload-Link",
-                  "Persönliches Onboarding & Setup inklusive",
-                ].map((f) => (
-                  <li key={f} className="flex items-start gap-2 text-sm text-navy-900/70">
-                    <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-gold-500" />
-                    {f}
-                  </li>
-                ))}
-              </ul>
-              <Link
-                href="/demo"
-                className="mt-8 block w-full rounded-lg border border-navy-200 py-3 text-center text-sm font-semibold text-navy-900 transition-colors hover:bg-navy-50"
-              >
-                Demo vereinbaren
-              </Link>
-            </div>
-
-            {/* Alltag — highlighted */}
-            <div className="relative rounded-2xl border-2 border-gold-500 bg-white p-8 shadow-md">
-              <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-gold-500 px-4 py-1 text-xs font-bold uppercase tracking-wider text-navy-950">
-                Beliebt
-              </span>
-              <p className="text-sm font-semibold uppercase tracking-wider text-gold-600">
-                Alltag
-              </p>
-              <p className="mt-4">
-                <span className="text-3xl font-bold text-navy-900">CHF 299</span>
-                <span className="ml-1 text-base text-navy-400">/ Monat</span>
-              </p>
-              <p className="mt-2 text-sm text-navy-900/70">
-                Telefonassistentin + Fallübersicht
-              </p>
-              <ul className="mt-6 space-y-3">
-                {[
-                  "Alles aus Starter, plus:",
-                  "Digitale Telefonassistentin (24/7, nach Wunsch konfigurierbar)",
+                  "Digitale Telefonassistentin Lisa (24/7, mehrsprachig)",
+                  "Bestätigungs-SMS + Foto-Upload für Ihre Kunden",
                   "Fallübersicht: alle Meldungen an einem Ort",
-                  "Bestätigungs-SMS + Foto-Upload (weniger Rückfragen)",
-                  "Mehrsprachig (DE/EN/FR/IT)",
+                  "Google-Bewertungen gezielt anfragen",
+                  "Persönliches Onboarding & Setup inklusive",
                 ].map((f) => (
                   <li key={f} className="flex items-start gap-2 text-sm text-navy-900/70">
                     <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-gold-500" />
@@ -472,47 +439,13 @@ export default function HomePage() {
                 href="/demo"
                 className="mt-8 block w-full rounded-lg bg-gold-500 py-3 text-center text-sm font-semibold text-navy-950 transition-all hover:bg-gold-400 hover:shadow-lg hover:shadow-gold-500/20"
               >
-                Demo vereinbaren
-              </Link>
-            </div>
-
-            {/* Wachstum */}
-            <div className="rounded-2xl border border-navy-200 bg-white p-8 shadow-sm transition-shadow hover:shadow-md">
-              <p className="text-sm font-semibold uppercase tracking-wider text-navy-400">
-                Wachstum
-              </p>
-              <p className="mt-4">
-                <span className="text-3xl font-bold text-navy-900">CHF 399</span>
-                <span className="ml-1 text-base text-navy-400">/ Monat</span>
-              </p>
-              <p className="mt-2 text-sm text-navy-900/70">
-                Alltag + Bewertungen & Priorität
-              </p>
-              <ul className="mt-6 space-y-3">
-                {[
-                  "Alles aus Alltag, plus:",
-                  "Google-Bewertungen gezielt anfragen",
-                  "Prioritäts-Support (schnellere Reaktion)",
-                  "Bewertungen zum richtigen Zeitpunkt auslösen",
-                  "Stärkeres Google-Profil — mehr Anfragen aus der Region",
-                ].map((f) => (
-                  <li key={f} className="flex items-start gap-2 text-sm text-navy-900/70">
-                    <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-gold-500" />
-                    {f}
-                  </li>
-                ))}
-              </ul>
-              <Link
-                href="/demo"
-                className="mt-8 block w-full rounded-lg border border-navy-200 py-3 text-center text-sm font-semibold text-navy-900 transition-colors hover:bg-navy-50"
-              >
-                Demo vereinbaren
+                14 Tage kostenlos testen
               </Link>
             </div>
           </div>
 
-          <p className="mt-8 text-center text-sm font-medium italic text-navy-900/60">
-            Setup kostenfrei · Erster Monat gratis · 30-Tage-Versprechen
+          <p className="mt-6 text-center text-sm font-medium italic text-navy-900/60">
+            Setup kostenfrei · 14 Tage kostenlos · Monatlich kündbar
           </p>
 
           <p className="mt-4 text-center">
@@ -520,7 +453,7 @@ export default function HomePage() {
               href="/pricing"
               className="text-sm font-semibold text-gold-600 transition-colors hover:text-gold-500"
             >
-              Alle Details zu den Preisen &rarr;
+              Alle Details zum Preis &rarr;
             </Link>
           </p>
 
@@ -530,7 +463,7 @@ export default function HomePage() {
               Testen Sie FlowSight — ohne Risiko.
             </h3>
             <p className="mt-2 text-base font-semibold text-gold-600">
-              Setup kostenfrei. Erster Monat gratis.
+              14 Tage kostenlos. Setup inklusive.
             </p>
             <p className="mx-auto mt-4 max-w-xl text-sm leading-relaxed text-navy-900/70">
               Unser Versprechen: Wenn Sie nach 30&nbsp;Tagen nicht mindestens
@@ -559,7 +492,7 @@ export default function HomePage() {
             {[
               {
                 q: "Bekomme ich auch eine Website?",
-                a: "Ja — im Starter-Paket ist eine moderne, mobil-optimierte Website im Firmenlook enthalten. In einer Woche live.",
+                a: "Ja — eine moderne, mobil-optimierte Website im Firmenlook ist inklusive. In einer Woche live.",
               },
               {
                 q: "Brauche ich technisches Wissen?",

--- a/src/web/app/(marketing)/pricing/page.tsx
+++ b/src/web/app/(marketing)/pricing/page.tsx
@@ -14,46 +14,15 @@ function CheckIcon({ className = "h-5 w-5" }: { className?: string }) {
   );
 }
 
-const TIERS = [
-  {
-    name: "Starter",
-    price: "CHF 199",
-    subtitle: "Website + Online-Schadenmeldung",
-    highlighted: false,
-    features: [
-      "Moderne Website im Firmenlook (mobiloptimiert)",
-      "Online-Schadenmeldung in 3 Schritten",
-      "Betriebsinfo per E-Mail bei neuer Meldung",
-      "Kunden-SMS: Bestätigung + Foto-Upload-Link",
-      "Persönliches Onboarding & Setup inklusive",
-    ],
-  },
-  {
-    name: "Alltag",
-    price: "CHF 299",
-    subtitle: "Telefonassistentin + Fallübersicht",
-    highlighted: true,
-    features: [
-      "Alles aus Starter, plus:",
-      "Digitale Telefonassistentin (24/7, nach Wunsch konfigurierbar)",
-      "Fallübersicht: alle Meldungen an einem Ort",
-      "Bestätigungs-SMS + Foto-Upload (weniger Rückfragen)",
-      "Mehrsprachig (DE/EN/FR/IT)",
-    ],
-  },
-  {
-    name: "Wachstum",
-    price: "CHF 399",
-    subtitle: "Alltag + Bewertungen & Priorität",
-    highlighted: false,
-    features: [
-      "Alles aus Alltag, plus:",
-      "Google-Bewertungen gezielt anfragen",
-      "Prioritäts-Support (schnellere Reaktion)",
-      "Bewertungen zum richtigen Zeitpunkt auslösen",
-      "Stärkeres Google-Profil — mehr Anfragen aus der Region",
-    ],
-  },
+const FEATURES = [
+  "Moderne Website im Firmenlook (mobiloptimiert)",
+  "Online-Schadenmeldung in 3 Schritten",
+  "Digitale Telefonassistentin Lisa (24/7, mehrsprachig)",
+  "Bestätigungs-SMS + Foto-Upload für Ihre Kunden",
+  "Fallübersicht: alle Meldungen an einem Ort",
+  "E-Mail-Benachrichtigung bei jeder neuen Meldung",
+  "Google-Bewertungen gezielt anfragen",
+  "Persönliches Onboarding & Setup inklusive",
 ] as const;
 
 export default function PricingPage() {
@@ -72,65 +41,52 @@ export default function PricingPage() {
         </div>
       </section>
 
-      {/* ── 3 Pricing cards ─────────────────────────────── */}
+      {/* ── Single pricing card ─────────────────────────── */}
       <section className="bg-navy-50 py-16 lg:py-24">
-        <div className="mx-auto max-w-6xl px-6 lg:px-8">
-          <div className="grid gap-6 lg:grid-cols-3">
-            {TIERS.map((tier) => (
-              <div
-                key={tier.name}
-                className={`relative rounded-2xl bg-white p-8 shadow-sm ${
-                  tier.highlighted
-                    ? "border-2 border-gold-500 shadow-md"
-                    : "border border-navy-200"
-                }`}
-              >
-                {tier.highlighted && (
-                  <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-gold-500 px-4 py-1 text-xs font-bold uppercase tracking-wider text-navy-950">
-                    Beliebt
-                  </span>
-                )}
+        <div className="mx-auto max-w-xl px-6 lg:px-8">
+          <div className="relative rounded-2xl border-2 border-gold-500 bg-white p-8 shadow-md">
+            <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-gold-500 px-4 py-1 text-xs font-bold uppercase tracking-wider text-navy-950">
+              Alles inklusive
+            </span>
 
-                <p
-                  className={`text-sm font-semibold uppercase tracking-wider ${
-                    tier.highlighted ? "text-gold-600" : "text-navy-400"
-                  }`}
+            <p className="text-sm font-semibold uppercase tracking-wider text-gold-600">
+              FlowSight
+            </p>
+            <p className="mt-4">
+              <span className="text-4xl font-bold text-navy-900">CHF 299</span>
+              <span className="ml-1 text-base text-navy-400">/ Monat</span>
+            </p>
+            <p className="mt-2 text-sm text-navy-900/70">
+              Website, Telefonassistentin, Dashboard, SMS, Bewertungen — ein Preis für alles.
+            </p>
+
+            <ul className="mt-8 space-y-3">
+              {FEATURES.map((f) => (
+                <li
+                  key={f}
+                  className="flex items-start gap-2 text-sm text-navy-900/80"
                 >
-                  {tier.name}
-                </p>
-                <p className="mt-4">
-                  <span className="text-3xl font-bold text-navy-900">
-                    {tier.price}
-                  </span>
-                  <span className="ml-1 text-base text-navy-400">/ Monat</span>
-                </p>
-                <p className="mt-2 text-sm text-navy-900/70">{tier.subtitle}</p>
+                  <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-gold-500" />
+                  {f}
+                </li>
+              ))}
+            </ul>
 
-                <ul className="mt-8 space-y-3">
-                  {tier.features.map((f) => (
-                    <li
-                      key={f}
-                      className="flex items-start gap-2 text-sm text-navy-900/80"
-                    >
-                      <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-gold-500" />
-                      {f}
-                    </li>
-                  ))}
-                </ul>
-
-                <Link
-                  href="/demo"
-                  className={`mt-8 block w-full rounded-lg py-3.5 text-center text-sm font-semibold transition-all ${
-                    tier.highlighted
-                      ? "bg-gold-500 text-navy-950 hover:bg-gold-400 hover:shadow-lg hover:shadow-gold-500/20"
-                      : "border border-navy-200 text-navy-900 hover:bg-navy-50"
-                  }`}
-                >
-                  Demo vereinbaren
-                </Link>
-              </div>
-            ))}
+            <Link
+              href="/demo"
+              className="mt-8 block w-full rounded-lg bg-gold-500 py-3.5 text-center text-sm font-semibold text-navy-950 transition-all hover:bg-gold-400 hover:shadow-lg hover:shadow-gold-500/20"
+            >
+              14 Tage kostenlos testen
+            </Link>
           </div>
+
+          <p className="mt-6 text-center text-sm text-navy-400">
+            Ihr Betrieb hat spezielle Anforderungen?{" "}
+            <Link href="/demo" className="font-semibold text-gold-600 hover:text-gold-500">
+              Schreiben Sie uns
+            </Link>{" "}
+            — wir finden eine passende Lösung.
+          </p>
         </div>
       </section>
 
@@ -178,12 +134,12 @@ export default function PricingPage() {
           <div className="mt-10 divide-y divide-navy-200/60">
             {[
               {
-                q: "Kann ich später upgraden?",
-                a: "Ja, jederzeit. Sie starten z.B. mit Starter und fügen Voice und Dashboard hinzu, sobald Sie bereit sind.",
+                q: "Was ist alles enthalten?",
+                a: "Alles: Website, Telefonassistentin Lisa (24/7), Dashboard, SMS-Bestätigungen, Bewertungs-Engine, Mehrsprachig — ein Preis, keine versteckten Extras.",
               },
               {
                 q: "Gibt es eine Mindestlaufzeit?",
-                a: "Nein. Alle Pakete sind monatlich kündbar — ohne Bindung.",
+                a: "Nein. Monatlich kündbar — ohne Bindung.",
               },
               {
                 q: "Was kostet die Einrichtung?",

--- a/src/web/app/handout/[id]/page.tsx
+++ b/src/web/app/handout/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { HANDOUTS, PACKAGES, type HandoutData } from "@/src/lib/marketing/handouts";
+import { HANDOUTS, PRODUCT, type HandoutData } from "@/src/lib/marketing/handouts";
 import { SITE } from "@/src/lib/marketing/constants";
 import { generateQrSvg } from "@/src/lib/marketing/qr";
 import { PrintButton } from "./PrintButton";
@@ -154,49 +154,36 @@ export default async function HandoutPage({
           </div>
         </section>
 
-        {/* ━━━ PAKETE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */}
+        {/* ━━━ PREIS ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */}
         <section className="mt-5">
           <h2 className="text-[10px] font-bold uppercase tracking-[0.15em] text-navy-400">
-            Pakete & Preise
+            Preis
           </h2>
-          <div className="mt-2.5 grid grid-cols-3 gap-2.5">
-            {PACKAGES.map((pkg) => {
-              const isRec = pkg.id === data.recommendedPackage;
-              return (
-                <div
-                  key={pkg.id}
-                  className={`rounded-xl p-3.5 ${
-                    isRec
-                      ? "border-2 border-gold-500 bg-gold-100/30 shadow-sm"
-                      : "border border-navy-200"
-                  }`}
-                >
-                  <div className="flex items-center justify-between">
-                    <p className={`text-[10px] font-bold uppercase tracking-wider ${isRec ? "text-gold-600" : "text-navy-400"}`}>
-                      {pkg.name}
-                    </p>
-                    {isRec && (
-                      <span className="rounded-full bg-gold-500 px-1.5 py-0.5 text-[8px] font-bold uppercase text-navy-950">
-                        Empfohlen
-                      </span>
-                    )}
-                  </div>
-                  <p className="mt-1 text-base font-bold">
-                    {pkg.price}
-                    <span className="text-[10px] font-normal text-navy-400"> / Mt.</span>
-                  </p>
-                  <p className="text-[10px] text-navy-400">{pkg.subtitle}</p>
-                  <ul className="mt-2 space-y-0.5">
-                    {pkg.features.map((f) => (
-                      <li key={f} className="flex items-start gap-1 text-[10px] leading-snug text-navy-900/80">
-                        <Check />
-                        <span>{f}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              );
-            })}
+          <div className="mt-2.5">
+            <div className="rounded-xl border-2 border-gold-500 bg-gold-100/30 p-3.5 shadow-sm">
+              <div className="flex items-center justify-between">
+                <p className="text-[10px] font-bold uppercase tracking-wider text-gold-600">
+                  {PRODUCT.name}
+                </p>
+                <span className="rounded-full bg-gold-500 px-1.5 py-0.5 text-[8px] font-bold uppercase text-navy-950">
+                  Alles inklusive
+                </span>
+              </div>
+              <p className="mt-1 text-base font-bold">
+                {PRODUCT.price}
+                <span className="text-[10px] font-normal text-navy-400"> / Mt.</span>
+              </p>
+              <p className="text-[10px] text-navy-400">{PRODUCT.subtitle}</p>
+              <ul className="mt-2 space-y-0.5">
+                {PRODUCT.features.map((f) => (
+                  <li key={f} className="flex items-start gap-1 text-[10px] leading-snug text-navy-900/80">
+                    <Check />
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-2 text-[10px] text-navy-400">14 Tage kostenlos testen · Monatlich kündbar</p>
+            </div>
           </div>
         </section>
 

--- a/src/web/src/lib/marketing/handouts.ts
+++ b/src/web/src/lib/marketing/handouts.ts
@@ -11,7 +11,6 @@ export interface HandoutData {
   location: string;
   contactName: string;
   demoDate: string; // ISO date string, e.g. "2026-03-05"
-  recommendedPackage: "starter" | "alltag" | "wachstum";
   recommendationReason: string;
   demoWebsiteUrl?: string;
   wizardUrl?: string;
@@ -25,7 +24,6 @@ export const HANDOUTS: Record<string, HandoutData> = {
     location: "Oberrieden",
     contactName: "Herr Dörfler",
     demoDate: "2026-03-05",
-    recommendedPackage: "alltag",
     recommendationReason:
       "Viele Anrufe ausserhalb der Bürozeiten — die Telefonassistentin fängt diese ab und erstellt strukturierte Fälle.",
     demoWebsiteUrl: "https://flowsight.ch/doerfler-ag",
@@ -33,45 +31,17 @@ export const HANDOUTS: Record<string, HandoutData> = {
   },
 };
 
-export const PACKAGES = [
-  {
-    id: "starter" as const,
-    name: "Starter",
-    price: "CHF 199",
-    subtitle: "Website + Online-Schadenmeldung",
-    features: [
-      "Moderne Website im Firmenlook (mobiloptimiert)",
-      "Online-Schadenmeldung in 3 Schritten",
-      "Betriebsinfo per E-Mail bei neuer Meldung",
-      "Kunden-SMS: Bestätigung + Foto-Upload-Link",
-      "Persönliches Onboarding & Setup inklusive",
-    ],
-  },
-  {
-    id: "alltag" as const,
-    name: "Alltag",
-    price: "CHF 299",
-    subtitle: "Telefonassistentin + Fallübersicht",
-    highlighted: true,
-    features: [
-      "Alles aus Starter, plus:",
-      "Digitale Telefonassistentin (24/7, konfigurierbar)",
-      "Fallübersicht: alle Meldungen an einem Ort",
-      "Bestätigungs-SMS + Foto-Upload (weniger Rückfragen)",
-      "Mehrsprachig (DE / EN / FR / IT)",
-    ],
-  },
-  {
-    id: "wachstum" as const,
-    name: "Wachstum",
-    price: "CHF 399",
-    subtitle: "Bewertungen & Priorität",
-    features: [
-      "Alles aus Alltag, plus:",
-      "Google-Bewertungen gezielt anfragen",
-      "Bewertungen zum richtigen Zeitpunkt auslösen",
-      "Stärkeres Google-Profil — mehr Anfragen aus der Region",
-      "Prioritäts-Support (schnellere Reaktion)",
-    ],
-  },
-] as const;
+export const PRODUCT = {
+  name: "FlowSight",
+  price: "CHF 299",
+  subtitle: "Website, Telefonassistentin, Dashboard, SMS, Bewertungen — alles inklusive.",
+  features: [
+    "Moderne Website im Firmenlook (mobiloptimiert)",
+    "Online-Schadenmeldung in 3 Schritten",
+    "Digitale Telefonassistentin Lisa (24/7, mehrsprachig)",
+    "Bestätigungs-SMS + Foto-Upload für Ihre Kunden",
+    "Fallübersicht: alle Meldungen an einem Ort",
+    "Google-Bewertungen gezielt anfragen",
+    "Persönliches Onboarding & Setup inklusive",
+  ],
+} as const;


### PR DESCRIPTION
## Summary
- **Pricing:** Replace 3-tier Starter/Alltag/Wachstum with single product at CHF 299/month — aligned with gold_contact (business tests one system, buys one system)
- **Pre-Contact Check:** New `pre_contact_check.mjs` script — 9 automated checks mapping to §14 Pflichtbestandteile, GO/NO-GO verdict before any prospect contact
- **Docs:** All pricing references updated across 8 docs (gold_contact, operating_model, business_briefing, demo_script, sales_agent, pitch_deck, LinkedIn brief, STATUS)

## What changed
| Area | Before | After |
|------|--------|-------|
| Pricing page | 3-column grid (199/299/399) | Single centered card (299) |
| Homepage | 3-column pricing teaser | Single card + "Alles inklusive" |
| Handout page | 3 packages with "Empfohlen" | Single product card |
| gold_contact | Mixed 199/299 references | Consistent 299 flat |
| Trial | "30 Tage" / "Erster Monat gratis" | "14 Tage kostenlos" |

## Still pending (separate PR)
- [ ] Sales Voice Agent (Lisa) Retell config — needs prompt update + retell_sync
- [ ] Homepage guarantee section text refinement

## Test plan
- [x] `next build` passes
- [ ] Pricing page renders single card
- [ ] Homepage pricing section renders single card
- [ ] Handout page renders correctly
- [ ] `pre_contact_check.mjs --slug=weinberger-ag` runs with valid env

🤖 Generated with [Claude Code](https://claude.com/claude-code)