### PR TITLE
docs: restructure plan.md for build phase execution

### DIFF
--- a/docs/redesign/plan.md
+++ b/docs/redesign/plan.md
@@ -1,667 +1,410 @@
-# Gold Contact Redesign — Kompromisslose Vollumsetzung
+# Gold Contact Build — Steuerungsdokument
 
 **Zeitraum:** 12.03. – 10.04.2026 | **Maschinenstart:** 11.04. | **Flug:** 01.05.
-**170h Founder-Fokus | CC parallel**
-**Status:** ACTIVE — Phase 0 (Zielbilder) DONE, Phase 1 (Build) beginnt.
+**Phase:** Build (Zielbilder → Praxis)
+**Standard:** Gold Contact — dauerhaft, kompromisslos, Abbruchkriterium
 
 ---
 
-## Stand 12.03. — Wo wir sind
+## 1. Executive Framing
 
-### Phase 0: Redesign-Zielbilder — DONE ✅
+Dies ist das zentrale Steuerungsdokument fuer die Build-Phase des Gold Contact Redesigns.
 
-Alle 6 Straenge haben Gold-Level-Zielbilder. 4 IST-Audits (aus Code). 1 bindendes Querschnittsdokument (Identity Contract). Jeder Strang geschaerft und querverwiesen.
+**Was diese Phase ist:**
+Ueberfuehrung von 6 Gold-Level-Zielbildern in ein funktionierendes, E2E-getestetes System.
+Kein Prototyp. Kein MVP-Minimum. Ein kompromisslos gutes Produkt, das am 11.04. auf echte Prospects losgelassen wird.
 
-| Strang | Dokument | PRs | Status |
-|--------|----------|-----|--------|
-| Leitstand | leitstand.md | — | DONE |
-| Voice | voice_ist.md + voice.md | #153-#155 | DONE |
-| Identity Contract | identity_contract.md | #156 | DONE (Querschnitt) |
-| Prospect Journey | prospect_journey_ist.md + prospect_journey.md | #157-#158, #164 | DONE (geschaerft) |
-| Wizard | wizard_ist.md + wizard.md | #160-#161 | DONE |
-| Review | review_ist.md + review.md | #162-#163 | DONE |
+**Warum sie entscheidend ist:**
+Die Zielbilder definieren, was Gold bedeutet. Die Build-Phase entscheidet, ob Gold Realitaet wird.
+Jede Woche, die unter Standard gebaut wird, multipliziert sich in der Trial-Phase.
+Ein halbgoldener Maschinenstart ist schlimmer als kein Start.
 
-**Was die Zielbilder liefern (neu fuer den Build):**
-- **Wizard:** Notfall→Telefon-Logik (N1-N7), Kategorie-Vereinheitlichung Voice+Wizard, PLZ_CITY_MAP als Shared Module, gebrandete Correction Page
-- **Review:** Bewertungs-Vorbereiter (kein Google-Klon), Nachlauf als System (6 Status-Badges, Tracking, max 2 Anfragen), refresh_reviews.mjs
-- **Prospect Journey:** 18 Touchpoints inkl. T13b (Review PoV), Stille-Logik, Day-10-Call-Scripts, Profil-Differenzierung (Meister/Betrieb)
-- **Voice:** PLZ-Verzeichnis erweitert, Partial-Case-Handling, Chain-Cron, FAQ-Persistenz
-- **Leitstand:** Nachlauf-Badges, Review-Spalte, Demo-Case-Tabs, Prospect-View-Polish
-- **Identity Contract:** 7 verbindliche Regeln (R1-R7), Dual-SSOT (Supabase gewinnt), alle E-Mails auf Tenant-Branding
+**Gold Contact Standard = Abbruchkriterium:**
+- Kein Prospect geht raus, wenn der reale Eindruck nicht Gold ist.
+- Kein Feature wird "gut genug" shipped — es wird Gold oder es wird nicht shipped.
+- Lieber Scope schneiden als unter Gold live gehen.
+- Der Founder Release Gate (§8) ist der finale Beweis. Nicht Checklisten. Nicht CI-Checks. Sondern: "Wuerde ich diesen Prospect ohne Bauchweh kontaktieren?"
 
-### Phase 1: Build — NAECHSTER SCHRITT
+---
 
-**Wo wir stehen:** Start von Woche 1 (12.03.). Die Zielbilder haben Tag 1 der Woche 1 verbraucht. Ab morgen (13.03.): Build beginnt.
+## 2. Phasen + Gesamtbild
 
-**Was sich gegenueber dem Original-Plan aendert:**
-1. **Specs sind jetzt klar.** Jeder Build-Task hat ein Zielbild als Referenz. Kein Raten, keine offenen Designfragen.
-2. **Bugs entfernt.** Ticketlist bereinigt — alte Bugs (Voice, Doerfler, Kalender etc.) werden nach Build E2E neu getestet. Clean Slate.
-3. **Wizard + Review haben eigene Build-Specs.** Die Zielbilder definieren exakt was gebaut werden muss (RS1-RS10, N1-N7, NS1-NS3 etc.).
-4. **Identity Contract ist bindend.** Alle 7 E-Mail-Templates muessen auf Tenant-Branding umgestellt werden — das ist jetzt eine klare Liste, nicht eine vage Anforderung.
+### Was hinter uns liegt
 
-### Grober Zeithorizont
+**Phase 0: Redesign-Zielbilder — DONE**
+
+| Strang | Dokument | Status |
+|--------|----------|--------|
+| Leitstand | leitstand.md | DONE |
+| Voice | voice_ist.md + voice.md | DONE |
+| Identity Contract | identity_contract.md | DONE (Querschnitt, 7 Regeln R1-R7) |
+| Prospect Journey | prospect_journey_ist.md + prospect_journey.md | DONE (geschaerft, 18 Touchpoints) |
+| Wizard | wizard_ist.md + wizard.md | DONE (N1-N7, Kategorie-Vereinheitlichung) |
+| Review | review_ist.md + review.md | DONE (RS1-RS10, Nachlauf-System) |
+
+**Was die Zielbilder liefern:** Klare Build-Specs. Jeder Build-Block hat eine Zielbild-Referenz. Kein Raten, keine offenen Designfragen.
+
+### Was vor uns liegt
+
+**Phase 1: Build — AKTIV (ab 13.03.)**
+
+Zweck: Zielbilder in funktionierenden Code, verifizierte Oberflaechen und getestete Journeys ueberfuehren.
 
 ```
-WOCHE 1 (12.-18.03.)     Build-Start. Blocker Kill + Weinberger = Gold.
-                          Identity Contract auf alle E-Mails durchschlagen.
-                          Day-5-Email + Demo-Case-Tabs + Welcome-Polish.
-                          ~6 verbleibende Tage nach Zielbild-Phase.
-
-WOCHE 2 (19.-25.03.)     Standard auf alle 7 Websites + alle Agents.
-                          Review Surface = Bewertungs-Vorbereiter (review.md).
-                          Wizard Gold (Notfall-Logik, Kategorie-Vereinheitlichung).
-                          Video-Produktion (Founder).
-
-WOCHE 3 (26.03.-01.04.)  Trial Journey E2E Dry-Run (beide Profile).
-                          Nachlauf-System (Review-Badges, Tracking, Resend).
-                          Vertrag. Call-Scripts ueben.
-
-WOCHE 4 (02.-10.04.)     5 Prospects provisionieren + QA.
-                          Founder Release Gate (10 Beruehrungspunkte).
-                          Maschinenstart-Freigabe.
-
-11.04.                    MASCHINENSTART — Erste E-Mail geht raus.
-01.05.                    FLUG — System laeuft founder-arm.
+Woche 1 (13.-18.03.)   REFERENZ — Weinberger = Gold. System-Kern steht.
+Woche 2 (19.-25.03.)   DURCHSCHLAG — Standard auf alle 7 + alle Agents + Review Gold.
+Woche 3 (26.03.-01.04.) VERIFIKATION — Journey E2E, Dry-Run, Vertrag.
+Woche 4 (02.-10.04.)   MASCHINE — 5 Prospects provisioniert. Founder Release Gate.
+11.04.                  MASCHINENSTART — Erste E-Mail geht raus.
+01.05.                  FLUG — System laeuft founder-arm.
 ```
 
 ---
 
-## Rahmung
+## 3. SSOT-Rollen
 
-Kein Minimum. Maximum.
+Drei Dokumente. Drei Rollen. Keine Doppelpflege.
 
-Alle Gold-Contact-Berührungspunkte werden bis 10.04. kompromisslos umgesetzt.
-Es gibt kein "später" für Erlebnis- und Berührungspunkte, die im Gold Contact benannt sind.
-Der Standard wird nicht an einem Goldstandard sichtbar, sondern schlägt auf alle aktiven Flächen durch.
+| Dokument | Rolle | Wann lesen |
+|----------|-------|-----------|
+| **docs/redesign/plan.md** | Build-Steuerung: Wochenplan, Streams, Gates, Founder-Aufgaben | "Was mache ich diese Woche?" |
+| **docs/ticketlist.md** | Bugs, Findings, Backlog, operative Tickets | "Was ist kaputt / offen?" |
+| **docs/STATUS.md** | Laufendes Lagebild: was ist live, aktueller Stand | "Was ist der Zustand des Systems?" |
 
-Wir optimieren nicht auf "gerade genug für den Start", sondern auf eine brutal gute, persönliche, ausgereifte Contact-to-Test Experience vor Marktöffnung.
-
-**Teuerster Fehler:** Den Umfang unterschätzen und in Woche 3 merken, dass 4 von 7 Websites noch nicht angefasst wurden. Der Feind ist nicht mangelnde Qualität an einem Punkt — sondern vergessene Stränge, die erst spät sichtbar werden.
-
----
-
-## Definitionen: Modus vs Tier
-
-### Modus-Logik = Leistungs-/Deliverable-Logik
-
-Was FlowSight dem Betrieb liefert. Bestimmt durch Website-Qualität des Prospects.
-
-| Modus | Name | Kriterium | FlowSight liefert |
-|-------|------|-----------|-------------------|
-| **Modus 1** | Full | Keine/schwache Website (≤ 5/10) | Komplette Website + Wizard + Voice + Ops |
-| **Modus 2** | Extend | Bestehende Website funktional (6+/10) | Website intelligent erweitern + Wizard/CTA + Voice + Ops |
-| **Modus 3** | Pure System | Starke bestehende Website (8+/10) | Voice + Ops + Reviews + Systemlayer, keine Website als Hauptdeliverable |
-
-**Schnelltest:** Hat er eine Website? → NEIN → Modus 1. Würdest du dort anfragen? → NEIN → Modus 1, JA → Modus 2.
-
-### Tier-Logik = Prioritäts-/Fokuslogik im Redesign
-
-Wo im Redesign der Fokus liegt. Bestimmt durch strategische Rolle im Gold Contact.
-
-| Tier | Name | Kriterium | Redesign-Fokus |
-|------|------|-----------|---------------|
-| **Tier 1** | Kernfokus | Sanitär/Heizung/Spengler, aktive Gold-Contact-Kernflächen | Voller Gold Standard, jeder Berührungspunkt perfekt |
-| **Tier 2** | Demo/Referenz | Demo-Tenant, Referenz-System, nicht für realen Prospect-Kontakt | Muss professionell aussehen (wer Brunner sieht, denkt "so sähe mein Betrieb aus"), aber kein Outreach-Material |
-| **Tier 3** | Aktiver Sonderfall | Reales Interesse, ausserhalb Kernvertikale, spezifischer Lernwert | Gezielter Scope: was lernen wir hier? Kein voller Gold-Standard-Durchlauf, aber operativ wertvoll. |
-
-**Wichtig:** Modus und Tier sind unabhängig. Ein Case kann Modus 1 + Tier 1 sein. Oder Tier 3 und trotzdem operativ wertvoll.
-
-### Aktive Cases: Modus × Tier
-
-| Case | Modus | Tier | Begründung |
-|------|-------|------|------------|
-| **Jul. Weinberger AG** | 2 (Extend) | 1 (Kern) | Goldstandard, ICP 90+, eigene Website vorhanden. Referenz für alles. |
-| **Dörfler AG** | 1 (Full) | 1 (Kern) | Erster Kunde, Founder wohnt um die Ecke, persönlicher Start. Keine eigene Website. |
-| **Widmer Sanitär** | 1 (Full) | 1 (Kern) | Spenglerei, Oberrieden. Website von FlowSight. |
-| **Orlandini** | 1 (Full) | 1 (Kern) | Sanitär, Horgen. Website von FlowSight. Partner-Daten offen (#89). |
-| **Walter Leuthold** | 1 (Full) | 1 (Kern) | Sanitär, Oberrieden. Website von FlowSight. |
-| **Brunner Haustechnik** | 1 (Full) | 2 (Demo) | Demo-Tenant, Thalwil. Showroom-Fläche. Kein realer Prospect, aber: wer Brunner sieht, muss beeindruckt sein. |
-| **BigBen Pub / Paul** | 1 (Full) | 3 (Sonderfall) | Gastro, nicht Sanitär. Aber: persönliche Beziehung, reales Interesse an Voice, sehr kurze Feedbackschleife. Spezifischer Lernwert: Swisscom-Einzelnummer → Weiterleitung auf Voice-Agent. Dieses Pattern wird später generisch relevant. |
-
-### BigBen / Paul: Scope und Lernziel
-
-BigBen ist kein irrelevanter Ausreisser. BigBen ist ein aktiver Sonderfall mit konkretem Wert:
-
-**Warum drin:**
-- Paul ist persönlich bekannt, interessiert, kurze Feedbackschleife
-- Website steht im Wesentlichen (wartet auf Material/Fotos)
-- Realer Lernfall: Swisscom Einzelnummer → Weiterleitung auf Voice-Agent
-- Telefonie-/Weiterleitungs-Pattern wird generisch relevant (viele KMU haben Swisscom Festnetz)
-- Frühes reales Feedback zu Voice im Nicht-Sanitär-Kontext
-
-**Was wir konkret von BigBen lernen wollen:**
-1. Swisscom-Festnetz → Twilio-Weiterleitung: funktioniert das zuverlässig? Latenz? Qualität?
-2. Voice-Agent für Gastro (Reservierung, Events): wie anders ist der Prompt vs Sanitär?
-3. Founder-Touch bei persönlich bekanntem Prospect: wie fühlt sich der Gold-Contact-Flow an?
-
-**Was BigBen im Redesign bekommt (Tier 3):**
-- Website fertigstellen wenn Material/Fotos kommen (CC)
-- Voice-Agent verifizieren (CC + Founder)
-- Swisscom-Weiterleitung testen wenn Paul bereit (Founder)
-- Kein eigenes Video, keine eigene Outreach-Sequenz, kein Full Dry-Run
-
-**Was BigBen NICHT bekommt:**
-- Nicht denselben QA-Durchlauf wie Tier-1-Kernflächen
-- Kein Pre-Contact-Check Gate (Paul wird persönlich kontaktiert, nicht über Maschine)
-- Kein Platz im Founder Release Gate (eigener Strang, eigenes Timing)
+**Regel:** Nach jedem Build-Block: STATUS.md updaten. Findings → ticketlist.md. Plan-Fortschritt → hier markieren.
 
 ---
 
-## Die 9 Redesign-Stränge
+## 4. Die 4 Build-Streams
 
-### Strang A: Contact / Outreach / Founder Touch
-
-| Scope | Definition of Done |
-|-------|-------------------|
-| 3 Outreach-Templates (HOT/WARM/COLD) — Gold-Contact-konform | Kein "Demo", kein "10 Min Gespräch", kein Preis. "Wir haben Lisa für Sie gebaut. Rufen Sie an." |
-| Call-Scripts für beide Profile (Meister + Betrieb) | Geübt, laut vorgelesen, Varianten durchgespielt (begeistert/skeptisch/Bürokraft) |
-| Day-10-Call Script | Meister: "Hat Ihre Frau es gesehen?" Betrieb: "Hat Ihre Bürokraft die Übersicht gesehen?" |
-| Weiterempfehlungs-Frage eingebaut | Nach positivem Day-10-Call: "Kennen Sie einen Kollegen?" |
-| Persönliche Outreach-E-Mails für erste 5 Prospects | Geschrieben (nicht generiert), Firmenname im Betreff, kein Template-Gefühl |
-
-**Owner:** 70% Founder, 30% CC (Template-Basis + Alignment-Review)
-
-### Strang B: Video-Maschine
-
-| Scope | Definition of Done |
-|-------|-------------------|
-| Equipment + Workflow | Loom oder OBS, gutes Mikro, Licht, Screen-Recording, Edit-Workflow. Setup steht, reproduzierbar. |
-| Weinberger-Video (45-60s) | "Das habe ich für die Jul. Weinberger AG gebaut." Website → Lisa-Anruf → SMS. Mehrere Takes, geschnitten. |
-| Generisches Intro-Video (30-45s) | Kein Firmenname. "So funktioniert Lisa." Wiederverwendbar für Modus 2/WARM. |
-| 3-5 Prospect-spezifische Videos auf Vorrat | Für die Top-5 Prospects, die am 11.04. kontaktiert werden. |
-| Video-Hosting + Einbindung | Loom-Link in E-Mail oder embedded — entschieden + umgesetzt. |
-| Produktions-Playbook | "Neues Prospect-Video in 30 Min" — Schritt-für-Schritt, Routine. |
-
-Video ist Kernbestandteil des High-End-Systems, nicht Nice-to-have. Der Strang durchzieht Woche 1-4.
-
-**Owner:** 90% Founder (Aufnahme + Schnitt), 10% CC (Hosting-Integration)
-
-### Strang C: Gold Standard — Alle 7 Kunden-Websites
-
-| Website | Modus | Tier | Status heute | Was fehlt für Gold Standard |
-|---------|-------|------|-------------|---------------------------|
-| **Weinberger AG** | 2 | 1 | 95% | Final-QA, Performance, Video-Integration |
-| **Dörfler AG** | 1 | 1 | 85% | Mobile QA, Brand Color verifiziert, Reviews aktuell?, links.md |
-| **Walter Leuthold** | 1 | 1 | 80% | links.md fehlt, Mobile QA, Reviews verifizieren |
-| **Orlandini** | 1 | 1 | 80% | links.md fehlt, Partner-Daten prüfen (#89), Mobile QA |
-| **Widmer** | 1 | 1 | 80% | links.md fehlt, Spenglerei-Kategorien verifizieren, Mobile QA |
-| **Brunner HT** | 1 | 2 | 80% | Demo muss genauso beeindrucken wie Echtbetrieb. Showroom-Qualität. |
-| **BigBen Pub** | 1 | 3 | 75% | Material/Fotos von Paul ausstehend. Fertigstellen wenn Material kommt. |
-
-**Definition of Done pro Tier-1-Website:**
-- [ ] Mobile + Desktop: pixel-perfect, keine 404s, alle Bilder laden
-- [ ] Brand Color korrekt
-- [ ] Services korrekt + aktuell
-- [ ] Reviews korrekt + aktuell (Crawl-Daten verifiziert)
-- [ ] Emergency-Banner korrekt (wenn aktiv)
-- [ ] Wizard funktioniert mit richtigen Kategorien
-- [ ] links.md existiert
-- [ ] Lighthouse Performance Score > 90
-- [ ] Lighthouse Accessibility Score > 90
-
-**Definition of Done Tier-2 (Brunner):** Gleich wie Tier 1 minus links.md. Plus: wirkt als Demo überzeugend.
-**Definition of Done Tier-3 (BigBen):** Website komplett wenn Material da. Keine Lighthouse-Optimierung, kein Pre-Contact-Check.
-
-**Owner:** 80% CC (Code + Performance + QA), 20% Founder (inhaltliche Verifikation + iPhone-Test)
-
-### Strang D: Voice-Agent-Standard
-
-| Agent | Tier | Status | Was fehlt |
-|-------|------|--------|-----------|
-| Weinberger DE (Intake) | 1 | LIVE | Final E2E, Gold-Contact-Greeting verifiziert |
-| Weinberger INTL (Intake) | 1 | LIVE | Final E2E |
-| Flowsight Sales DE (Lisa Interest Capture) | — | LIVE (PR #150) | Verifiziert, published |
-| Flowsight Sales INTL (Lisa Interest Capture) | — | LIVE (PR #150) | Verifiziert, published |
-| Dörfler Intake | 1 | prüfen | Status prüfen. Wenn live: Gold-Standard-QA. Wenn nicht: aufbauen. |
-| Brunner HT Intake | 2 | prüfen | Demo-Agent. Muss genauso professionell sein. |
-| BigBen Intake | 3 | prüfen | Verifizieren wenn Paul bereit. |
-
-**Definition of Done pro Agent:**
-- [ ] Greeting: korrekter Firmenname, "mein Name ist Lisa"
-- [ ] PLZ-Erkennung funktioniert
-- [ ] Notfall-Empathie-Branch getestet
-- [ ] Closing: deterministic, kein Loop, max 7 Fragen
-- [ ] FAQ-Edge: sauber abgefangen
-- [ ] Keine falschen Infos (Preise, Zeiten, Team)
-- [ ] Published via retell_sync.mjs
-- [ ] E2E: Anruf → SMS → Dashboard-Fall korrekt
-
-**Owner:** 60% CC (Agent-JSON + Sync + Verification), 40% Founder (Live-Anrufe als QA)
-
-### Strang E: SMS / Welcome / Magic Link / Prospect Experience Layer
-
-| Element | Gold-Contact-Anforderung | Status | Was fehlt |
-|---------|--------------------------|--------|-----------|
-| **SMS Absendername** | "Von Weinberger" (sein Name) | LIVE | DEMO_SIP_CALLER_ID verifizieren (BLOCKER) |
-| **SMS Inhalt** | Zusammenfassung + Korrekturlink + Foto-Upload | LIVE | Template-Review: Ist der Text wirklich gut? |
-| **SMS Latenz** | < 10 Sekunden nach Anruf | LIVE (ungemessen) | Latenz messen + dokumentieren |
-| **Welcome-Mail** | Persönlich: "{NACHNAME}", Testnummer, 3 Schritte | Teilweise | `{NACHNAME}` + `{FIRMA}` einbauen |
-| **Magic Link** | Click → Dashboard, kein Passwort | LIVE | Funktioniert — Final QA |
-| **Welcome Page** | "/ops/welcome" — CTA: "Rufen Sie an" | LIVE | Polish: sieht das BRUTAL GUT aus, oder nur "funktioniert"? |
-| **Day-5-Email** | "Tipp: Testen Sie Lisa mit einem echten Anruf" | FEHLT | Bauen. Gold-Contact-Pflichtbestandteil (WOW 6 Enabler). |
-| **Day-13-Email** | "Ihr Test läuft morgen ab" — warm, kein Druck | Implementiert | Verifizieren: wird sie gesendet? Stimmt der Ton? |
-
-**Owner:** 80% CC (Code), 20% Founder (Ton + Text-Review)
-
-### Strang F: Leitstand / Mobile Experience
-
-| Element | Gold-Contact-Anforderung | Status | Was fehlt |
-|---------|--------------------------|--------|-----------|
-| **Prospect First Visit** | Welcome-Banner, Testnummer prominent, klare Orientierung | LIVE | Polish: Ist der erste Eindruck "WOW" oder "Backend"? |
-| **Case List** | KPI-Kacheln, Filter, Suche | LIVE | Demo-Case Filtering: `is_demo=true` RAUS aus Default-View |
-| **Case Detail** | Kategorie, PLZ, Dringlichkeit, Timeline, SMS-Status | LIVE | Final Review |
-| **Case-Creation Email** | "Neue Meldung: {Kategorie} in {Ort}" an Betrieb | UNVERIFIZIERT | Verifizieren/bauen |
-| **Review Button** | Nur wenn status=done + Kontaktdaten | LIVE | E2E testen |
-| **Mobile Experience** | Meister öffnet auf iPhone | LIVE | Expliziter Mobile-QA-Pass für Dashboard |
-| **Tenant Branding** | Name + Initials statt "FlowSight" | LIVE | Verifizieren für alle aktiven Tenants |
-
-**Owner:** 70% CC (Code), 30% Founder (UX-Review auf echtem Gerät)
-
-### Strang G: Trial Journey Tag 0–14
-
-Jeder Tag hat einen definierten Zustand. Jeder Zustand wird real durchgespielt — für BEIDE Profile (Meister + Betrieb).
-
-| Tag | Was passiert | Automatisch? | Verifiziert? |
-|-----|------------|-------------|-------------|
-| **0** | Welcome-Mail + Magic Link + Testnummer | Ja (provision_trial) | Ja |
-| **0** | Prospect ruft an → WOW 2+3 (Lisa + SMS) | System | Weinberger: ja. Alle anderen: NEIN |
-| **0-1** | Prospect öffnet Dashboard → WOW 4 | System | Teilweise |
-| **2-5** | Prospect testet abends → WOW 5 | System | Nicht explizit getestet |
-| **5** | **Day-5-Email: "Testen Sie mit einem echten Anruf"** | FEHLT → Bauen | — |
-| **5-10** | Echte Anrufe → WOW 6 | Prospect-Initiative | Day-5-Email als Nudge |
-| **7** | Lifecycle Tick: Engagement-Check | Ja | Ja |
-| **10** | **Founder ruft an** (Pflicht) | Nein (Morning Report Alert) | Call-Script vorbereiten + üben |
-| **10** | Weiterempfehlungs-Frage | Nein (Founder) | Im Call-Script integriert |
-| **13** | Auto-Email: "Ihr Test läuft morgen ab" | Ja (Tick) | Versand verifizieren |
-| **14** | Decision: Convert / Dock / Offboard | Founder | Vertrag muss stehen |
-
-**Definition of Done:** Full Dry-Run für Profil "Meister" UND Profil "Betrieb" durchgespielt. Jeder Tag, jede E-Mail, jeder Bildschirm. Dokumentiert.
-
-**Owner:** 50/50 Founder + CC
-
-### Strang H: Provisioning / QA / Quality Gates / SSOT
-
-| Element | Ziel | Status |
-|---------|------|--------|
-| `provision_trial.mjs` | < 15 Min E2E | Funktioniert, Timing ungemessen |
-| `pre_contact_check.mjs` | Pflicht vor jedem Kontakt (kein optional) | Existiert, optional |
-| `offboard_tenant.mjs` | Clean Delete funktioniert | LIVE |
-| Quality Gate 1-7 | Alle 7 Checks pro Prospect bestanden | Checkliste da, Enforcement fehlt |
-| Demo-Case Seeding | Profil-angepasst (Meister: 3, Betrieb: 15) | Default 15, kein Auto-Routing |
-| Morning Report | Zeigt: Outreach-ready, Active Trials, Health | Teilweise |
-| SSOT Docs | STATUS + Ticketlist + gold_contact aktuell | Aktuell bis PR #150 |
-
-**Owner:** 90% CC, 10% Founder (Verification)
-
-### Strang I: Vertrags-/Closing-Readiness
-
-| Element | Ziel | Status |
-|---------|------|--------|
-| SaaS-Vertrag CH-Recht | Template fertig, Anwalt abgestimmt | FEHLT |
-| Pricing | 299 CHF/Monat, monatlich kündbar | Entschieden, nicht im Vertrag |
-| Konversions-Flow | Prospect sagt Ja → Schritt-für-Schritt dokumentiert + getestet | Dokumentiert, nicht getestet |
-| Offboarding-Flow | Prospect sagt Nein → Clean Delete + E-Mail | LIVE |
-| AVV/DSGVO | Auftragsverarbeitung, Löschrechte | Referenziert, nicht formalisiert |
-
-**Owner:** 90% Founder (Legal), 10% CC (Docs + Flow-Dokumentation)
-
----
-
-## Kritischer Pfad
+### Arbeitslogik
 
 ```
-WOCHE 1                    WOCHE 2                    WOCHE 3                    WOCHE 4
-────────                   ────────                   ────────                   ────────
-
-[BLOCKER KILL]─────────┐
-  DEMO_SIP_CALLER_ID   │
-  Case-Creation Email   │
-  Demo-Case Filtering   │
-  Day-5-Email bauen     │
-                        │
-[WEINBERGER = GOLD]────┼──[STANDARD → ALLE 7]──────[FINAL QA ALLE 7]
-  Website perfekt       │    Tier 1: 5 Websites       Performance + Content
-  Agent verifiziert     │    Tier 2: Brunner HT
-  SMS verifiziert       │    Tier 3: BigBen (wenn
-  Welcome-Flow perfekt  │      Material da)
-                        │
-[VIDEO SETUP]──────────┼──[VIDEO PRODUKTION]────────[VIDEO INTEGRATION]────[VIDEOS FÜR 5 PROSPECTS]
-  Equipment             │    Weinberger-Video          Generisches Video      Prospect-spezifisch
-  Workflow              │    Schnitt-Routine           Hosting entschieden    Auf Vorrat
-  Test-Recording        │
-                        │
-[OUTREACH ALIGNMENT]───┼──[TEMPLATES FINAL]─────────[CALL-SCRIPTS ÜBEN]────[5 EMAILS GESCHRIEBEN]
-  Gold-Contact-Sprache  │    HOT/WARM/COLD             Meister + Betrieb      Personalisiert
-  "Test" statt "Demo"   │    Video integriert           Varianten              Ready to send
-                        │
-                        └──────────────────────────[FULL DRY RUN]──────────[FOUNDER RELEASE GATE]
-                                                      Tag 0-14 Meister        5 Prospects geprüft
-                                                      Tag 0-14 Betrieb        Go/No-Go pro Prospect
-                                                      Fix was bricht          Maschinenstart-Freigabe
-
-                           [VERTRAG START]──────────[VERTRAG FINAL]
-                             Template + Anwalt        Unterschriftsreif
-
-                                                    [PROVISIONING HÄRTEN]──[5 × PROVISIONIERT]
-                                                      < 15 Min                Pre-Contact ✓
-                                                      Auto-Scaling            QA bestanden
+Zielbild-Referenz → Build-Block → Done-Kriterium → E2E-Test → naechster Block
 ```
 
-**Abhängigkeiten:**
-1. **Blocker Kill → alles andere.** Ohne DEMO_SIP_CALLER_ID kann kein SMS-Test funktionieren. Tag 1-2 Woche 1.
-2. **Weinberger Gold → Standard Rollout.** Erst wenn Weinberger perfekt ist, wissen wir was "Gold Standard" konkret bedeutet.
-3. **Video Setup → Video Produktion.** Equipment + Workflow Woche 1, Produktion ab Woche 2.
-4. **Full Dry Run → Machine.** Erst wenn Tag 0-14 komplett durchgespielt ist, können wir Prospects provisionieren.
-5. **Vertrag → Conversion-Readiness.** Parallel, aber muss Ende Woche 3 stehen.
-6. **Alle 7 Websites → Founder Release Gate.** Gate in Woche 4 prüft auch Website-Qualität.
+- Keine Build-Arbeit ohne Zielbildbezug.
+- Keine Busywork.
+- Kein Website-first Drift (Websites = Stream 2, nicht Stream 1).
+- Lieber Scope schneiden als unter Gold live gehen.
+
+### Stream-Uebersicht
+
+| # | Stream | Kern-Inhalt | CC | Founder | Zielbild-Referenz |
+|---|--------|------------|-----|---------|-------------------|
+| S1 | **System-Kern** | Identity auf alle E-Mails, Day-5-Email, Demo-Tabs, Wizard Gold, Review Gold, Leitstand-Nachlauf | 90% | 10% | identity_contract, prospect_journey, wizard, review, leitstand |
+| S2 | **Oberflaechen-Qualitaet** | 7 Websites Gold, alle Agents E2E, SMS-Config | 80% | 20% | voice, wizard, gold_contact |
+| S3 | **Journey-Verifikation** | Trial E2E Tag 0-14, Dry-Run beide Profile, Review-Flow | 50% | 50% | prospect_journey, review |
+| S4 | **Founder-Readiness** | Videos, Outreach-Templates, Vertrag, Call-Scripts | 20% | 80% | gold_contact, prospect_journey |
+
+### Abhaengigkeiten
+
+```
+S1 (System-Kern) ──→ S2 (Oberflaechen) ──→ S3 (Journey E2E) ──→ S4 (Founder Gate)
+     ↑                      ↑                      ↑
+     │                      │                      │
+ Woche 1               Woche 2               Woche 3-4
+     │                                             │
+     └── S4 laeuft PARALLEL ab Woche 1 ───────────┘
+         (Videos, Outreach, Vertrag sind Founder-Work
+          und brauchen keinen fertigen System-Kern)
+```
+
+**Nicht parallelisierbar:**
+- S3 (Journey E2E) braucht S1 + S2 als Voraussetzung.
+- Founder Release Gate (Woche 4) braucht alle 3 Streams als Voraussetzung.
+
+**Sinnvoll parallel:**
+- S1 (CC baut System-Kern) + S4 (Founder produziert Videos/Outreach) = Woche 1-2.
+- S2 (CC baut Oberflaechen) + S4 (Founder uebt Call-Scripts) = Woche 2-3.
 
 ---
 
-## 4-Wochen-Plan
+## 5. Stream-Details + Build-Bloecke
 
-### Woche 1: REFERENZ-STANDARD (12.–18.03.)
+### S1: System-Kern
 
-**Ziel:** Weinberger AG ist das perfekte Referenz-System. Alle Blocker eliminiert. Video-Setup steht.
+Der unsichtbare Unterbau. Wenn S1 nicht steht, ist alles andere Fassade.
 
-**Aktive Stränge:** A (Outreach Alignment), B (Video Setup), C (Weinberger), D (Weinberger Agent), E (SMS/Welcome), F (Dashboard), H (QA)
+| Block | Beschreibung | Zielbild | Done-Kriterium |
+|-------|-------------|----------|----------------|
+| S1.1 | **Identity: 7 E-Mail-Templates auf Tenant-Branding** | identity_contract R1-R7 | Alle 7 E-Mails: Subject = `{display_name}`, Sender = `{display_name} via FlowSight`, kein "[FlowSight]" |
+| S1.2 | **Day-5-Email bauen** (Profil-Differenzierung Meister/Betrieb) | prospect_journey §4 Tag 5 | E-Mail kommt an. Unterdrueckung bei aktiven Prospects. Bedingt: `day5_nudge_sent_at`. |
+| S1.3 | **Demo-Case-Tabs** ("Ihre Faelle" / "So sieht Ihr Alltag aus") | prospect_journey §4 Tag 0 T9 | Default-Tab = echte Cases. Demo-Cases in eigenem Tab. Leerer Zustand mit CTA. |
+| S1.4 | **Day-7-Engagement-Snapshot** | prospect_journey §4 Tag 7 | JSONB `day7_snapshot` wird geschrieben. Morning Report zeigt Engagement-Signal. |
+| S1.5 | **Wizard: Notfall-Logik** (N1-N7) | wizard §3 | Notfall → Telefon-CTA primaer. "Schriftlich melden" sekundaer. Kein Case ohne Warnung. |
+| S1.6 | **Wizard: Kategorie-Vereinheitlichung** | wizard §8 | Eine Quelle `categories[]` in Tenant-Config. Voice + Wizard lesen dieselbe Liste. |
+| S1.7 | **Review Surface: Bewertungs-Vorbereiter** | review §3 (RS1-RS10) | Auftrags-Block, editierbares Textarea, Clipboard + Google CTA, keine Sterne, kein "Max Mustermann". |
+| S1.8 | **Review: Nachlauf-System** | review §5 (NS1-NS3) | 6 Status-Badges, review_sent_at, case_events Tracking, max 2 Anfragen, Resend nach 7d. |
+| S1.9 | **Leitstand: Review-Badges + Nachlauf** | leitstand + review §5.3 | Review-Badge im Falldetail. "Review anfragen" / "Nochmals" / "Kein Review". |
+| S1.10 | **Welcome Page Polish** | prospect_journey §4 Tag 0 T5 | Trial-Countdown, Tagline ohne "FlowSight", Profil-CTAs, Disabled-Nav ausgeblendet. |
 
-| # | Task | Owner | h | Strang | Typ |
-|---|------|-------|---|--------|-----|
-| 1.1 | DEMO_SIP_CALLER_ID auf Vercel setzen + SMS E2E testen | Founder | 1 | E | **GC-Pflicht** |
-| 1.2 | Case-Creation Email Notification verifizieren/bauen | CC | 2 | F | **GC-Pflicht** |
-| 1.3 | Demo-Case Filtering: Prospect-View filtert `is_demo=true` raus | CC | 1 | F | **GC-Pflicht** |
-| 1.4 | Day-5-Email bauen ("Tipp: Testen Sie mit echtem Anruf") | CC | 3 | G | **GC-Pflicht** |
-| 1.5 | Welcome-Mail: `{NACHNAME}` + `{FIRMA}` Personalisierung | CC | 2 | E | **GC-Pflicht** |
-| 1.6 | Pre-Contact-Check als Pflicht-Gate (nicht optional) | CC | 2 | H | **Standardisierung** |
-| 1.7 | Outreach-Templates: "Demo"→"Test", Pricing raus, Gold-Contact-Sprache | CC | 3 | A | **GC-Pflicht** |
-| 1.8 | Provisioning: Auto-Scale Demo-Cases nach team_size | CC | 1 | H | **Standardisierung** |
-| 1.9 | links.md für Walter Leuthold, Orlandini, Widmer | CC | 1 | C | **Standardisierung** |
-| 1.10 | Weinberger Website: Lighthouse > 90, Mobile Final-QA | CC | 3 | C | **GC-Pflicht** |
-| 1.11 | Weinberger Agent DE + INTL: Full E2E (Anruf → SMS → Dashboard) | CC+F | 2+2 | D | **GC-Pflicht** |
-| 1.12 | Welcome Page "/ops/welcome" Polish: brutal gut, nicht nur funktional | CC | 3 | F | **GC-Pflicht** |
-| 1.13 | Day-13-Email: Versand verifizieren, Ton prüfen | CC+F | 2+1 | G | **GC-Pflicht** |
-| 1.14 | **Video-Setup:** Equipment, Loom/OBS, Mikro, Licht, Test-Recording | Founder | 4 | B | **Enablement** |
-| 1.15 | **Video-Hosting-Entscheid:** Loom-Link in E-Mail oder Website-Embed? | Founder | 1 | B | **Enablement** |
-| 1.16 | **Weinberger E2E Dry-Run:** Website → Anruf → SMS → Dashboard → Welcome → Magic Link | Founder | 3 | G | **GC-Pflicht** |
-| 1.17 | Outreach-Templates lesen + Gold-Contact-Drift markieren | Founder | 2 | A | **GC-Pflicht** |
-| 1.18 | Vertrag: SaaS-Template CH-Recht recherchieren, Anwalt kontaktieren | Founder | 4 | I | **GC-Pflicht** |
-| 1.19 | Modus-1-Betriebe Inventur (Dörfler/Widmer/Orlandini/Leuthold): Status-Notiz pro Betrieb | Founder | 3 | C | **Standardisierung** |
-| 1.20 | Fixes aus Weinberger Dry-Run (1.16) | CC | 5 | — | **Puffer** |
+### S2: Oberflaechen-Qualitaet
 
-**Founder: ~21h | CC: ~30h**
+Was der Prospect sieht und hoert. Der Spiegel-Effekt.
 
-**Entscheidungen Woche 1:**
-- Video-Hosting: Loom oder Self-hosted?
-- Vertrag: Anwalt, SaaS-Vorlage, oder selbst entwerfen?
+**Websites — Modus × Tier:**
 
-**Gate/Exit-Kriterien:**
-- [ ] DEMO_SIP_CALLER_ID gesetzt + SMS kommt an
-- [ ] Weinberger E2E fehlerfrei (WOW 1-4 durchgespielt)
-- [ ] Alle 6 Blocker/Gaps geschlossen
-- [ ] Video-Setup funktioniert (Test-Recording gemacht)
-- [ ] Outreach-Templates Gold-Contact-konform
+| Website | Modus | Tier | Gold-Standard |
+|---------|-------|------|---------------|
+| Weinberger AG | 2 (Extend) | 1 (Kern) | Referenz fuer alles |
+| Doerfler AG | 1 (Full) | 1 (Kern) | Mobile + Desktop, Reviews, Wizard-Kategorien |
+| Walter Leuthold | 1 (Full) | 1 (Kern) | Mobile + Desktop, Reviews |
+| Orlandini | 1 (Full) | 1 (Kern) | Mobile + Desktop, Reviews |
+| Widmer | 1 (Full) | 1 (Kern) | Mobile + Desktop, Spenglerei-Kategorien |
+| Brunner HT | 1 (Full) | 2 (Demo) | Showroom-Qualitaet |
+| BigBen Pub | 1 (Full) | 3 (Sonderfall) | Fertig wenn Material da. Zeitbox: max 4h. |
 
-**SSOT-Folgen:** Ticketlist Q1 gelöst. Neue PRs archiviert. STATUS.md Datum-Bump.
+**Website Gold-Kriterium (Tier 1):** Mobile + Desktop pixel-perfect. Lighthouse > 90. Reviews aktuell. Wizard funktioniert. links.md existiert.
 
----
+| Block | Beschreibung | Done-Kriterium |
+|-------|-------------|----------------|
+| S2.1 | **Weinberger = Referenz-Gold** | Lighthouse > 90, Mobile QA, Video-Integration, E2E fehlerfrei |
+| S2.2 | **Tier-1-Websites × 4** (Doerfler, Leuthold, Orlandini, Widmer) | Gleicher Standard wie Weinberger. Pro Website: CC baut, Founder verifiziert auf iPhone. |
+| S2.3 | **Brunner HT Showroom** | Demo = genauso beeindruckend wie Echtbetrieb |
+| S2.4 | **Alle Voice-Agents: Gold-QA** | Greeting korrekt, PLZ, Empathie, Closing, FAQ, E2E (Anruf→SMS→Dashboard) |
+| S2.5 | **SMS-Config alle Tenants** | Absendername + Inhalt + Link pro Tenant verifiziert |
+| S2.6 | **Tab-Titel + Sidebar** | `{short_name} OPS`, Tenant-Initialen, kein "FlowSight OPS" |
 
-### Woche 2: STANDARD DURCHSCHLAGEN (19.–25.03.)
+### S3: Journey-Verifikation
 
-**Ziel:** Der Weinberger-Standard gilt für alle 7 Websites, alle Agents, alle SMS-Configs. Erstes Video fertig. Outreach-Templates final.
+Der Beweis, dass alles zusammen funktioniert.
 
-**Aktive Stränge:** B (Video Produktion), C (alle 7 Websites), D (alle Agents), E (SMS alle Tenants), A (Templates Final)
+| Block | Beschreibung | Zielbild | Done-Kriterium |
+|-------|-------------|----------|----------------|
+| S3.1 | **Trial-Emails verifizieren** (Welcome, Day-5, Day-13, Offboarding) | prospect_journey §5 | Alle 4 kommen an, richtiger Ton, Tenant-Branding, CTA funktioniert |
+| S3.2 | **Provisioning < 15 Min** | prospect_journey §10 | Gemessen, optimiert, reproduzierbar |
+| S3.3 | **Review E2E** | review §3-§5 | Case→done→Badge→"Review anfragen"→E-Mail→Surface→Clipboard→Google |
+| S3.4 | **Full Dry-Run Profil "Meister"** | prospect_journey §4 komplett | Tag 0-14 real durchgespielt. Jede E-Mail, jeder Screen. |
+| S3.5 | **Full Dry-Run Profil "Betrieb"** | prospect_journey §4 komplett | Dasselbe, Betrieb-Perspektive (Buerokraft, Dashboard-Fokus) |
+| S3.6 | **Konversions-Flow testen** | prospect_journey §4 Tag 14 | Prospect Ja → Status, Peoplefone, Demo-Cases loeschen. Dokumentiert. |
 
-| # | Task | Owner | h | Strang | Typ |
-|---|------|-------|---|--------|-----|
-| 2.1 | **Tier 1: Dörfler → Gold Standard** (Mobile QA, Brand Color, Reviews, Kategorien, Lighthouse > 90) | CC | 3 | C | **Standardisierung** |
-| 2.2 | **Tier 1: Walter Leuthold → Gold Standard** | CC | 3 | C | **Standardisierung** |
-| 2.3 | **Tier 1: Orlandini → Gold Standard** (Partner-Daten klären #89) | CC | 3 | C | **Standardisierung** |
-| 2.4 | **Tier 1: Widmer → Gold Standard** (Spenglerei-Kategorien) | CC | 3 | C | **Standardisierung** |
-| 2.5 | **Tier 2: Brunner HT → Gold Standard** (Demo = Showroom-Qualität) | CC | 3 | C | **Standardisierung** |
-| 2.6 | **Tier 3: BigBen Pub** — fertigstellen wenn Material/Fotos da. Sonst: Status quo beibehalten. | CC | 2 | C | **Sonderfall** |
-| 2.7 | Weinberger Website: Video-Embed oder Loom-Link-Integration | CC | 2 | B+C | **GC-Pflicht** |
-| 2.8 | **Alle aktiven Intake-Agents:** Gold-Standard-QA (Greeting, PLZ, Empathie, Closing, FAQ) | CC | 5 | D | **GC-Pflicht** |
-| 2.9 | **SMS-Config Review:** Absendername + Inhalt + Link für JEDEN aktiven Tenant | CC | 2 | E | **GC-Pflicht** |
-| 2.10 | Outreach-Templates HOT/WARM/COLD: Final-Version, Video-Link integriert | CC | 2 | A | **GC-Pflicht** |
-| 2.11 | **Video #1: Weinberger AG** (45-60s, Screen-Recording, mehrere Takes, Schnitt) | Founder | 10 | B | **GC-Pflicht** |
-| 2.12 | **Video #2: Generisches Intro** (30-45s, kein Firmenname, wiederverwendbar) | Founder | 5 | B | **GC-Pflicht** |
-| 2.13 | **Mobile QA: Alle 7 Websites auf iPhone** — Screenshot-Protokoll pro Website | Founder | 5 | C | **GC-Pflicht** |
-| 2.14 | **Alle Agents live-testen:** Jede Nummer anrufen, Lisa-Qualität bewerten | Founder | 4 | D | **GC-Pflicht** |
-| 2.15 | Outreach E-Mail #1 für Weinberger persönlich schreiben (kein Template) | Founder | 2 | A | **GC-Pflicht** |
-| 2.16 | Vertrag: Template-Entwurf, Anwalt-Feedback verarbeiten | Founder | 4 | I | **GC-Pflicht** |
-| 2.17 | Fixes aus Mobile QA + Agent-Tests (2.13, 2.14) | CC | 5 | — | **Puffer** |
+### S4: Founder-Readiness
 
-**Founder: ~30h | CC: ~33h**
+Nur der Founder kann diese Arbeit tun. Nicht delegierbar.
 
-**Entscheidungen Woche 2:**
-- Orlandini Partner (#89): rein oder raus?
-- BigBen: Material da? Wenn ja: fertigstellen. Wenn nein: zurückstellen.
-
-**Gate/Exit-Kriterien:**
-- [ ] Alle 5 Tier-1-Websites: Lighthouse > 90, Mobile QA bestanden, keine 404s
-- [ ] Tier-2 (Brunner): Showroom-Qualität bestätigt
-- [ ] Alle aktiven Agents: E2E verifiziert, Gold-Standard-QA bestanden
-- [ ] SMS-Config für alle aktiven Tenants verifiziert
-- [ ] Video #1 (Weinberger) + Video #2 (Generisch) fertig
-- [ ] Outreach-Templates final (3 Varianten, Video integriert)
-
-**SSOT-Folgen:** Jede Website-Änderung → PR. Agent-Updates → retell_sync.mjs. STATUS.md + Ticketlist aktualisieren.
+| Block | Beschreibung | Referenz | Done-Kriterium |
+|-------|-------------|----------|----------------|
+| S4.1 | **Video-Setup** (Equipment, Workflow, Test-Recording) | gold_contact | Setup steht, reproduzierbar |
+| S4.2 | **Weinberger-Video** (45-60s) | gold_contact | "Das habe ich fuer Jul. Weinberger AG gebaut." Mehrere Takes, geschnitten. |
+| S4.3 | **Generisches Intro-Video** (30-45s) | gold_contact | Kein Firmenname. Wiederverwendbar. |
+| S4.4 | **3 Prospect-spezifische Videos** | gold_contact | Top-3 Prospects. Persoenlich, kein Template. |
+| S4.5 | **Outreach-Templates** (HOT/WARM/COLD) | gold_contact SS11 | Kein "Demo", kein Preis, kein "10 Min Gespraech". Video integriert. |
+| S4.6 | **5 persoenliche Outreach-E-Mails** | gold_contact SS11 | Geschrieben (nicht generiert), Firmenname im Betreff |
+| S4.7 | **Day-10-Call-Scripts ueben** | prospect_journey §4 Tag 10 | 3 Varianten (begeistert/skeptisch/Buerokraft) laut vorgelesen |
+| S4.8 | **SaaS-Vertrag** | — | Template fertig, Anwalt abgestimmt, unterschriftsreif, 299 CHF/Monat |
+| S4.9 | **DEMO_SIP_CALLER_ID verifizieren** | — | Env var auf Vercel. SMS E2E. BLOCKER fuer alles. |
 
 ---
 
-### Woche 3: JOURNEY PERFEKTIONIEREN (26.03.–01.04.)
+## 6. Wochenplan
 
-**Ziel:** Trial-Journey Tag 0-14 für BEIDE Profile real durchgespielt. Vertrag steht. 5 Videos fertig. Provisioning gehärtet.
+### Woche 1: REFERENZ (13.–18.03.)
 
-**Aktive Stränge:** G (Trial Journey), B (weitere Videos), I (Vertrag), F (Dashboard Polish), H (Provisioning), A (Call-Scripts)
+**Ziel:** Weinberger AG ist das perfekte Referenz-System. System-Kern steht. Video-Setup bereit.
 
-| # | Task | Owner | h | Strang | Typ |
-|---|------|-------|---|--------|-----|
-| 3.1 | **Full Dry-Run Profil "Meister":** Tag 0 (Outreach+Video an sich selbst senden) → Tag 1 (Magic Link) → Tag 5 (Day-5-Email prüfen, echten Anruf simulieren) → Tag 10 (Call-Script üben) → Tag 13 (Auto-Email prüfen) → Tag 14 (Entscheidung durchspielen) | Founder | 8 | G | **GC-Pflicht** |
-| 3.2 | **Full Dry-Run Profil "Betrieb":** Gleicher Durchlauf, Betrieb-Perspektive (Bürokraft, Dashboard-Fokus, 2. Magic Link) | Founder | 5 | G | **GC-Pflicht** |
-| 3.3 | **Video #3-5: Prospect-spezifisch** (3 Hot-Prospects aus Scout-Auswahl) | Founder | 10 | B | **GC-Pflicht** |
-| 3.4 | **Day-10-Call Scripts üben:** 3 Varianten laut vorlesen (begeistert / skeptisch / Bürokraft) | Founder | 3 | A | **GC-Pflicht** |
-| 3.5 | **Vertrag finalisieren:** SaaS-Template final, AVV-Entwurf, mit Anwalt abgestimmt | Founder | 5 | I | **GC-Pflicht** |
-| 3.6 | Scout: Top-20 Prospects identifizieren, Top-5 für Woche 4 auswählen | F+CC | 2+2 | H | **Enablement** |
-| 3.7 | BigBen: Swisscom-Weiterleitung testen wenn Paul bereit. Ergebnisse dokumentieren. | Founder | 2 | Sonderfall | **Sonderfall** |
-| 3.8 | Alle Trial-Emails verifizieren: Welcome, Day-5, Day-13. Versand testen, Ton prüfen. | CC | 3 | G | **GC-Pflicht** |
-| 3.9 | Dashboard Prospect-View: Willkommens-Banner, "Ihre Nummer", Case-Filter, mobile Polish | CC | 4 | F | **GC-Pflicht** |
-| 3.10 | Review Engine E2E: Case → Done → Review-Button → Email → Surface → Google-Link | CC | 2 | F | **GC-Pflicht** |
-| 3.11 | Provisioning Pipeline messen + optimieren (Ziel: < 15 Min) | CC | 3 | H | **Standardisierung** |
-| 3.12 | Morning Report erweitern: "Outreach-ready Prospects", "System Health" | CC | 2 | H | **Standardisierung** |
-| 3.13 | Konversions-Flow dokumentieren + testen: Prospect Ja → Vertrag → Peoplefone → Agent finalisieren → Demo-Cases löschen | CC | 2 | I | **GC-Pflicht** |
-| 3.14 | Fixes aus Dry-Runs (3.1, 3.2) | CC | 6 | — | **Puffer** |
+**Warum entscheidend:** Erst wenn Weinberger perfekt ist, wissen wir was "Gold" konkret bedeutet. Alles andere baut darauf auf.
 
-**Founder: ~35h | CC: ~24h**
+| Was | CC | Founder |
+|-----|-----|---------|
+| **Baut** | S1.1 (7 E-Mail-Templates), S1.2 (Day-5-Email), S1.3 (Demo-Tabs), S1.5-S1.6 (Wizard Notfall + Kategorien), S1.10 (Welcome Polish), S2.1 (Weinberger Gold), S2.6 (Tab-Titel) | S4.1 (Video-Setup), S4.9 (SMS-Blocker) |
+| **Verifiziert** | — | Weinberger E2E Dry-Run (Website→Anruf→SMS→Dashboard→Welcome) |
+| **Entscheidet** | — | Video-Hosting (Loom vs Embed), Vertrag-Quelle (Anwalt vs Vorlage) |
 
-**Gate/Exit-Kriterien:**
-- [ ] Full Dry-Run "Meister" bestanden: jeder Tag, jede E-Mail, jeder Bildschirm
-- [ ] Full Dry-Run "Betrieb" bestanden: dasselbe
-- [ ] 5 Videos fertig (2 aus Woche 2 + 3 neu)
-- [ ] Vertrag unterschriftsreif (mindestens Founder-approved Entwurf)
-- [ ] Provisioning < 15 Min gemessen
-- [ ] Review Engine E2E verifiziert
-- [ ] Day-10-Call Script sitzt (geübt, nicht nur geschrieben)
+**CC: ~30h | Founder: ~20h**
 
-**SSOT-Folgen:** Trial Journey als verifizierte Realität dokumentieren. Konversions-Flow in Operating Model aufnehmen. BigBen Learnings dokumentieren.
+**Test-/QA-Fokus:** Weinberger E2E fehlerfrei. Alle 7 E-Mails Tenant-gebranded.
+
+**Exit-Kriterium:** Weinberger E2E bestanden (WOW 1-4 durchgespielt). Identity Contract auf alle E-Mails angewendet. Day-5-Email funktioniert.
+
+**Groesstes Drift-Risiko:** CC baut zu viel Website-Polish statt System-Kern. **Gegenmittel:** S1 vor S2. Identity + Emails + Demo-Tabs zuerst, Lighthouse-Score danach.
 
 ---
 
-### Woche 4: MASCHINE SCHARF + FOUNDER RELEASE GATE (02.–10.04.)
+### Woche 2: DURCHSCHLAG (19.–25.03.)
+
+**Ziel:** Weinberger-Standard auf alle 7 Websites, alle Agents, alle SMS-Configs. Review Surface = Bewertungs-Vorbereiter. Erstes Video fertig.
+
+**Warum entscheidend:** Der Unterschied zwischen "einem guten Beispiel" und "einem System". Wenn nur Weinberger Gold ist, haben wir kein Produkt.
+
+| Was | CC | Founder |
+|-----|-----|---------|
+| **Baut** | S1.7-S1.9 (Review Surface + Nachlauf), S2.2 (4 Tier-1-Websites), S2.3 (Brunner), S2.4 (alle Agents QA), S2.5 (SMS-Config) | S4.2 (Weinberger-Video), S4.3 (Generisches Video), S4.5 (Outreach-Templates) |
+| **Verifiziert** | — | Mobile QA alle 7 Websites (iPhone), alle Agents live-testen |
+| **Entscheidet** | — | Orlandini Partner (#89): rein oder raus? BigBen: Material da? |
+
+**CC: ~35h | Founder: ~25h**
+
+**Test-/QA-Fokus:** Review Surface E2E (Fall→done→Badge→Review→Surface→Google). Alle Agents: Anruf→SMS→Dashboard korrekt.
+
+**Exit-Kriterium:** 5 Tier-1-Websites Gold. Alle Agents E2E. Review Surface live + funktional. 2 Videos fertig. SMS-Config verifiziert.
+
+**Groesstes Drift-Risiko:** Founder verbringt 15h mit Video-Produktion und vergisst Mobile QA. **Gegenmittel:** Mobile QA = Gate fuer Woche 3. Kein Dry-Run auf nicht-getesteten Surfaces.
+
+---
+
+### Woche 3: VERIFIKATION (26.03.–01.04.)
+
+**Ziel:** Trial-Journey Tag 0-14 fuer BEIDE Profile real durchgespielt. Vertrag steht. 5 Videos fertig. Review-Flow verifiziert.
+
+**Warum entscheidend:** Hier bricht, was in Woche 1-2 falsch war. Dry-Run ist der Haertetest. Alles was hier bricht, wird in Woche 4 als Puffer gefixt — oder der Maschinenstart verschiebt sich.
+
+| Was | CC | Founder |
+|-----|-----|---------|
+| **Baut** | S1.4 (Day-7-Snapshot), S1.8 (Nachlauf-System Feinschliff), S3.1 (Trial-Emails), S3.2 (Provisioning), S3.3 (Review E2E), S3.6 (Konversions-Flow) | S4.4 (3 Prospect-Videos), S4.7 (Call-Scripts ueben), S4.8 (Vertrag finalisieren) |
+| **Verifiziert** | Fixes aus Dry-Runs (Puffer: ~6h) | S3.4 (Dry-Run Meister), S3.5 (Dry-Run Betrieb) |
+| **Entscheidet** | — | Maschinenstart-Schwelle: 3/5 oder hoeheres Minimum? |
+
+**CC: ~25h | Founder: ~35h**
+
+**Test-/QA-Fokus:** Full Dry-Run beide Profile. Jeder Tag, jede E-Mail, jeder Bildschirm. Was bricht, wird gefixt.
+
+**Exit-Kriterium:** Dry-Run "Meister" bestanden. Dry-Run "Betrieb" bestanden. Vertrag unterschriftsreif. 5 Videos fertig. Provisioning < 15 Min.
+
+**Groesstes Drift-Risiko:** Dry-Run enthuellt zu viele Fehler → Woche 4 wird reine Fix-Woche statt Provisioning. **Gegenmittel:** Puffer 6h CC + 3h Founder. Wenn mehr als 6h Fixes noetig: Scope schneiden (weniger Prospects in Woche 4).
+
+---
+
+### Woche 4: MASCHINE (02.–10.04.)
 
 **Ziel:** 5 Prospects provisioniert, QA-bestanden. Founder Release Gate bestanden. Am 11.04. geht die erste E-Mail raus.
 
-**Aktive Stränge:** H (Provisioning 5×), A (5 persönliche Mails), B (Video-Feinschliff), C (neue Websites), alle Stränge Final-QA
+**Warum entscheidend:** Die letzte Woche. Kein Raum fuer neue Features. Nur: provisionieren, testen, freigeben.
 
-| # | Task | Owner | h | Strang | Typ |
-|---|------|-------|---|--------|-----|
-| 4.1 | **Prospect #1 provisionieren:** Crawl → Website → Agent → Tenant → SMS → Demo-Cases → Pre-Contact-Check | CC | 3 | H | **Enablement** |
-| 4.2 | **Prospect #2 provisionieren** | CC | 3 | H | **Enablement** |
-| 4.3 | **Prospect #3 provisionieren** | CC | 3 | H | **Enablement** |
-| 4.4 | **Prospect #4 provisionieren** | CC | 3 | H | **Enablement** |
-| 4.5 | **Prospect #5 provisionieren** | CC | 3 | H | **Enablement** |
-| 4.6 | **QA alle 5 Prospects:** Founder ruft jede Nummer an, prüft SMS, öffnet Dashboard, testet Website auf iPhone | Founder | 5 | H | **GC-Pflicht** |
-| 4.7 | **5 persönliche Outreach-E-Mails schreiben** | Founder | 5 | A | **GC-Pflicht** |
-| 4.8 | **Outreach-Sequenz Prospect #1 komplett:** E-Mail + Video + Call-Script + Day-10-Script | Founder | 3 | A | **GC-Pflicht** |
-| 4.9 | Video-Feinschliff: Alle 5 Prospect-Videos fertig? Retakes wo nötig. | Founder | 4 | B | **GC-Pflicht** |
-| 4.10 | Video-Produktions-Playbook finalisieren: "Neues Video in 30 Min" | Founder | 2 | B | **Standardisierung** |
-| 4.11 | Reise-Checklist durchgehen: Founder fliegt 01.05. Monitoring, Eskalation, Morning Report. | Founder | 2 | H | **Enablement** |
-| 4.12 | Quality Gate Enforcement: Pre-Contact-Check Ergebnis pro Prospect dokumentieren | CC | 2 | H | **Standardisierung** |
-| 4.13 | Morning Report: "5 Prospects outreach-ready, 0 active trials, system healthy" | CC | 1 | H | **Standardisierung** |
-| 4.14 | Final System-Check: Health grün, Sentry konfiguriert, Telegram läuft, Lifecycle Tick OK | CC | 2 | H | **GC-Pflicht** |
-| 4.15 | SSOT Final Review: STATUS.md, Ticketlist.md, gold_contact.md — Stand 10.04. | CC+F | 2+2 | H | **Standardisierung** |
-| 4.16 | **FOUNDER RELEASE GATE** (siehe unten) | Founder | 4 | ALLE | **GC-Pflicht** |
-| 4.17 | Puffer | F+CC | 3+2 | — | **Puffer** |
+| Was | CC | Founder |
+|-----|-----|---------|
+| **Baut** | 5× Prospect provisionieren (Crawl→Website→Agent→Tenant→SMS→Demo-Cases) | S4.6 (5 persoenliche Outreach-E-Mails) |
+| **Verifiziert** | Final System-Check (Health, Sentry, Telegram, Lifecycle Tick) | **FOUNDER RELEASE GATE** pro Prospect (§8) |
+| **Entscheidet** | — | Go/No-Go pro Prospect. Maschinenstart-Freigabe. |
 
-**Founder: ~30h | CC: ~21h**
+**CC: ~20h | Founder: ~30h**
+
+**Test-/QA-Fokus:** Founder ruft jede Nummer an, prueft SMS, oeffnet Dashboard auf iPhone, liest Outreach-E-Mail.
+
+**Exit-Kriterium:** Mindestens 3/5 Prospects bestehen Founder Release Gate. System Health gruen. Morning Report zeigt "outreach-ready".
+
+**Groesstes Drift-Risiko:** Founder gibt Prospects durch, die nicht Gold sind ("Reicht schon fuer den Anfang"). **Gegenmittel:** Gate ist 10/10 oder 8-9/10 (mit dokumentiertem Plan fuer fehlende Punkte). < 8 = Prospect geht nicht raus.
 
 ---
 
-## Founder Release Gate: "Maschinenstart-Freigabe"
+## 7. Rollenlogik
 
-### Was ist das
+### CC-Work (System + Code)
 
-Am Ende von Woche 4, vor dem 11.04., durchläuft der Founder einen strukturierten Go/No-Go-Entscheid pro Prospect. Die Frage ist nicht "funktioniert die Technik?" — sondern:
+- Alle Build-Bloecke in S1 + S2
+- E-Mail-Templates, Wizard-Logik, Review Surface, Leitstand-Nachlauf
+- Website Gold-Standard (Code, Performance, Lighthouse)
+- Agent-JSON + retell_sync.mjs
+- Provisioning der 5 Prospects in Woche 4
+- Fixes aus Dry-Runs und QA
+- SSOT-Updates nach jedem Block
 
-> **"Würde ich diesen Prospect jetzt ohne Bauchweh kontaktieren — ja oder nein?"**
+### Founder-Work (Erlebnis + Entscheid)
 
-### Wer prüft
+- Videos aufnehmen + schneiden
+- Outreach-E-Mails schreiben (persoenlich, kein Template)
+- Call-Scripts ueben (laut, mit Varianten)
+- SaaS-Vertrag (Anwalt, Template, Finalisierung)
+- Mobile QA auf echtem iPhone
+- Alle Agents live anrufen
+- DEMO_SIP_CALLER_ID setzen (BLOCKER)
+- Dry-Run beide Profile durchspielen
+- Founder Release Gate durchfuehren
 
-Founder persönlich. Nicht delegierbar. Jeder Prospect wird einzeln bewertet.
+### Gemeinsame Gates
 
-### Prüfkriterien pro Prospect (10 Berührungspunkte)
+| Gate | Wann | Wer prueft |
+|------|------|-----------|
+| Weinberger E2E | Ende Woche 1 | Founder (Anruf + iPhone) + CC (System-Check) |
+| Mobile QA alle 7 | Ende Woche 2 | Founder (iPhone) + CC (Lighthouse) |
+| Dry-Run Meister | Woche 3 | Founder (durchspielt) + CC (fixt was bricht) |
+| Dry-Run Betrieb | Woche 3 | Founder (durchspielt) + CC (fixt was bricht) |
+| **Founder Release Gate** | Ende Woche 4 | **Founder allein** (nicht delegierbar) |
 
-| # | Berührungspunkt | Prüfung | Bestanden? |
-|---|----------------|---------|------------|
-| 1 | **Persönliche E-Mail** | Gelesen. Klingt persönlich, nicht nach Template. Firmenname im Betreff. Würde ich das an einen Freund weiterleiten? | [ ] |
-| 2 | **Prospect-spezifisches Video** | Angeschaut. Zeigt SEINEN Betrieb. Kein Versprecher, kein Rauschen, guter Ton. Würde ich das meiner Mutter zeigen? | [ ] |
-| 3 | **Website / Webfläche** | Auf iPhone geöffnet. Sieht professionell aus. Sein Name, seine Services, seine Reviews. Keine 404s. Lädt schnell. | [ ] |
-| 4 | **Voice-Agent** | Angerufen. Lisa sagt seinen Firmennamen. PLZ funktioniert. Kein Fehler. Höflich, schnell, kompetent. | [ ] |
-| 5 | **SMS-Moment** | SMS kam an. Richtiger Absendername. Inhalt stimmt. Link funktioniert. Foto-Upload funktioniert. | [ ] |
-| 6 | **Welcome / Magic Link** | Link geklickt. Dashboard öffnet sich. Kein Passwort. Welcome Page zeigt seine Nummer. | [ ] |
-| 7 | **Dashboard / Mobile** | Auf iPhone geöffnet. Sein Testfall ist da. Filter funktioniert. Demo-Cases nicht störend. Sieht professionell aus. | [ ] |
-| 8 | **Trial-Journey Tag 0-14** | Day-5 Email: kommt, richtiger Ton. Day-13 Email: kommt, richtiger Ton. Lifecycle Tick: läuft. | [ ] |
-| 9 | **Day-10 Call-Script** | Für diesen Prospect vorbereitet. Meister oder Betrieb? Welche Frage? Welche Variante bei Skepsis? | [ ] |
-| 10 | **Vertrags-/Closing-Readiness** | Wenn er Ja sagt: Vertrag da? Preis klar? Nächster Schritt definiert? | [ ] |
+### Reine Freigabepunkte (Founder)
+
+- Video-Hosting-Entscheid (Woche 1)
+- Vertrag-Quelle (Woche 1)
+- Orlandini Partner-Entscheid (Woche 2)
+- Maschinenstart-Schwelle (Woche 3)
+- Go/No-Go pro Prospect (Woche 4)
+
+---
+
+## 8. Founder Release Gate
+
+### Prüfkriterien pro Prospect (10 Beruehrungspunkte)
+
+> **"Wuerde ich diesen Prospect jetzt ohne Bauchweh kontaktieren — ja oder nein?"**
+
+| # | Beruehrungspunkt | Pruefung |
+|---|-----------------|---------|
+| 1 | **Persoenliche E-Mail** | Klingt persoenlich, nicht nach Template. Firmenname im Betreff. |
+| 2 | **Prospect-spezifisches Video** | Zeigt SEINEN Betrieb. Kein Versprecher, guter Ton. |
+| 3 | **Website / Webflaeche** | Auf iPhone geoeffnet. Professionell. Sein Name, seine Services. Schnell. |
+| 4 | **Voice-Agent** | Angerufen. Lisa sagt seinen Firmennamen. PLZ funktioniert. Kein Fehler. |
+| 5 | **SMS-Moment** | SMS kam an. Richtiger Absendername. Link funktioniert. Foto-Upload geht. |
+| 6 | **Welcome / Magic Link** | Link geklickt → Dashboard. Kein Passwort. Welcome Page zeigt seine Nummer. |
+| 7 | **Dashboard / Mobile** | Auf iPhone. Sein Testfall da. Demo-Cases nicht stoerend. Professionell. |
+| 8 | **Trial-Journey Tag 0-14** | Day-5, Day-13 Email kommen an. Richtiger Ton. Lifecycle Tick laeuft. |
+| 9 | **Day-10 Call-Script** | Fuer diesen Prospect vorbereitet. Meister oder Betrieb? Welche Variante bei Skepsis? |
+| 10 | **Vertrags-/Closing-Readiness** | Wenn er Ja sagt: Vertrag da? Preis klar? Naechster Schritt definiert? |
 
 ### Bewertung
 
 - **10/10:** Prospect geht raus am 11.04.
-- **8-9/10:** Prospect geht raus, fehlende Punkte werden in Woche 1 nach Maschinenstart nachgezogen (nur wenn kein Kill-Szenario betroffen).
-- **< 8/10:** Prospect geht NICHT raus. CC fixt. Founder re-prüft.
+- **8-9/10:** Geht raus, fehlende Punkte werden nachgezogen (kein Kill-Szenario betroffen).
+- **< 8/10:** Prospect geht NICHT raus. CC fixt. Founder re-prueft.
 
-### Was bei "Nein"
+### Minimum fuer Maschinenstart
 
-Prospect wird nicht kontaktiert am 11.04. CC fixt die fehlenden Punkte. Founder prüft erneut. Prospect geht raus, sobald Gate bestanden — auch nach dem 11.04.
-
-**Kein Prospect geht raus, der das Gate nicht bestanden hat.** Lieber 3 perfekte Kontakte als 5 mittelmässige.
-
-### Minimum für Maschinenstart
-
-- **Mindestens 3 von 5 Prospects** müssen das Founder Release Gate bestehen.
-- Wenn weniger als 3: Maschinenstart verschieben auf den Tag, an dem 3 Prospects Gate bestanden haben.
-- Das ist kein Scheitern — das ist Qualitätskontrolle.
+- Mindestens **3 von 5** Prospects muessen Gate bestehen.
+- Weniger als 3: Maschinenstart verschieben.
+- Das ist kein Scheitern — das ist Qualitaetskontrolle.
+- **Kein Prospect geht raus, der das Gate nicht bestanden hat.**
 
 ---
 
-## Task-Typen im Redesign
+## 9. Anti-Drift
 
-| Typ | Bedeutung | Beispiele |
-|-----|-----------|----------|
-| **GC-Pflicht** | Direkt im Gold Contact als Berührungspunkt benannt. Nicht verhandelbar. | Video, SMS, Lisa-Greeting, Day-5-Email, Day-10-Call, Welcome-Flow |
-| **Standardisierung** | Gold-Contact-Standard auf alle Flächen durchschlagen. Der Unterschied zwischen "einem guten Beispiel" und "einem System". | Alle 7 Websites, alle Agents, alle SMS-Configs, Provisioning-Auto-Scaling |
-| **Enablement** | Support-Arbeit, die GC-Pflicht-Punkte ermöglicht. | Provisioning, Scout, Video-Setup, Equipment |
-| **Sonderfall** | BigBen / Tier-3 Arbeit. Gezielt, nicht aufgeblasen. | BigBen Website, Swisscom-Test, Gastro-Agent |
-| **Puffer** | Fixes für das, was in Dry-Runs und QA bricht. 15-20% des Plans. | "Fixes aus Dry-Run" Blöcke |
+### Was NICHT Teil der Build-Phase ist
 
----
+| Thema | Grund |
+|-------|-------|
+| Google Reviews API Import | gold_contact: "Google-Link klicken", nicht automatisch importieren |
+| Stripe / automatisierte Billing | Vertrag + manuelle Rechnung reicht fuer 1-5 Kunden |
+| Mobile App / PWA | Magic Link → Dashboard. Kein App Store. |
+| Kalender-Sync | Kundenfeedback-Trigger, nicht Gold Contact |
+| Analytics Dashboard | Post-Go-Live |
+| LinkedIn | Marketing-Kanal, nicht Contact-to-Test Experience |
 
-## Anti-Drift
+### 4 Drift-Gefahren
 
-### NICHT Teil dieses 4-Wochen-Redesigns
-
-| Thema | Warum raus | Gold-Contact-Bezug |
-|-------|-----------|-------------------|
-| Google Reviews API Import | Gold Contact sagt "Bewertungsseite → Google-Link klicken." Nicht "automatisch importieren." Das IST der Standard. | §12: Reviews one-way outbound |
-| Stripe / automatisierte Billing | Gold Contact sagt "Founder aktiviert Abo." Vertrag + manuelle Rechnung reicht für 1-5 Kunden. | §11: "Founder aktiviert" |
-| Mobile App / PWA | Gold Contact sagt "Magic Link → Dashboard." Kein App Store. | §3: "Kein Setup nötig" |
-| Kalender-Sync (N3) | Kundenfeedback-Trigger, nicht Gold-Contact-Bestandteil. | Nicht referenziert |
-| Analytics Dashboard (N23) | Post-Go-Live Metrik-Tool. | §15: Metriken = Founder-Notiz |
-| LinkedIn Unternehmensseite (L5) | Marketing-Kanal, nicht Contact-to-Test Experience. | Nicht referenziert |
-| Twilio Number-Pool Automation | Operational convenience. Manuelles Reassign reicht für < 10 Trials. | Nicht referenziert |
-
-### Wo Website-first Drift droht
-
-**Gefahr:** CC verbringt 40h mit Lighthouse-Optimierung und CSS-Feinschliff an 7 Websites, während Trial-Journey-Emails nicht getestet sind.
-
-**Gegenmittel:** Websites = Strang C. Trial Journey = Strang G. Eigene Exit-Kriterien pro Strang. Woche 2 = Website-Woche, Woche 3 = Journey-Woche. Nicht umgekehrt, nicht verschmelzen.
-
-### Wo Architektur-Selbstzweck droht
-
-**Gefahr:** CC baut automatisierte Lighthouse-CI-Pipeline, Pre-Contact-Check als GitHub Action, Demo-Case-Routing-Engine — technisch sauber, merkt keiner.
-
-**Gegenmittel:** Jeder CC-Task muss diese Frage bestehen: *"Merkt der Prospect den Unterschied?"* Pre-Contact-Check als Script mit --pass Flag = ja. CI-Pipeline dafür = overengineered für 5 Prospects.
-
-### Wo "viel gebaut, aber Erlebnis nicht brutal gut" droht
-
-**Gefahr:** Am 10.04. alle Checklisten grün, aber: Video mittelmässig, Outreach-Mail Template-Gefühl, Day-10-Call improvisiert.
-
-**Gegenmittel:** Der Founder Release Gate testet das Erlebnis, nicht das System. "Würde ich das meiner Mutter zeigen?" schlägt "Lighthouse Score 94."
-
-### Wo BigBen den Kernfokus verwässert
-
-**Gefahr:** Founder verbringt 15h mit Swisscom-Debugging für Paul, während Tier-1-Call-Scripts nicht geübt sind.
-
-**Gegenmittel:** BigBen = Tier 3. Feste Zeitbox: max 4h im gesamten Redesign (2h Woche 3, 2h Puffer). Swisscom-Test nur wenn Paul bereit UND Tier-1-Gates on track.
+| Gefahr | Gegenmittel |
+|--------|------------|
+| **Website-first:** CC verbringt 40h mit Lighthouse statt System-Kern | S1 vor S2. Identity + Emails + Tabs zuerst. |
+| **Architektur-Selbstzweck:** Automatisierte CI-Pipeline fuer 5 Prospects | Jeder CC-Task muss bestehen: "Merkt der Prospect den Unterschied?" |
+| **Viel gebaut, Erlebnis nicht brutal gut:** Checklisten gruen, Video mittelmaessig | Founder Release Gate testet Erlebnis, nicht System. |
+| **BigBen verwaessert Kernfokus:** 15h Swisscom-Debugging statt Call-Scripts | Zeitbox: max 4h. Nur wenn Tier-1-Gates on track. |
 
 ---
 
-## Stunden-Übersicht
+## 10. Zeithorizont-Uebersicht
 
-| Woche | Founder | CC | Thema |
-|-------|---------|-----|-------|
-| 1 | 21h | 30h | Referenz-Standard + Blocker Kill |
-| 2 | 30h | 33h | Standard Durchschlagen (alle 7 + Videos) |
-| 3 | 35h | 24h | Journey Perfektionieren + Vertrag |
-| 4 | 30h | 21h | Maschine Scharf + Founder Release Gate |
-| **Total** | **116h** | **108h** | |
+| Woche | CC | Founder | Thema | Gate |
+|-------|-----|---------|-------|------|
+| 1 (13.-18.03.) | ~30h | ~20h | Referenz-Standard + System-Kern | Weinberger E2E |
+| 2 (19.-25.03.) | ~35h | ~25h | Standard Durchschlagen + Review Gold | Mobile QA + Agents E2E |
+| 3 (26.03.-01.04.) | ~25h | ~35h | Journey Verifikation + Vertrag | Dry-Run × 2 |
+| 4 (02.-10.04.) | ~20h | ~30h | Maschine Scharf | **Founder Release Gate** |
+| **Total** | **~110h** | **~110h** | | |
 
-**Founder: 116h von 170h** → 54h Reserve für Video-Retakes, Vertragsverhandlung, Dry-Run-Fixes, weitere Prospects, oder BigBen.
+**Founder: 110h von 170h** → 60h Reserve fuer Video-Retakes, Vertragsverhandlung, Dry-Run-Fixes, weitere Prospects.
 
-Die 54h Reserve ist kein Budget für neue Features. Es ist der Unterschied zwischen "Plan geschafft" und "brutal gut." Die Reserve fliesst dorthin, wo Dry-Runs und das Founder Release Gate zeigen, dass es noch nicht reicht.
-
----
-
-## Top 5 Entscheidungen, die wir erzwingen müssen
-
-1. **Video-Hosting (Woche 1):** Loom-Link in E-Mail oder embedded auf Website? Muss vor Produktion feststehen.
-2. **Orlandini Partner-Daten #89 (Woche 2):** Rein oder raus? Blockiert Website-Gold-Standard.
-3. **Vertrag-Template-Quelle (Woche 1-2):** Anwalt, SaaS-Vorlage, oder selbst entwerfen?
-4. **Day-5-Email Ton (Woche 1):** Wie direktiv? Muss zum Gold-Contact-Ton passen ("beiläufig, nicht drängend").
-5. **Maschinenstart-Schwelle (Woche 4):** Mindestens 3/5 Prospects müssen Founder Release Gate bestehen. Wenn weniger: verschieben?
-
-## Top 5 Artefakte, die am 10.04. stehen müssen
-
-1. **5 Prospect-spezifische Videos** — aufgenommen, geschnitten, gehostet, in Outreach-E-Mails eingebunden
-2. **5 outreach-ready Prospects** — Website + Agent + SMS + Dashboard + Pre-Contact-Check + Founder Release Gate bestanden
-3. **SaaS-Vertrag** — unterschriftsreif, 299 CHF/Monat, monatlich kündbar, AVV inklusive
-4. **Trial-Journey verifiziert** — für beide Profile (Meister + Betrieb) Tag 0-14 real durchgespielt
-5. **7 Kunden-Websites auf Gold Standard** — Tier 1 (5×): Lighthouse > 90, Mobile QA, Content verifiziert. Tier 2 (1×): Showroom-Qualität. Tier 3 (1×): fertig wenn Material da.
-
-## Woran wir am 10.04. erkennen, dass Gold Contact materialisiert ist
-
-Am 11.04. öffnet Gunnar sein Handy, wählt Prospect #1 aus, und drückt "Senden" auf eine E-Mail, die den Namen des Betriebs im Betreff hat, ein 45-Sekunden-Video enthält das seinen Betrieb zeigt, und eine Testnummer die sofort funktioniert. Alles dahinter — Website, Lisa, SMS, Dashboard, Welcome-Flow, Review-Engine, Trial-Emails, Day-10-Script, Vertrag — steht. Nicht "meistens." Nicht "für Weinberger." Für jeden Prospect, der das Founder Release Gate bestanden hat. Kompromisslos.
+Die Reserve ist kein Budget fuer neue Features. Sie fliesst dorthin, wo Dry-Runs und das Founder Release Gate zeigen, dass es noch nicht reicht.
 
 ---
 
-## Änderungen gegenüber V1
+## 11. Am 10.04. erkennen wir Gold daran
 
-| Punkt | V1 | V2 |
-|-------|----|----|
-| **Rahmung** | Implizit Minimum-Go-Live ("was muss mindestens stehen") | Explizit kompromisslose Vollumsetzung |
-| **BigBen** | "Sonderfall, gleicher Standard?" als offene Frage | Klar gerahmt: Tier 3, Sonderfall ausserhalb Kernvertikale, im Scope mit spezifischem Lernziel (Swisscom), Zeitbox 4h |
-| **Modus/Tier** | Vermischt (Modus 1 = Tier 1 implizit) | Sauber getrennt: Modus = Deliverable-Logik, Tier = Prioritäts-Logik. 7 Cases explizit zugeordnet. |
-| **Founder Release Gate** | Fehlte | Strukturiertes Go/No-Go pro Prospect, 10 Berührungspunkte, Minimum 3/5 für Maschinenstart |
-| **Anti-Drift BigBen** | Nicht adressiert | Explizite Zeitbox (4h), Gegenmittel gegen Verwässerung |
-| **Video als Strang** | Unterpunkt in Woche 2 | Eigener Produktionsstrang B, durchzieht Woche 1-4, Playbook als Deliverable |
-| **Websites** | Weinberger Gold, Rest "kommt mit" | Alle 7 explizit mit Tier-spezifischer Definition of Done |
+Am 11.04. oeffnet Gunnar sein Handy, waehlt Prospect #1 aus und drueckt "Senden" auf eine E-Mail, die den Namen des Betriebs im Betreff hat, ein 45-Sekunden-Video enthaelt das seinen Betrieb zeigt, und eine Testnummer die sofort funktioniert. Alles dahinter — Website, Lisa, SMS, Dashboard, Welcome-Flow, Review-Engine, Trial-Emails, Day-10-Script, Vertrag — steht. Nicht "meistens." Nicht "fuer Weinberger." Fuer jeden Prospect, der das Founder Release Gate bestanden hat. Kompromisslos.


### PR DESCRIPTION
## Summary
- Transform plan.md from 668-line redesign planning document into ~400-line CEO-grade build execution document
- Replace 9 redesign strands with 4 build streams (S1 System-Kern, S2 Oberflächen-Qualität, S3 Journey-Verifikation, S4 Founder-Readiness)
- Add 31 explicit build blocks with Zielbild references, done criteria, and E2E tests
- Add 4-week timeline with CC/Founder splits per week, drift risks, and exit criteria
- Founder Release Gate: 10 Berührungspunkte, 3/5 prospects must pass
- Gold Contact = permanent standard, not phase

## Test plan
- [ ] Verify all Zielbild cross-references point to existing files
- [ ] Confirm SSOT role descriptions match ticketlist.md + STATUS.md
- [ ] Review build block sequencing (S1→S2→S3→S4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)