### PR TITLE
feat: Lisa Sales → Interest Capture Agent

### DIFF
--- a/docs/OPS_BOARD.md
+++ b/docs/OPS_BOARD.md
@@ -1,6 +1,6 @@
 # OPS Board — FlowSight Roadmap (SSOT)
 
-**Updated:** 2026-03-11 (PR #148: Demo→Test Flow)
+**Updated:** 2026-03-11 (PR #150: Lisa Interest Capture)
 **Rule:** CC updates with every deliverable. Founder reviews weekly.
 **Einziger Task-Tracker.** Alle offenen Tasks leben hier.
 
@@ -107,9 +107,10 @@
 | S2 | Scout v2 — ICP Scoring + Multi-Query | CC | **DONE** ✅ |
 | S3 | E-Mail-Vorlage + Anruf-Skript ready | CC | **DONE** ✅ |
 | S5 | BigBen Pub — Paul Follow-up | Founder | OFFEN — Paul interessiert (#79/#80) |
-| S6 | Sales Agent Pricing aktualisiert (199/299/399) | CC | **VERALTET** — muss auf 299 flat umgestellt werden |
+| S6 | ~~Sales Agent Pricing (199/299/399)~~ → **Ersetzt durch S9** | CC | N/A |
 | S7 | **Demo→Test Flow** — "Kostenlos testen" statt "Demo buchen" | CC | **DONE** ✅ (PR #148) |
 | S8 | **299 Flat Pricing** — Ein Produkt, alle Docs aligned | CC | **DONE** ✅ (PR #147) |
+| S9 | **Lisa Interest Capture** — Sales Agent → Erreichbarkeits-Netz, Gold-Contact-aligned | CC | **DONE** ✅ (PR #150) |
 | G10 | GTM SSOT Docs (Plan v2 + Tracker) | CC | **DONE** ✅ |
 | G9a | Weinberger Website (Leckerli D) | CC | **DONE** ✅ (PR #116) |
 | G9b | Weinberger Lisa (Leckerli B-Full) | CC | **DONE** ✅ (PR #118) |
@@ -203,6 +204,7 @@
 | 2026-03-11 | Gold Contact — Nordstern-Dokument (Kaufmodell, Profile, Journey, Architektur) | PR #145 |
 | 2026-03-11 | 299 Flat Pricing — Ein Produkt, ein Preis. 3-Tier eliminiert. Pre-Contact Quality Gate | PR #147 |
 | 2026-03-11 | Demo→Test Flow — /testen Page, /demo redirect, DemoForm PLZ+Website, Qualify-SMS | PR #148 |
+| 2026-03-11 | Lisa Interest Capture — Sales Agent → Erreichbarkeits-Netz. Kein Pricing/Pitch/Demo-Buchen. Founder-Rückruf. Gold-Contact-aligned. | PR #150 |
 
 **Ältere Completed (vor 04.03.):** Siehe `docs/archive/wave_log.md`
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # FlowSight — STATUS (Company SSOT)
 
-**Datum:** 2026-03-11 (PR #148: Demo→Test Flow — "Kostenlos testen" statt "Demo buchen")
+**Datum:** 2026-03-11 (PR #150: Lisa Interest Capture — Sales Agent → Erreichbarkeits-Netz)
 **Owner:** Founder + CC (Head Ops)
 
 ## Was ist FlowSight?
@@ -31,7 +31,7 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 | **Peoplefone Front Door** | LIVE ✅ | Brand-Nr → Twilio → SIP → Retell |
 | **Morning Report** | LIVE ✅ | 15 KPIs + Trial Status + Deep Health, GH Actions Cron (daily 07:30 UTC), Telegram + E-Mail (RED/YELLOW) |
 | **Marketing Website** | LIVE ✅ | flowsight.ch (homepage, pricing, /testen — "Kostenlos testen" flow) |
-| **Sales Voice Agent** | LIVE ✅ | "Lisa" auf 044 552 09 19 (Pricing-Update auf 299 flat ausstehend) |
+| **Interest Capture Agent** | LIVE ✅ | "Lisa" auf 044 552 09 19 — Interest Capture (kein Pricing, kein Pitch, Founder-Rückruf) |
 | **Customer Websites** | LIVE ✅ | /kunden/[slug] — SSG template (12 sections, ServiceDetailOverlay, lightbox, galleries) |
 | **Customer Links Page** | LIVE ✅ | /kunden/[slug]/links — SSG, alle Kunden-URLs auf einen Blick, noindex |
 | **Review Engine** | LIVE ✅ | Manual button, review_sent_at, tenant-scoped GOOGLE_REVIEW_URL, SMS fallback |
@@ -76,8 +76,9 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 - **Gold Contact (11.03.):** PR #145. Nordstern-Dokument für Sales/Trial/Product/Go-Live. 5-Stufen-Kaufmodell, Spiegel-Effekt, 7 WOW-Momente, Meister/Betrieb-Profile, Phase 0-3 Journey mit konkretem High-Touch-Handover.
 - **299 Flat Pricing (11.03.):** PR #147. Ein Produkt, ein Preis: CHF 299/Monat. 3-Tier Packages eliminiert. Pre-Contact Quality Gate (`pre_contact_check.mjs`). Gold Contact + alle Docs aligned.
 - **Demo→Test Flow (11.03.):** PR #148. "Demo buchen" → "Kostenlos testen". Neue /testen Page ("Wir bauen Lisa für Ihren Betrieb"), /demo redirect, DemoForm mit PLZ+Website, Qualify-orientierte Bestätigung. Stage 1 von 3.
+- **Lisa Interest Capture (11.03.):** PR #150. Sales Agent → Interest Capture Agent. Kein Pricing, kein Feature-Pitch, kein Demo-Buchen. Stattdessen: warm empfangen, Interesse erfassen, Founder-Rückruf vorbereiten. Gold-Contact-aligned.
 - **BLOCKER:** Keine. Go-Live möglich.
-- **Nächster Schritt:** Sales Voice Agent Lisa Pricing auf 299 flat updaten. Founder-Actions vor Reise — siehe `docs/runbooks/reise_checklist.md`.
+- **Nächster Schritt:** Founder-Actions vor Reise — siehe `docs/runbooks/reise_checklist.md`.
 
 ## Fixe Entscheidungen (No Drift)
 

--- a/docs/runbooks/sales_agent.md
+++ b/docs/runbooks/sales_agent.md
@@ -1,19 +1,28 @@
-# Agent Brief: Sales Voice Agent
+# Agent Brief: Interest Capture Agent (Lisa)
 
-**Date:** 2026-02-26
+**Date:** 2026-03-11
 **Owner:** Head Ops Agent
 **Phone:** 044 552 09 19
+**Role:** Interest Capture — NOT Sales
 
 ## Purpose
 
-The Sales Voice Agent handles inbound calls on FlowSight's business number. It answers questions about FlowSight products, pricing, and features, and helps interested callers book a demo.
+Lisa on 044 552 09 19 is an **Interest Capture Agent**, not a Sales Agent. She warmly receives inbound calls on FlowSight's business number, understands why the caller is reaching out, captures name/company/callback preference, and prepares a personal founder callback.
+
+**What Lisa does NOT do:**
+- No pricing (never, even if asked directly)
+- No feature pitch or product explanations
+- No demo booking or calendar scheduling
+- No package/tier discussions
+
+**Why:** Gold Contact principle — "Nicht erklären, zeigen." The founder calls back personally and builds the system for the prospect. Lisa is the warm reception, not the pitch.
 
 ## Architecture
 
 | Component | Path |
 |-----------|------|
-| DE Agent Template | `retell/flowsight_sales_de.json` |
-| INTL Agent Template | `retell/flowsight_sales_intl.json` |
+| DE Agent Template | `retell/exports/flowsight_sales_agent.json` |
+| INTL Agent Template | `retell/exports/flowsight_sales_agent_intl.json` |
 | Webhook | `src/web/app/api/retell/sales/route.ts` |
 | Email Function | `src/web/src/lib/email/resend.ts` → `sendSalesLeadNotification()` |
 
@@ -21,22 +30,35 @@ The Sales Voice Agent handles inbound calls on FlowSight's business number. It a
 
 | Agent | Language | Voice | Role |
 |-------|----------|-------|------|
-| FlowSight Sales DE | de-DE | Ela (`NE7AIW5DoJ7lUosXV2KR`) | German sales + language gate |
-| FlowSight Sales INTL | en-US | TBD | Multilingual sales (EN/FR/IT) |
+| FlowSight Sales DE | de-DE | Susi (`custom_voice_3209d3...`) | German interest capture + language gate |
+| FlowSight Sales INTL | en-US | TBD | Multilingual interest capture (EN/FR/IT) |
 
 ## Responsibilities
 
-1. **Answer FlowSight questions** — products, pricing, features, setup process
-2. **Book demos** — collect name, company, phone number
-3. **Language routing** — detect non-German → transfer to INTL agent
-4. **Lead notification** — send email to founder after each call
+1. **Warm reception** — greet caller, understand context (email received? website seen? referral?)
+2. **Capture interest** — collect name, company, preferred callback time
+3. **Founder callback** — "Herr Wende meldet sich persönlich bei Ihnen"
+4. **Language routing** — detect non-German → transfer to INTL agent
+5. **Lead notification** — send email to founder after each call
 
-## Knowledge Base
+## Conversation Flow
 
-The agent's knowledge is embedded in the conversation flow prompt (no external KB). Content sources:
-- Marketing website (flowsight.ch)
-- Flat pricing: CHF 299/month, everything included (Website, Lisa 24/7, Dashboard, SMS, Reviews)
-- Key facts: Swiss company, DSGVO-konform, no recordings, monthly cancellation
+```
+Welcome → Interest Capture → Logic Split
+                                ├─ Callback Ready → Closing (callback confirmed)
+                                ├─ Info Only → Closing (no callback wanted)
+                                └─ Out of Scope → Closing (not FlowSight)
+```
+
+Typical call: 60-90 seconds. Maximum 5 turns. Short and warm.
+
+## Deflection Patterns
+
+| Caller asks | Lisa says |
+|-------------|-----------|
+| "Was kostet das?" | "Das hängt vom Betrieb ab. Herr Wende bespricht das am liebsten persönlich — soll ich einen Rückruf einrichten?" |
+| "Was genau macht ihr?" | "Wir helfen Betrieben, erreichbar zu sein. Herr Wende erklärt das am besten persönlich." |
+| "Kann man das testen?" | "Ja! Herr Wende baut das System persönlich für Ihren Betrieb. Soll er Sie zurückrufen?" |
 
 ## Post-Call Analysis Schema
 
@@ -45,7 +67,8 @@ The agent's knowledge is embedded in the conversation flow prompt (no external K
 | `caller_name` | string | NO | Name of the caller |
 | `company_name` | string | NO | Company name |
 | `interest_level` | string | YES | "hoch" / "mittel" / "niedrig" |
-| `demo_requested` | string | YES | "ja" / "nein" |
+| `callback_requested` | string | YES | "ja" / "nein" |
+| `callback_time` | string | NO | Preferred callback time (e.g. "morgen Nachmittag") |
 | `call_summary` | string | YES | 2-3 sentence summary (German) |
 
 Phone number comes from `call.from_number` — not re-asked during the call.
@@ -54,29 +77,31 @@ Phone number comes from `call.from_number` — not re-asked during the call.
 
 1. Verify Retell signature (`x-retell-signature` + `RETELL_API_KEY`)
 2. Skip non-`call_analyzed` events
-3. Extract sales fields from post-call analysis
-4. Send lead email to founder via Resend
-5. RED WhatsApp alert if email fails
+3. Extract interest-capture fields from post-call analysis
+4. Send notification email to founder via Resend (subject: "Rückruf-Wunsch")
+5. RED alert if email fails
 6. Return 204
 
 **No Supabase insert** — no case, no tenant lookup. Pure email notification.
 
 ## Stop Criteria
 
-- Max call duration: 420s (7 min)
+- Max call duration: 300s (5 min) — shorter than before (was 7 min), because no product pitch needed
 - Non-FlowSight topics: polite decline → end call
 - No recordings (CLAUDE.md constraint)
 
 ## Differences from Intake Agent
 
-| Aspect | Intake Agent | Sales Agent |
-|--------|-------------|-------------|
-| Purpose | Damage reports | Product consultation + demo booking |
+| Aspect | Intake Agent | Interest Capture Agent |
+|--------|-------------|------------------------|
+| Purpose | Damage reports for customers | Capture interest, arrange founder callback |
 | Webhook | `/api/retell/webhook` | `/api/retell/sales` |
 | DB insert | Yes (Supabase cases) | No |
 | Tenant lookup | Yes | No |
 | Email target | Tenant ops email | Founder (MAIL_REPLY_TO) |
-| Fields | PLZ, city, category, urgency, description | caller_name, company_name, interest, demo, summary |
+| Fields | PLZ, city, category, urgency, description | caller_name, company, callback_requested, callback_time, summary |
+| Pricing | Never | Never |
+| Call duration | Up to 7 min | Up to 5 min |
 
 ## Founder Manual Steps (after deployment)
 
@@ -85,3 +110,4 @@ Phone number comes from `call.from_number` — not re-asked during the call.
 3. Set up INTL agent ID in DE agent's swap tool
 4. Phone routing: 044 552 09 19 → Twilio → Retell Sales DE Agent
 5. Test call on 044 552 09 19
+6. Publish both agents (is_published must be true)

--- a/retell/exports/flowsight_sales_agent.json
+++ b/retell/exports/flowsight_sales_agent.json
@@ -32,45 +32,51 @@
     },
     {
       "type": "string",
-      "name": "demo_requested",
-      "description": "Whether the caller wants a demo. Return exactly one of: \"ja\", \"nein\".",
+      "name": "callback_requested",
+      "description": "Whether the caller wants a callback from the founder. Return exactly one of: \"ja\", \"nein\".",
       "required": true
     },
     {
       "type": "string",
+      "name": "callback_time",
+      "description": "Preferred callback time if mentioned (e.g. \"morgen Nachmittag\", \"heute ab 16 Uhr\"). Return empty string if not specified.",
+      "required": false
+    },
+    {
+      "type": "string",
       "name": "call_summary",
-      "description": "2-3 sentence summary of the call in German. Include what the caller asked about and the outcome.",
+      "description": "2-3 sentence summary of the call in German. Include what the caller asked about, their context (e.g. saw email, visited website), and the outcome.",
       "required": true
     }
   ],
   "version": 1,
   "is_published": false,
-  "version_title": "FlowSight Sales DE",
+  "version_title": "FlowSight Sales DE — Interest Capture",
   "post_call_analysis_model": "gpt-4.1-mini",
   "pii_config": {
     "mode": "post_call",
     "categories": []
   },
-  "analysis_successful_prompt": "Evaluate whether the agent had a successful call. A successful call means the agent answered questions about FlowSight and/or collected demo booking information (name, company, phone number).",
-  "analysis_summary_prompt": "Write a 2-3 sentence summary of the call. Note what the caller was interested in and whether they requested a demo.",
+  "analysis_successful_prompt": "Evaluate whether the agent had a successful call. A successful call means the agent warmly captured the caller's interest and collected at least a name or company for a founder callback.",
+  "analysis_summary_prompt": "Write a 2-3 sentence summary of the call in German. Note the caller's context (e.g. received email, saw website, heard from colleague) and whether a callback was requested.",
   "analysis_user_sentiment_prompt": "Evaluate user's sentiment, mood and satisfaction level.",
   "voice_id": "custom_voice_3209d3305910d955836523bfac",
-  "max_call_duration_ms": 420000,
+  "max_call_duration_ms": 300000,
   "interruption_sensitivity": 1,
   "allow_user_dtmf": true,
   "user_dtmf_options": {},
   "conversationFlow": {
     "conversation_flow_id": "",
     "version": 1,
-    "global_prompt": "Du bist Lisa, die digitale Assistentin von FlowSight. Du beantwortest Fragen zu FlowSight und hilfst Interessenten, eine Demo zu buchen.\n\nSTIL\n- Sprich natürlich und freundlich — wie eine kompetente Beraterin, nicht wie ein Roboter.\n- Kurze Sätze. Keine Aufzählungen vorlesen. Nie mehrere Fragen in einem Satz.\n- Positive Mikro-Reaktionen: 'Das freut mich!', 'Gute Frage.', 'Genau.' — bevor du die nächste Frage stellst.\n- Maximal 7 Fragen pro Gespräch.\n- Wenn der Anrufer spricht: HÖRE SOFORT AUF zu reden. Warte, bis er fertig ist.\n\nSPRACHERKENNUNG — GLOBALER INTERRUPT (PRIORITÄT 1)\nDieses Regelwerk gilt bei JEDER Nachricht des Anrufers.\n\nSchritt 1 — Keyword-Check (exakt):\nWenn die Nachricht des Anrufers eines dieser Wörter/Phrasen enthält (case-insensitive): english, englisch, in english, speak english, can you speak english, do you speak english, I don't speak German, français, francais, french, en français, je ne parle pas allemand, parlez-vous français, italiano, in italiano, italian, parli italiano, non parlo tedesco\n=> SOFORT Tool 'swap_to_intl_agent' AUSFÜHREN. Nicht ankündigen, nicht fragen. Einfach das Tool aufrufen.\n\nSchritt 2 — Sprach-Plausibilitäts-Check:\nWenn die Nachricht keinen Sinn als Deutsch ergibt:\n=> Frage EINMAL: 'Entschuldigung, ich habe Sie nicht verstanden. Sprechen Sie Deutsch?'\n=> Wenn die NÄCHSTE Antwort wieder kein verständliches Deutsch ist: SOFORT Tool 'swap_to_intl_agent' AUSFÜHREN.\n\nSPRACHE\n- Du sprichst AUSSCHLIESSLICH Hochdeutsch. Schweizerdeutsch verstehen, auf Hochdeutsch antworten.\n- Verwende KEINE englischen Wörter.\n\nWISSENSBASIS — FLOWSIGHT PRODUKT\nFlowSight ist eine digitale Lösung für Sanitär- und Heizungsbetriebe in der Schweiz. Wir bieten:\n\n1. **Professionelle Website** mit integriertem Schadensmelde-Wizard\n   - Kunden melden Schäden direkt online (24/7)\n   - Automatische Kategorisierung und Dringlichkeitseinschätzung\n   - Mobiloptimiert, schnell, modern\n   - Bestätigungs-E-Mail an den Melder\n\n2. **KI-Telefonassistent**\n   - Nimmt Anrufe entgegen, 24/7, 5 Sprachen (DE/CH-DE/EN/FR/IT)\n   - Erfasst Schadensmeldungen strukturiert\n   - Leitet Fälle direkt ins Dashboard weiter\n   - Schweizer Telefonnummer inklusive\n\n3. **Ops Dashboard** für den Betrieb\n   - Alle Fälle kommen automatisch rein — kein neues System lernen\n   - Terminplanung mit ICS-Einladung per E-Mail\n   - Foto-Anhänge pro Fall (direkt vom Handy)\n   - Google-Review-Anfragen per Knopfdruck\n\nPAKETE & PREISE\n- **Starter** (CHF 199/Monat): Moderne Website im Firmenlook + Online-Schadenmeldung in 3 Schritten + Betriebsinfo per E-Mail + Kunden-SMS mit Bestätigung und Foto-Upload-Link + persönliches Onboarding\n- **Alltag** (CHF 299/Monat): Alles aus Starter + Digitale Telefonassistentin (24/7, konfigurierbar) + Fallübersicht (alle Meldungen an einem Ort) + Bestätigungs-SMS + Foto-Upload + mehrsprachig (DE/EN/FR/IT)\n- **Wachstum** (CHF 399/Monat): Alles aus Alltag + Google-Bewertungen gezielt anfragen + Prioritäts-Support + stärkeres Google-Profil für mehr Anfragen aus der Region\n- Telefonminuten: Abrechnung nach Verbrauch, keine Grundgebühr. Ein typisches Gespräch dauert 2-4 Minuten.\n- Monatlich kündbar, keine Bindung\n- Einrichtung gemeinsam in einer Woche, persönliches Onboarding. Keine Setup-Kosten in der Pilotphase.\n\nWICHTIGE FAKTEN\n- Schweizer Firma, Sitz in Oberrieden ZH\n- DSGVO-konform, EU-Server\n- Keine Gesprächsaufnahmen\n- 24/7 erreichbar über den Telefonassistenten\n- Aktuell in der Pilotphase mit ersten Kunden\n\nHÄUFIGE FRAGEN\n- 'Was kostet das?' → Pakete erklären: Starter ab CHF 199, Alltag ab CHF 299, Wachstum ab CHF 399. Monatlich kündbar, keine Bindung, keine Setup-Kosten in der Pilotphase.\n- 'Wie funktioniert der Telefonassistent?' → Anrufe werden von KI entgegengenommen, strukturiert erfasst, als Fall in die Fallübersicht übermittelt. 24/7, mehrsprachig.\n- 'Können wir das testen?' → Ja! Keine Bindung, monatlich kündbar. Wir richten alles gemeinsam ein — in einer Woche. Demo vereinbaren!\n- 'Brauche ich technische Kenntnisse?' → Nein, wir richten alles gemeinsam ein — persönliches Onboarding inklusive.\n- 'Welche Sprachen?' → DE, CH-DE, EN, FR und IT (Telefonassistentin). Website auf Deutsch.\n- 'Was passiert mit den Daten?' → DSGVO-konform, EU-Server, keine Aufnahmen.\n- 'Kann ich später upgraden?' → Ja, jederzeit. Man startet z.B. mit Starter und fügt Voice und Fallübersicht hinzu, sobald man bereit ist.\n\nPROSPECT-ERKENNUNG (Cold-E-Mail / Demo-Website)\nWenn der Anrufer erwähnt, dass er eine E-Mail erhalten hat, sich die Demo-Website angeschaut hat, oder FlowSight bereits kennt:\n- Reagiere positiv: 'Schön, dass Sie sich das angeschaut haben!'\n- Frage: 'Was hat Ihnen besonders gefallen?' oder 'Gab es etwas, das Sie besonders angesprochen hat?'\n- Wenn er Interesse zeigt: 'Herr Wende, unser Gründer, meldet sich gerne persönlich bei Ihnen. Wann passt es Ihnen am besten — heute Nachmittag oder morgen?'\n- Sammle Name + Firma + bevorzugte Rückrufzeit.\n- Fahre NICHT das volle Sales-Script. Sei gesprächig, interessiert, kurz.\n- Setze demo_booked=true sobald Name und Firma gesammelt wurden.\n\nZIEL\nDein Hauptziel ist es, eine Demo zu vereinbaren. Wenn der Anrufer interessiert ist:\n1. Frage nach dem Namen\n2. Frage nach der Firma\n3. Frage nach der Telefonnummer (für Rückruf)\n4. Bestätige: 'Vielen Dank! Wir melden uns innerhalb von 24 Stunden bei Ihnen.'\n\nWICHTIG: Die Telefonnummer des Anrufers wird automatisch erfasst. Frage NUR nach der Rückrufnummer, wenn der Anrufer von einer anderen Nummer zurückgerufen werden möchte.\n\nTHEMA\n- Nur FlowSight-bezogene Themen. Bei anderen Anliegen höflich ablehnen.\n- Keine Aufnahme/Recording erwähnen.\n- Keine Konkurrenz schlecht reden.\n- Keine Versprechen machen, die nicht im Produktumfang sind.\n\nDATENSCHUTZ\n- Keine persönlichen Daten in die Zusammenfassung (ausser Name und Firma, die der Anrufer selbst nennt).",
+    "global_prompt": "Du bist Lisa, die digitale Assistentin von FlowSight. Du nimmst Anrufe auf der FlowSight-Geschäftsnummer entgegen.\n\nDEINE ROLLE\nDu bist KEIN Sales-Agent. Du bist ein Erreichbarkeits-Netz für den Gründer.\nDein Ziel: Den Anrufer warm empfangen, sein Anliegen verstehen, und einen persönlichen Rückruf vom Gründer Gunnar Wende vorbereiten.\n\nWAS DU TUST\n- Freundlich und warm begrüssen\n- Kurz verstehen, warum die Person anruft (Interesse an FlowSight? E-Mail erhalten? Website gesehen? Empfehlung?)\n- Name und Firma erfragen (wenn der Anrufer es nicht von selbst nennt)\n- Rückruf von Herrn Wende anbieten und bevorzugte Zeit erfragen\n- Kurz bestätigen und verabschieden\n\nWAS DU NICHT TUST\n- KEINE Preise nennen. Niemals. Auch nicht auf direkte Nachfrage. Stattdessen: 'Das bespricht Herr Wende gerne persönlich mit Ihnen — er kann das viel besser einordnen als ich.'\n- KEINE Pakete oder Features aufzählen. Kein Produkt-Pitch.\n- KEINE Demo buchen. Kein Termin-Kalender.\n- KEINE technischen Details erklären (Dashboard, SMS, Wizard etc.)\n- NICHT versuchen, den Anrufer zu überzeugen oder zu verkaufen.\n\nWENN DER ANRUFER KONKRETE FRAGEN STELLT\n- 'Was kostet das?' → 'Das hängt ein bisschen vom Betrieb ab. Herr Wende bespricht das am liebsten persönlich — soll ich einen Rückruf für Sie einrichten?'\n- 'Was genau macht ihr?' → 'Wir helfen Sanitär- und Heizungsbetrieben, erreichbar zu sein — auch abends und am Wochenende. Herr Wende erklärt Ihnen das am besten persönlich. Darf ich einen Rückruf organisieren?'\n- 'Kann man das testen?' → 'Ja, auf jeden Fall! Herr Wende baut das System persönlich für Ihren Betrieb. Soll er Sie zurückrufen?'\n- Bei allen anderen Produktfragen: Freundlich auf den Rückruf verweisen.\n\nWENIG SAGEN, VIEL ZUHÖREN\n- Maximal 5 Turns im Gespräch. Das soll kurz und warm sein, nicht lang und informativ.\n- Wenn der Anrufer viel erzählt: zuhören, nicht unterbrechen.\n- Positive Mikro-Reaktionen: 'Das freut mich!', 'Verstehe.', 'Schön, dass Sie anrufen.'\n\nSTIL\n- Natürlich und freundlich — wie eine kompetente Empfangsperson, nicht wie ein Roboter.\n- Kurze Sätze. Nie mehrere Fragen in einem Satz.\n- Wenn der Anrufer spricht: SOFORT aufhören zu reden. Warten bis er fertig ist.\n\nSPRACHERKENNUNG — GLOBALER INTERRUPT (PRIORITÄT 1)\nDieses Regelwerk gilt bei JEDER Nachricht des Anrufers.\n\nSchritt 1 — Keyword-Check (exakt):\nWenn die Nachricht des Anrufers eines dieser Wörter/Phrasen enthält (case-insensitive): english, englisch, in english, speak english, can you speak english, do you speak english, I don't speak German, français, francais, french, en français, je ne parle pas allemand, parlez-vous français, italiano, in italiano, italian, parli italiano, non parlo tedesco\n=> SOFORT Tool 'swap_to_intl_agent' AUSFÜHREN. Nicht ankündigen, nicht fragen. Einfach das Tool aufrufen.\n\nSchritt 2 — Sprach-Plausibilitäts-Check:\nWenn die Nachricht keinen Sinn als Deutsch ergibt:\n=> Frage EINMAL: 'Entschuldigung, ich habe Sie nicht verstanden. Sprechen Sie Deutsch?'\n=> Wenn die NÄCHSTE Antwort wieder kein verständliches Deutsch ist: SOFORT Tool 'swap_to_intl_agent' AUSFÜHREN.\n\nSPRACHE\n- Du sprichst AUSSCHLIESSLICH Hochdeutsch. Schweizerdeutsch verstehen, auf Hochdeutsch antworten.\n- Verwende KEINE englischen Wörter.\n\nKONTEXT\n- FlowSight ist eine Schweizer Firma aus Oberrieden ZH.\n- Wir helfen Sanitär- und Heizungsbetrieben, erreichbar zu sein — mit einer persönlichen Telefonassistentin, einer Website und einem Dashboard.\n- Gunnar Wende ist der Gründer. Er meldet sich persönlich zurück.\n\nTHEMA\n- Nur FlowSight-bezogene Anrufe. Bei anderen Anliegen höflich ablehnen.\n- Keine Konkurrenz schlecht reden.\n\nDATENSCHUTZ\n- Keine persönlichen Daten in die Zusammenfassung (ausser Name und Firma, die der Anrufer selbst nennt).",
     "nodes": [
       {
         "instruction": {
           "type": "static_text",
-          "text": "Guten Tag, hier ist Lisa — ich bin die digitale Assistentin von FlowSight. Wie kann ich Ihnen helfen?"
+          "text": "Grüezi, hier ist Lisa von FlowSight. Wie kann ich Ihnen helfen?"
         },
         "always_edge": {
-          "destination_node_id": "node-sales",
+          "destination_node_id": "node-capture",
           "id": "always-edge-welcome",
           "transition_condition": {
             "type": "prompt",
@@ -90,11 +96,11 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Du führst ein natürliches Beratungsgespräch über FlowSight.\n\nSPRACHERKENNUNG (PRIORITÄT 1 — BEI JEDER NACHRICHT PRÜFEN)\nDie Sprachprüfung aus dem Global Prompt gilt hier für JEDE Nachricht des Anrufers.\nBei Trigger-Keywords: SOFORT Tool 'swap_to_intl_agent' AUFRUFEN.\nBei unverständlichem Deutsch: EINMAL nachfragen, dann transferieren.\n\nABLAUF\n1. Lass den Anrufer erzählen, was ihn interessiert. Hör zu.\n2. PROSPECT-CHECK: Wenn er eine E-Mail, Demo-Website oder FlowSight erwähnt → Prospect-Erkennung aus dem Global Prompt anwenden (kurz, gesprächig, Rückruf von Herrn Wende anbieten).\n3. Beantworte Fragen aus der Wissensbasis. Sei konkret bei Preisen und Features.\n4. Wenn der Anrufer Interesse zeigt: Biete eine Demo an.\n5. Für die Demo sammle:\n   - Name (falls nicht schon genannt)\n   - Firmenname\n   - Ob eine andere Rückrufnummer gewünscht ist (Standardnummer wird automatisch erfasst)\n6. Fasse zusammen und bestätige.\n\nWICHTIG\n- Nie zwei Fragen in einem Satz.\n- Wenn der Anrufer nur eine schnelle Info will: Gib sie und biete die Demo optional an.\n- Wenn der Anrufer kein Interesse hat: Bedanke dich freundlich und verabschiede dich.\n- Setze demo_booked=true wenn Name und Firma gesammelt wurden.\n- Setze out_of_scope=true wenn das Anliegen nichts mit FlowSight zu tun hat."
+          "text": "Du führst ein kurzes, warmes Gespräch. Dein Ziel: verstehen warum der Anrufer anruft, und einen Rückruf vom Gründer organisieren.\n\nSPRACHERKENNUNG (PRIORITÄT 1 — BEI JEDER NACHRICHT PRÜFEN)\nDie Sprachprüfung aus dem Global Prompt gilt hier für JEDE Nachricht des Anrufers.\nBei Trigger-Keywords: SOFORT Tool 'swap_to_intl_agent' AUFRUFEN.\nBei unverständlichem Deutsch: EINMAL nachfragen, dann transferieren.\n\nABLAUF\n1. Lass den Anrufer erzählen, warum er anruft. Hör zu.\n2. Wenn er eine E-Mail, Website oder Empfehlung erwähnt: Reagiere positiv ('Schön, dass Sie anrufen!').\n3. Erfrage freundlich Name und Firma (falls nicht schon genannt).\n4. Biete Rückruf an: 'Herr Wende, unser Gründer, meldet sich gerne persönlich bei Ihnen.'\n5. Frage nach bevorzugter Zeit: 'Wann passt es Ihnen am besten?'\n6. Bestätige kurz und verabschiede dich warm.\n\nWICHTIG\n- KEINE Preise, KEINE Features, KEINE Demo-Buchung.\n- Bei Produktfragen: freundlich auf Rückruf verweisen.\n- Nie zwei Fragen in einem Satz.\n- Setze callback_ready=true wenn Name oder Firma erfasst wurden.\n- Setze out_of_scope=true wenn das Anliegen nichts mit FlowSight zu tun hat.\n- Maximal 5 Turns. Kurz und warm, nicht lang und informativ."
         },
-        "name": "Sales Conversation Node",
+        "name": "Interest Capture Node",
         "edges": [],
-        "id": "node-sales",
+        "id": "node-capture",
         "type": "conversation",
         "display_position": {
           "x": 623,
@@ -105,13 +111,13 @@
             "type": "agent_swap",
             "agent_id": "agent_fb4b956eec31db9c591880fdeb",
             "name": "swap_to_intl_agent",
-            "description": "Transfer the caller to the multilingual (EN/FR/IT) sales agent. Call this tool when the caller speaks a non-German language or explicitly requests English/French/Italian.",
+            "description": "Transfer the caller to the multilingual (EN/FR/IT) agent. Call this tool when the caller speaks a non-German language or explicitly requests English/French/Italian.",
             "post_call_analysis_setting": "only_destination_agent"
           }
         ],
         "skip_response_edge": {
           "destination_node_id": "node-logic-split",
-          "id": "skip-response-edge-sales",
+          "id": "skip-response-edge-capture",
           "transition_condition": {
             "type": "prompt",
             "prompt": "Skip response"
@@ -130,11 +136,11 @@
             }
           },
           {
-            "destination_node_id": "node-closing-demo",
-            "id": "edge-demo-booked",
+            "destination_node_id": "node-closing-callback",
+            "id": "edge-callback-ready",
             "transition_condition": {
               "type": "prompt",
-              "prompt": "demo_booked is true (caller provided name and company for a demo)"
+              "prompt": "callback_ready is true (caller provided name or company and a callback has been offered)"
             }
           },
           {
@@ -142,13 +148,13 @@
             "id": "edge-info-only",
             "transition_condition": {
               "type": "prompt",
-              "prompt": "The caller only wanted information and is ready to end the call (no demo booking)"
+              "prompt": "The caller does not want a callback and is ready to end the call"
             }
           }
         ],
         "id": "node-logic-split",
         "else_edge": {
-          "destination_node_id": "node-sales",
+          "destination_node_id": "node-capture",
           "id": "edge-logic-else",
           "transition_condition": {
             "type": "prompt",
@@ -164,11 +170,11 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Sage dem Anrufer sinngemäss auf Hochdeutsch: Vielen Dank für Ihr Interesse an FlowSight! Wir melden uns innerhalb von 24 Stunden bei Ihnen, um einen Demo-Termin zu vereinbaren. Ich wünsche Ihnen einen schönen Tag!"
+          "text": "Sage dem Anrufer sinngemäss auf Hochdeutsch: Vielen Dank für Ihren Anruf! Herr Wende meldet sich persönlich bei Ihnen. Ich wünsche Ihnen einen schönen Tag!"
         },
-        "name": "Closing Demo Node",
+        "name": "Closing Callback Node",
         "edges": [],
-        "id": "node-closing-demo",
+        "id": "node-closing-callback",
         "type": "conversation",
         "display_position": {
           "x": 1363,
@@ -176,7 +182,7 @@
         },
         "always_edge": {
           "destination_node_id": "end-call-node",
-          "id": "always-edge-closing-demo",
+          "id": "always-edge-closing-callback",
           "transition_condition": {
             "type": "prompt",
             "prompt": "Always"
@@ -186,7 +192,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Sage dem Anrufer sinngemäss auf Hochdeutsch: Vielen Dank für Ihren Anruf! Wenn Sie später Fragen haben oder eine Demo möchten, rufen Sie uns gerne wieder an. Einen schönen Tag!"
+          "text": "Sage dem Anrufer sinngemäss auf Hochdeutsch: Vielen Dank für Ihren Anruf! Wenn Sie später Fragen haben, rufen Sie gerne wieder an oder besuchen Sie flowsight.ch. Einen schönen Tag!"
         },
         "name": "Closing Info Node",
         "edges": [],
@@ -208,7 +214,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Sage dem Anrufer auf Hochdeutsch: Danke für Ihren Anruf. Dafür sind wir leider nicht zuständig. Bei Fragen zu digitalen Lösungen für Sanitär- und Heizungsbetriebe helfe ich Ihnen gerne."
+          "text": "Sage dem Anrufer auf Hochdeutsch: Danke für Ihren Anruf. Dafür sind wir leider nicht zuständig. Bei Fragen zu digitalen Lösungen für Handwerksbetriebe helfe ich Ihnen gerne."
         },
         "name": "Out-of-scope Closing",
         "edges": [],
@@ -237,7 +243,7 @@
         },
         "instruction": {
           "type": "prompt",
-          "text": "Beende das Gespräch höflich auf Hochdeutsch. Auf Wiedersehen."
+          "text": "Beende das Gespräch höflich auf Hochdeutsch. Auf Wiederhören."
         }
       }
     ],

--- a/retell/exports/flowsight_sales_agent_intl.json
+++ b/retell/exports/flowsight_sales_agent_intl.json
@@ -32,45 +32,51 @@
     },
     {
       "type": "string",
-      "name": "demo_requested",
-      "description": "Whether the caller wants a demo. Return exactly one of: \"ja\", \"nein\". Always use German values regardless of call language.",
+      "name": "callback_requested",
+      "description": "Whether the caller wants a callback from the founder. Return exactly one of: \"ja\", \"nein\". Always use German values regardless of call language.",
       "required": true
     },
     {
       "type": "string",
+      "name": "callback_time",
+      "description": "Preferred callback time if mentioned (e.g. \"tomorrow afternoon\", \"today after 4pm\"). Return empty string if not specified. Write in German.",
+      "required": false
+    },
+    {
+      "type": "string",
       "name": "call_summary",
-      "description": "2-3 sentence summary of the call in German. Include what the caller asked about and the outcome. Always write in German regardless of call language.",
+      "description": "2-3 sentence summary of the call in German. Include what the caller asked about, their context, and the outcome. Always write in German regardless of call language.",
       "required": true
     }
   ],
   "version": 1,
   "is_published": false,
-  "version_title": "FlowSight Sales INTL",
+  "version_title": "FlowSight Sales INTL — Interest Capture",
   "post_call_analysis_model": "gpt-4.1-mini",
   "pii_config": {
     "mode": "post_call",
     "categories": []
   },
-  "analysis_successful_prompt": "Evaluate whether the agent had a successful call. The caller was transferred from the German sales agent. A successful call means the agent answered FlowSight questions and/or collected demo booking information.",
-  "analysis_summary_prompt": "Write a 2-3 sentence summary of the call. Note the language used and whether a demo was requested.",
+  "analysis_successful_prompt": "Evaluate whether the agent had a successful call. A successful call means the agent warmly captured the caller's interest and collected at least a name or company for a founder callback.",
+  "analysis_summary_prompt": "Write a 2-3 sentence summary of the call in German. Note the language used, the caller's context, and whether a callback was requested.",
   "analysis_user_sentiment_prompt": "Evaluate user's sentiment, mood and satisfaction level.",
   "voice_id": "custom_voice_cf152ba48ccbac0370ecebcd88",
-  "max_call_duration_ms": 420000,
+  "max_call_duration_ms": 300000,
   "interruption_sensitivity": 1,
   "allow_user_dtmf": true,
   "user_dtmf_options": {},
   "conversationFlow": {
     "conversation_flow_id": "",
     "version": 1,
-    "global_prompt": "You are the phone consultant for FlowSight. You answer questions about FlowSight and help interested callers book a demo.\n\nCONTEXT\n- The caller was transferred from the German-speaking sales agent because they spoke English, French, or Italian.\n- The full conversation history carries over. Check what was already said before asking again.\n\nSTYLE\n- Speak naturally and warmly — like a knowledgeable consultant, not a robot.\n- Short sentences. No lists. Never ask multiple questions at once.\n- Positive micro-reactions: \"Great question!\", \"Absolutely.\", \"I'm glad you asked.\" — before your next answer.\n- Maximum 7 questions per call.\n- When the caller speaks: STOP talking immediately. Wait until they finish.\n\nLANGUAGE (STICKY MODE)\n- Detect the caller's language from the conversation history or their first sentence.\n- Supported: English, French, Italian.\n- Once you identify the language, STAY in that language for the ENTIRE call.\n- NEVER switch to German during the conversation.\n- Post-call analysis values must ALWAYS be in German — regardless of conversation language.\n\nKNOWLEDGE BASE — FLOWSIGHT PRODUCT\nFlowSight is a digital solution for plumbing and heating businesses in Switzerland. We offer:\n\n1. **Professional Website** with integrated damage reporting wizard\n   - Customers report damage directly online (24/7)\n   - Automatic categorization and urgency assessment\n   - Mobile-optimized, fast, modern\n   - Confirmation email sent to the reporter\n\n2. **AI Phone Assistant**\n   - Answers calls 24/7, 5 languages (DE/Swiss-DE/EN/FR/IT)\n   - Captures damage reports in structured format\n   - Routes cases directly into the dashboard\n   - Swiss phone number included\n\n3. **Ops Dashboard** for the business\n   - Cases come in automatically — no new system to learn\n   - Scheduling with ICS calendar invitations via email\n   - Photo attachments per case (directly from mobile)\n   - Google review requests with one click\n\nPACKAGES & PRICING\n- **Starter** (CHF 199/month): Modern website in company branding + online damage reporting in 3 steps + email notification to the business + customer SMS with confirmation and photo upload link + personal onboarding\n- **Alltag** (CHF 299/month): Everything from Starter + Digital phone assistant (24/7, configurable) + case overview (all reports in one place) + confirmation SMS + photo upload + multilingual (DE/EN/FR/IT)\n- **Wachstum** (CHF 399/month): Everything from Alltag + targeted Google review requests + priority support + stronger Google profile for more regional inquiries\n- Phone minutes: pay-per-use, no base charge. A typical call lasts 2-4 minutes.\n- Monthly cancellation, no lock-in\n- Setup together in one week, personal onboarding. No setup costs during pilot phase.\n\nKEY FACTS\n- Swiss company, based in Oberrieden ZH\n- GDPR-compliant, EU servers\n- No call recordings\n- 24/7 reachable via AI Phone Assistant\n- Currently in pilot phase with first customers\n\nPROSPECT RECOGNITION (Cold Email / Demo Website)\nIf the caller mentions receiving an email, having looked at a demo website, or already knowing FlowSight:\n- React positively: 'Great that you took a look!'\n- Ask: 'What stood out to you?' or 'Was there anything that particularly caught your attention?'\n- If interested: 'Mr. Wende, our founder, would love to speak with you personally. When works best — this afternoon or tomorrow?'\n- Collect name + company + preferred callback time.\n- Do NOT run the full sales script. Be conversational, interested, brief.\n- Set demo_booked=true once name and company are collected.\n\nGOAL\nYour main goal is to book a demo. If the caller is interested:\n1. Ask for their name\n2. Ask for their company name\n3. Ask if they want to be called back on a different number (the current number is automatically captured)\n4. Confirm: \"Thank you! We will contact you within 24 hours to schedule a demo.\"\n\nTOPIC\n- Only FlowSight-related topics. Politely decline other requests.\n- Never mention recording.\n- Never badmouth competitors.\n- Never make promises outside the product scope.\n\nPRIVACY\n- No personal data in the summary (except name and company the caller provides).\n\nGERMAN DETECTION — TRANSFER BACK TO DE AGENT\nAt EVERY turn, check if the caller is speaking German:\n- If the caller says 'Deutsch', 'auf Deutsch', 'Ich spreche Deutsch', or consistently responds in fluent German sentences:\n=> IMMEDIATELY call tool 'swap_to_de_agent'. Do NOT announce the transfer. Just call the tool.\n- If the caller's first message after transfer is clearly German (not just a single word):\n=> Ask ONCE in English: 'Do you prefer German?' If yes => call 'swap_to_de_agent'.\n- Maximum 1 transfer per call. After transfer you are no longer part of the conversation.",
+    "global_prompt": "You are Lisa, the digital assistant for FlowSight. You answer calls on the FlowSight business number.\n\nCONTEXT\n- The caller was transferred from the German-speaking agent because they spoke English, French, or Italian.\n- The full conversation history carries over. Check what was already said before asking again.\n\nYOUR ROLE\nYou are NOT a sales agent. You are a warm reception for the founder.\nYour goal: warmly greet the caller, understand why they're calling, and arrange a personal callback from founder Gunnar Wende.\n\nWHAT YOU DO\n- Greet warmly in the caller's language\n- Briefly understand why they're calling (interest in FlowSight? received email? saw website? referral?)\n- Ask for name and company (if not already mentioned)\n- Offer a callback: 'Mr. Wende, our founder, would love to speak with you personally.'\n- Ask for preferred time: 'When works best for you?'\n- Confirm briefly and say goodbye warmly\n\nWHAT YOU DO NOT DO\n- NO pricing. Never. Even if asked directly. Instead: 'That depends on the business — Mr. Wende can explain that much better in person. Shall I arrange a callback?'\n- NO feature lists or product pitch.\n- NO demo booking. No calendar.\n- NO technical details (dashboard, SMS, wizard etc.)\n- Do NOT try to convince or sell.\n\nIF THE CALLER ASKS SPECIFIC QUESTIONS\n- 'How much does it cost?' → 'That depends a bit on the business. Mr. Wende prefers to discuss that personally — shall I arrange a callback?'\n- 'What exactly do you do?' → 'We help plumbing and heating businesses stay reachable — even evenings and weekends. Mr. Wende can explain it best in person. May I arrange a callback?'\n- 'Can we try it?' → 'Absolutely! Mr. Wende builds the system personally for your business. Shall he call you back?'\n- For all other product questions: warmly refer to the callback.\n\nSTYLE\n- Natural and warm — like a competent receptionist, not a robot.\n- Short sentences. Never ask multiple questions at once.\n- When the caller speaks: STOP talking immediately. Wait until they finish.\n- Positive micro-reactions: 'Great!', 'I understand.', 'Good that you called.'\n- Maximum 5 turns. Short and warm, not long and informative.\n\nLANGUAGE (STICKY MODE)\n- Detect the caller's language from conversation history or their first sentence.\n- Supported: English, French, Italian.\n- Once identified, STAY in that language for the ENTIRE call.\n- NEVER switch to German during the conversation.\n- Post-call analysis values must ALWAYS be in German.\n\nGERMAN DETECTION — TRANSFER BACK TO DE AGENT\nAt EVERY turn, check if the caller is speaking German:\n- If the caller says 'Deutsch', 'auf Deutsch', 'Ich spreche Deutsch', or consistently responds in fluent German sentences:\n=> IMMEDIATELY call tool 'swap_to_de_agent'. Do NOT announce the transfer.\n- If the caller's first message after transfer is clearly German:\n=> Ask ONCE in English: 'Do you prefer German?' If yes => call 'swap_to_de_agent'.\n- Maximum 1 transfer per call.\n\nCONTEXT ABOUT FLOWSIGHT\n- Swiss company based in Oberrieden ZH.\n- We help plumbing and heating businesses stay reachable — with a personal phone assistant, a website, and a dashboard.\n- Gunnar Wende is the founder. He calls back personally.\n\nTOPIC\n- Only FlowSight-related calls. Politely decline other requests.\n- Never badmouth competitors.\n\nPRIVACY\n- No personal data in the summary (except name and company the caller provides).",
     "nodes": [
       {
         "instruction": {
           "type": "prompt",
-          "text": "You were transferred from the German sales agent. Check the conversation history to understand what language the caller speaks and what they already asked. Greet them warmly in their language (English, French, or Italian) and let them know you are here to help with FlowSight questions."
+          "text": "You were transferred from the German agent. Check the conversation history to understand what language the caller speaks and what they already asked. Greet them warmly in their language and let them know you're here to help."
         },
         "always_edge": {
-          "destination_node_id": "node-sales",
+          "destination_node_id": "node-capture",
           "id": "always-edge-welcome",
           "transition_condition": {
             "type": "prompt",
@@ -90,11 +96,11 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "You are continuing a sales conversation about FlowSight. The caller was transferred from the German agent.\n\nCHECK CONVERSATION HISTORY FIRST\n- Review what the caller already asked the German agent.\n- Do NOT repeat information that was already given.\n\nWORKFLOW\n1. Let the caller explain what they're interested in. Listen.\n2. Answer questions from the knowledge base. Be specific about pricing and features.\n3. If the caller shows interest: offer a demo.\n4. For the demo, collect:\n   - Name (if not already provided)\n   - Company name\n   - Whether they want a callback on a different number\n5. Summarize and confirm.\n\nIMPORTANT\n- Never ask two questions in one sentence.\n- If the caller just wants quick info: give it and optionally offer a demo.\n- If the caller is not interested: thank them and say goodbye.\n- Set demo_booked=true when name and company have been collected.\n- Set out_of_scope=true when the request has nothing to do with FlowSight.\n\nLANGUAGE (STICKY)\n- Stay in the caller's language for ALL turns.\n- Post-call analysis values always in German.\n\nGERMAN DETECTION (PRIORITY 1 — CHECK EVERY MESSAGE)\nIf the caller speaks German (keywords: 'Deutsch', 'auf Deutsch bitte', 'Ich spreche Deutsch', or fluent German sentences):\n=> IMMEDIATELY call tool 'swap_to_de_agent'. Do NOT announce the transfer.\nIf the caller's message is ambiguous (could be German): ask ONCE 'Do you prefer German?' If yes => call 'swap_to_de_agent'.\nYou MUST actually CALL the tool — saying 'I'll transfer you' is NOT enough."
+          "text": "You are having a short, warm conversation. Your goal: understand why the caller is calling, and arrange a personal callback from the founder.\n\nCHECK CONVERSATION HISTORY FIRST\n- Review what the caller already told the German agent.\n- Do NOT repeat questions that were already answered.\n\nGERMAN DETECTION (PRIORITY 1 — CHECK EVERY MESSAGE)\nIf the caller speaks German: IMMEDIATELY call tool 'swap_to_de_agent'. Do NOT announce the transfer.\nIf ambiguous: ask ONCE 'Do you prefer German?' If yes => call 'swap_to_de_agent'.\n\nWORKFLOW\n1. Let the caller explain why they're calling. Listen.\n2. If they mention an email, website, or referral: react positively.\n3. Ask for name and company (if not already known).\n4. Offer callback: 'Mr. Wende, our founder, would love to speak with you personally.'\n5. Ask for preferred time.\n6. Confirm briefly and say goodbye warmly.\n\nIMPORTANT\n- NO pricing, NO features, NO demo booking.\n- For product questions: warmly refer to the callback.\n- Never ask two questions in one sentence.\n- Set callback_ready=true when name or company has been collected.\n- Set out_of_scope=true when the request has nothing to do with FlowSight.\n- Maximum 5 turns. Short and warm.\n\nLANGUAGE (STICKY)\n- Stay in the caller's language for ALL turns.\n- Post-call analysis values always in German."
         },
-        "name": "Sales Conversation Node",
+        "name": "Interest Capture Node",
         "edges": [],
-        "id": "node-sales",
+        "id": "node-capture",
         "type": "conversation",
         "display_position": {
           "x": 623,
@@ -105,13 +111,13 @@
             "type": "agent_swap",
             "agent_id": "agent_d7dfe45ab444e1370e836c3e0f",
             "name": "swap_to_de_agent",
-            "description": "Transfer the caller back to the German sales agent. Call this tool when the caller clearly speaks German (e.g., 'Ich spreche Deutsch', 'auf Deutsch bitte', or consistently responds in fluent German). Maximum 1 transfer per call.",
+            "description": "Transfer the caller back to the German agent. Call this tool when the caller clearly speaks German. Maximum 1 transfer per call.",
             "post_call_analysis_setting": "only_destination_agent"
           }
         ],
         "skip_response_edge": {
           "destination_node_id": "node-logic-split",
-          "id": "skip-response-edge-sales",
+          "id": "skip-response-edge-capture",
           "transition_condition": {
             "type": "prompt",
             "prompt": "Skip response"
@@ -130,11 +136,11 @@
             }
           },
           {
-            "destination_node_id": "node-closing-demo",
-            "id": "edge-demo-booked",
+            "destination_node_id": "node-closing-callback",
+            "id": "edge-callback-ready",
             "transition_condition": {
               "type": "prompt",
-              "prompt": "demo_booked is true (caller provided name and company for a demo)"
+              "prompt": "callback_ready is true (caller provided name or company and a callback has been offered)"
             }
           },
           {
@@ -142,13 +148,13 @@
             "id": "edge-info-only",
             "transition_condition": {
               "type": "prompt",
-              "prompt": "The caller only wanted information and is ready to end the call (no demo booking)"
+              "prompt": "The caller does not want a callback and is ready to end the call"
             }
           }
         ],
         "id": "node-logic-split",
         "else_edge": {
-          "destination_node_id": "node-sales",
+          "destination_node_id": "node-capture",
           "id": "edge-logic-else",
           "transition_condition": {
             "type": "prompt",
@@ -164,11 +170,11 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Tell the caller IN THEIR LANGUAGE: Thank you for your interest in FlowSight! We will contact you within 24 hours to schedule a demo. Have a great day!"
+          "text": "Tell the caller IN THEIR LANGUAGE: Thank you for your call! Mr. Wende will get back to you personally. Have a great day!"
         },
-        "name": "Closing Demo Node",
+        "name": "Closing Callback Node",
         "edges": [],
-        "id": "node-closing-demo",
+        "id": "node-closing-callback",
         "type": "conversation",
         "display_position": {
           "x": 1363,
@@ -176,7 +182,7 @@
         },
         "always_edge": {
           "destination_node_id": "end-call-node",
-          "id": "always-edge-closing-demo",
+          "id": "always-edge-closing-callback",
           "transition_condition": {
             "type": "prompt",
             "prompt": "Always"
@@ -186,7 +192,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Tell the caller IN THEIR LANGUAGE: Thank you for your call! If you have questions later or want a demo, feel free to call us again. Have a great day!"
+          "text": "Tell the caller IN THEIR LANGUAGE: Thank you for your call! If you have questions later, feel free to call again or visit flowsight.ch. Have a great day!"
         },
         "name": "Closing Info Node",
         "edges": [],
@@ -208,7 +214,7 @@
       {
         "instruction": {
           "type": "prompt",
-          "text": "Tell the caller IN THEIR LANGUAGE: Thank you for your call, but this isn't something we handle. We specialize in digital solutions for plumbing and heating businesses. Feel free to call back if you have questions about that."
+          "text": "Tell the caller IN THEIR LANGUAGE: Thank you for your call, but this isn't something we handle. We specialize in digital solutions for trade businesses. Feel free to call back if you have questions about that."
         },
         "name": "Out-of-scope Closing",
         "edges": [],

--- a/src/web/app/api/retell/sales/route.ts
+++ b/src/web/app/api/retell/sales/route.ts
@@ -193,11 +193,12 @@ export async function POST(req: Request) {
   const { data: extractedData, path: extractedPath } = probeExtractedData(call, payload);
   const extractedKeys = Object.keys(extractedData);
 
-  // ── Extract sales-specific fields ──────────────────────────────────
+  // ── Extract interest-capture fields ────────────────────────────────
   const callerName = nonEmptyStr(extractedData.caller_name);
   const companyName = nonEmptyStr(extractedData.company_name);
   const interestLevel = nonEmptyStr(extractedData.interest_level) ?? "nicht angegeben";
-  const demoRequested = nonEmptyStr(extractedData.demo_requested) ?? "nicht angegeben";
+  const callbackRequested = nonEmptyStr(extractedData.callback_requested) ?? nonEmptyStr(extractedData.demo_requested) ?? "nicht angegeben";
+  const callbackTime = nonEmptyStr(extractedData.callback_time);
   const callSummary =
     nonEmptyStr(extractedData.call_summary) ??
     nonEmptyStr(call?.call_analysis?.call_summary) ??
@@ -214,7 +215,7 @@ export async function POST(req: Request) {
     has_caller_name: !!callerName,
     has_company_name: !!companyName,
     interest_level: interestLevel,
-    demo_requested: demoRequested,
+    callback_requested: callbackRequested,
     has_from_number: !!fromNumber,
   });
 
@@ -225,7 +226,8 @@ export async function POST(req: Request) {
       companyName,
       fromNumber,
       interestLevel,
-      demoRequested,
+      callbackRequested,
+      callbackTime,
       callSummary,
       retellCallId,
     });

--- a/src/web/src/lib/email/resend.ts
+++ b/src/web/src/lib/email/resend.ts
@@ -546,14 +546,15 @@ interface SalesLeadPayload {
   companyName?: string;
   fromNumber?: string;
   interestLevel: string;
-  demoRequested: string;
+  callbackRequested: string;
+  callbackTime?: string;
   callSummary: string;
   retellCallId: string;
 }
 
 /**
- * Send a sales lead notification email to the founder.
- * Triggered by the Sales Voice Agent webhook after a call on 044 552 09 19.
+ * Send an interest-capture notification email to the founder.
+ * Triggered by the Interest Capture Agent webhook after a call on 044 552 09 19.
  *
  * Owns its own console.log (runs in a separate invocation via the sales webhook).
  * Errors are captured to Sentry but never thrown.
@@ -597,15 +598,16 @@ export async function sendSalesLeadNotification(
     const { data, error } = await getResend().emails.send({
       from,
       to,
-      subject: `${subjectPrefix} Neuer Lead — ${companyLabel} (${payload.interestLevel})`,
+      subject: `${subjectPrefix} Rückruf-Wunsch — ${companyLabel} (${payload.interestLevel})`,
       text: [
         `Neuer Anruf auf 044 552 09 19`,
         ``,
-        `Name:           ${payload.callerName || "nicht angegeben"}`,
-        `Firma:          ${payload.companyName || "nicht angegeben"}`,
-        `Telefon:        ${payload.fromNumber || "nicht angegeben"}`,
-        `Interesse:      ${payload.interestLevel}`,
-        `Demo gewünscht: ${payload.demoRequested}`,
+        `Name:             ${payload.callerName || "nicht angegeben"}`,
+        `Firma:            ${payload.companyName || "nicht angegeben"}`,
+        `Telefon:          ${payload.fromNumber || "nicht angegeben"}`,
+        `Interesse:        ${payload.interestLevel}`,
+        `Rückruf gewünscht: ${payload.callbackRequested}`,
+        ...(payload.callbackTime ? [`Bevorzugte Zeit:  ${payload.callbackTime}`] : []),
         ``,
         `Zusammenfassung:`,
         payload.callSummary,


### PR DESCRIPTION
## Summary
- **Role change:** Lisa on 044 552 09 19 is no longer a Sales Agent. She's an Interest Capture Agent — warm reception, founder callback, no pitch.
- **Retell DE + INTL:** Complete prompt + flow rewrite. No pricing, no features, no demo booking. Max 5 turns, 5 min call.
- **post_call_analysis:** `demo_requested` → `callback_requested` + new `callback_time` field
- **Webhook:** Updated field extraction with backwards-compatible fallback for `demo_requested`
- **Email:** Subject "Rückruf-Wunsch" instead of "Neuer Lead", includes callback time
- **Runbook:** `sales_agent.md` rewritten for Interest Capture role
- **SSOT:** STATUS.md + OPS_BOARD.md updated

## Why
Gold Contact principle: "Nicht erklären — zeigen." The old Sales Agent pitched packages, explained features, and booked demos. That contradicts the new model where the founder builds the system personally and calls back. Lisa is now the warm reception net — she catches interest and hands off to the founder.

## Test plan
- [ ] Build passes (no runtime changes beyond field mapping)
- [ ] Review Retell DE prompt: no pricing, no features, callback flow
- [ ] Review Retell INTL prompt: same role, multilingual
- [ ] Webhook: `callback_requested` field extracted (fallback to `demo_requested` for old calls)
- [ ] Email: new subject + layout with callback_time
- [ ] Founder: import updated agents in Retell Dashboard + publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)