### PR TITLE
feat: Identity Contract on all emails + tab title (Block A.1)

### DIFF
--- a/scripts/_ops/_lib/send_email.mjs
+++ b/scripts/_ops/_lib/send_email.mjs
@@ -10,16 +10,17 @@
 const RESEND_API = "https://api.resend.com/emails";
 
 /**
- * @param {{ to: string, subject: string, html: string, text?: string }} opts
+ * @param {{ to: string, subject: string, html: string, text?: string, fromName?: string }} opts
  * @returns {Promise<{ success: boolean, messageId?: string, error?: string }>}
  */
-export async function sendEmail({ to, subject, html, text }) {
+export async function sendEmail({ to, subject, html, text, fromName }) {
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
     return { success: false, error: "RESEND_API_KEY not set" };
   }
 
-  const from = process.env.MAIL_FROM || "noreply@send.flowsight.ch";
+  const addr = process.env.MAIL_FROM || "noreply@send.flowsight.ch";
+  const from = fromName ? `${fromName} <${addr}>` : addr;
 
   try {
     const body = { from, to, subject, html };

--- a/scripts/_ops/offboard_tenant.mjs
+++ b/scripts/_ops/offboard_tenant.mjs
@@ -116,18 +116,18 @@ async function main() {
 <!-- Gold accent bar -->
 <tr><td style="height:4px;background:#d4a853;font-size:0;line-height:0">&nbsp;</td></tr>
 <!-- Logo -->
-<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">FlowSight</td></tr>
+<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">${tenant.name}</td></tr>
 <!-- Heading -->
 <tr><td style="padding:0 24px;color:#e2e8f0;font-size:22px;font-weight:700">Guten Tag</td></tr>
 <!-- Body text -->
 <tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
-Ihr 14-Tage Trial bei FlowSight ist abgelaufen. Vielen Dank f&uuml;r Ihr Interesse.
+Ihr 14-Tage Trial ist abgelaufen. Vielen Dank f&uuml;r Ihr Interesse.
 </td></tr>
 <!-- What they experienced -->
 <tr><td style="padding:20px 24px 0;color:#94a3b8;font-size:13px;text-transform:uppercase;letter-spacing:1px">In den letzten 14 Tagen hatten Sie Zugang zu</td></tr>
 <tr><td style="padding:8px 24px 0;color:#e2e8f0;font-size:14px;line-height:2">
 &bull; Ihrer pers&ouml;nlichen KI-Assistentin Lisa<br>
-&bull; Dem FlowSight Dashboard<br>
+&bull; Dem Dashboard<br>
 &bull; Automatisierten SMS-Best&auml;tigungen<br>
 &bull; Dem Review-System
 </td></tr>
@@ -152,15 +152,15 @@ Falls Sie FlowSight in Ihrem Betrieb einsetzen m&ouml;chten, melden Sie sich jed
     const offboardText = [
       "Guten Tag",
       "",
-      "Ihr 14-Tage Trial bei FlowSight ist abgelaufen. Vielen Dank für Ihr Interesse.",
+      "Ihr 14-Tage Trial ist abgelaufen. Vielen Dank für Ihr Interesse.",
       "",
       "In den letzten 14 Tagen hatten Sie Zugang zu:",
       "- Ihrer persönlichen KI-Assistentin Lisa",
-      "- Dem FlowSight Dashboard",
+      "- Dem Dashboard",
       "- Automatisierten SMS-Bestätigungen",
       "- Dem Review-System",
       "",
-      "Falls Sie FlowSight in Ihrem Betrieb einsetzen möchten, melden Sie sich jederzeit.",
+      "Falls Sie das System in Ihrem Betrieb einsetzen möchten, melden Sie sich jederzeit.",
       "",
       "---",
       "Gunnar Wende — 044 552 09 19 — gunnar@flowsight.ch",
@@ -171,9 +171,10 @@ Falls Sie FlowSight in Ihrem Betrieb einsetzen m&ouml;chten, melden Sie sich jed
     } else {
       const offboardResult = await sendEmail({
         to: tenant.prospect_email,
-        subject: "Ihr FlowSight Trial — Danke für Ihr Interesse",
+        subject: `Ihr Trial — Danke für Ihr Interesse`,
         html: offboardHtml,
         text: offboardText,
+        fromName: `${tenant.name} via FlowSight`,
       });
 
       if (offboardResult.success) {

--- a/scripts/_ops/provision_trial.mjs
+++ b/scripts/_ops/provision_trial.mjs
@@ -258,12 +258,12 @@ async function main() {
 <!-- Gold accent bar -->
 <tr><td style="height:4px;background:#d4a853;font-size:0;line-height:0">&nbsp;</td></tr>
 <!-- Logo -->
-<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">FlowSight</td></tr>
+<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">${name}</td></tr>
 <!-- Heading -->
 <tr><td style="padding:0 24px;color:#e2e8f0;font-size:22px;font-weight:700">Guten Tag</td></tr>
 <!-- Welcome text -->
 <tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
-Ihr FlowSight Trial ist aktiv. Ab sofort k&ouml;nnen Sie unser System testen.
+Ihr 14-Tage Trial ist aktiv. Ab sofort k&ouml;nnen Sie das System testen.
 </td></tr>
 <!-- CTA button -->
 <tr><td style="padding:24px 24px 8px" align="center">
@@ -298,7 +298,7 @@ ${phoneSection}
     const welcomeText = [
       "Guten Tag",
       "",
-      "Ihr FlowSight Trial ist aktiv. Ab sofort können Sie unser System testen.",
+      "Ihr 14-Tage Trial ist aktiv. Ab sofort können Sie das System testen.",
       "",
       `Dashboard öffnen: ${magicLink}`,
       "",
@@ -319,9 +319,10 @@ ${phoneSection}
 
     const welcomeResult = await sendEmail({
       to: prospectEmail,
-      subject: "Willkommen — Ihr 14-Tage Trial bei FlowSight",
+      subject: `Willkommen — Ihr 14-Tage Trial für ${name}`,
       html: welcomeHtml,
       text: welcomeText,
+      fromName: `${name} via FlowSight`,
     });
 
     if (welcomeResult.success) {

--- a/src/web/app/api/cases/route.ts
+++ b/src/web/app/api/cases/route.ts
@@ -203,6 +203,14 @@ export async function POST(request: NextRequest) {
   try {
     const supabase = getServiceClient();
 
+    // Resolve tenant display name for email branding (Identity Contract E4)
+    const { data: tenantInfo } = await supabase
+      .from("tenants")
+      .select("name")
+      .eq("id", tenantId)
+      .single();
+    const tenantDisplayName = tenantInfo?.name ?? undefined;
+
     // Build insert payload — street/house_number are optional columns
     // that may not exist if the address migration hasn't been applied yet.
     const insertPayload: Record<string, unknown> = {
@@ -259,6 +267,7 @@ export async function POST(request: NextRequest) {
         caseId: row.id,
         seqNumber: row.seq_number,
         tenantId,
+        tenantDisplayName,
         contactEmail: data.contact_email,
         category: data.category,
       });
@@ -271,6 +280,7 @@ export async function POST(request: NextRequest) {
       caseId: row.id,
       seqNumber: row.seq_number,
       tenantId,
+      tenantDisplayName,
       source: data.source,
       category: data.category,
       urgency: data.urgency,

--- a/src/web/app/api/lifecycle/tick/route.ts
+++ b/src/web/app/api/lifecycle/tick/route.ts
@@ -204,7 +204,9 @@ async function sendDay13Email(
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) return false;
 
-  const from = process.env.MAIL_FROM || "noreply@send.flowsight.ch";
+  const fromAddr = process.env.MAIL_FROM || "noreply@send.flowsight.ch";
+  const safeName = companyName.replace(/[<>"]/g, "");
+  const from = `${safeName} via FlowSight <${fromAddr}>`;
 
   const html = `<!DOCTYPE html>
 <html lang="de">
@@ -214,14 +216,14 @@ async function sendDay13Email(
 <tr><td align="center">
 <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#0b1120;border-radius:8px;overflow:hidden">
 <tr><td style="height:4px;background:#d4a853;font-size:0;line-height:0">&nbsp;</td></tr>
-<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">FlowSight</td></tr>
+<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">${companyName}</td></tr>
 <tr><td style="padding:0 24px;color:#e2e8f0;font-size:22px;font-weight:700">Ihr Trial endet bald</td></tr>
 <tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
 Guten Tag,<br><br>
-Ihr FlowSight Trial f&uuml;r <strong style="color:#e2e8f0">${companyName}</strong> endet am <strong style="color:#e2e8f0">${trialEndDate}</strong>.
+Ihr 14-Tage Trial f&uuml;r <strong style="color:#e2e8f0">${companyName}</strong> endet am <strong style="color:#e2e8f0">${trialEndDate}</strong>.
 </td></tr>
 <tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
-Falls Sie FlowSight weiterhin nutzen m&ouml;chten, melden Sie sich bei uns &mdash; wir k&uuml;mmern uns um alles Weitere.
+Falls Sie das System weiterhin nutzen m&ouml;chten, melden Sie sich bei uns &mdash; wir k&uuml;mmern uns um alles Weitere.
 </td></tr>
 <tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
 Falls nicht: kein Problem. Ihre Daten werden nach Ablauf des Trials sicher gel&ouml;scht.
@@ -238,9 +240,9 @@ Falls nicht: kein Problem. Ihre Daten werden nach Ablauf des Trials sicher gel&o
   const text = [
     "Guten Tag,",
     "",
-    `Ihr FlowSight Trial für ${companyName} endet am ${trialEndDate}.`,
+    `Ihr 14-Tage Trial für ${companyName} endet am ${trialEndDate}.`,
     "",
-    "Falls Sie FlowSight weiterhin nutzen möchten, melden Sie sich bei uns — wir kümmern uns um alles Weitere.",
+    "Falls Sie das System weiterhin nutzen möchten, melden Sie sich bei uns — wir kümmern uns um alles Weitere.",
     "",
     "Falls nicht: kein Problem. Ihre Daten werden nach Ablauf des Trials sicher gelöscht.",
     "",
@@ -255,7 +257,7 @@ Falls nicht: kein Problem. Ihre Daten werden nach Ablauf des Trials sicher gel&o
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ from, to, subject: "Ihr FlowSight Trial endet bald", html, text }),
+      body: JSON.stringify({ from, to, subject: `Ihr Trial endet bald — ${companyName}`, html, text }),
     });
     return res.ok;
   } catch {

--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -60,15 +60,17 @@ export async function POST(
     );
   }
 
-  // ── Google Review URL (optional fallback — our review surface is primary)
+  // ── Tenant info (name + modules) ─────────────────────────────────────
   let googleReviewUrl: string | undefined;
+  let tenantDisplayName: string | undefined;
   {
     const { data: tenant } = await supabase
       .from("tenants")
-      .select("modules")
+      .select("name, modules")
       .eq("id", row.tenant_id)
       .single();
 
+    tenantDisplayName = tenant?.name ?? undefined;
     const modules = tenant?.modules as Record<string, unknown> | null;
     if (typeof modules?.google_review_url === "string" && modules.google_review_url.length > 0) {
       googleReviewUrl = modules.google_review_url;
@@ -100,6 +102,7 @@ export async function POST(
     sent = await sendReviewRequest({
       caseId: id,
       tenantId: row.tenant_id,
+      tenantDisplayName,
       contactEmail: row.contact_email,
       reviewSurfaceUrl,
       googleReviewUrl,

--- a/src/web/app/api/retell/webhook/route.ts
+++ b/src/web/app/api/retell/webhook/route.ts
@@ -397,6 +397,15 @@ export async function POST(req: Request) {
 
   Sentry.setTag("tenant_id", tenantId);
 
+  // Resolve tenant display name for email branding (Identity Contract E4)
+  const supabaseEarly = getServiceClient();
+  const { data: tenantRow } = await supabaseEarly
+    .from("tenants")
+    .select("name")
+    .eq("id", tenantId)
+    .single();
+  const tenantDisplayName = tenantRow?.name ?? undefined;
+
   // ── Module check: voice ─────────────────────────────────────────────
   if (!(await hasModule(tenantId, "voice"))) {
     Sentry.captureMessage("voice_module_disabled", {
@@ -491,6 +500,7 @@ export async function POST(req: Request) {
       caseId,
       seqNumber: row.seq_number,
       tenantId,
+      tenantDisplayName,
       source: "voice",
       category: category!,
       urgency: urgencyRaw as CaseUrgency,

--- a/src/web/app/ops/(dashboard)/layout.tsx
+++ b/src/web/app/ops/(dashboard)/layout.tsx
@@ -1,11 +1,17 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
 import { getServiceClient } from "@/src/lib/supabase/server";
 import { OpsShell } from "@/src/components/ops/OpsShell";
 
-async function resolveTenantName(
+interface TenantIdentity {
+  name: string | null;
+  shortName: string | null;
+}
+
+async function resolveTenantIdentity(
   user: { app_metadata?: Record<string, unknown> }
-): Promise<string | null> {
+): Promise<TenantIdentity> {
   try {
     const supabase = getServiceClient();
     // 1. Prefer explicit tenant_id from user metadata (set via Supabase admin)
@@ -13,20 +19,54 @@ async function resolveTenantName(
     if (metaTenantId) {
       const { data } = await supabase
         .from("tenants")
-        .select("name")
+        .select("name, modules")
         .eq("id", metaTenantId)
         .single();
-      if (data?.name) return data.name;
+      if (data?.name) {
+        const modules = data.modules as Record<string, unknown> | null;
+        const shortName =
+          typeof modules?.sms_sender_name === "string"
+            ? modules.sms_sender_name
+            : null;
+        return { name: data.name, shortName };
+      }
     }
     // 2. Fallback: if only one tenant exists (common in early MVP), use it
     const { data: tenants } = await supabase
       .from("tenants")
-      .select("name")
+      .select("name, modules")
       .limit(2);
-    if (tenants && tenants.length === 1) return tenants[0].name;
-    return null;
+    if (tenants && tenants.length === 1) {
+      const modules = tenants[0].modules as Record<string, unknown> | null;
+      const shortName =
+        typeof modules?.sms_sender_name === "string"
+          ? modules.sms_sender_name
+          : null;
+      return { name: tenants[0].name, shortName };
+    }
+    return { name: null, shortName: null };
   } catch {
-    return null;
+    return { name: null, shortName: null };
+  }
+}
+
+/**
+ * Dynamic tab title: "{short_name} OPS" per Identity Contract E1.
+ * Falls back to "FlowSight OPS" for admin or when no tenant is scoped.
+ */
+export async function generateMetadata(): Promise<Metadata> {
+  try {
+    const authClient = await getAuthClient();
+    const {
+      data: { user },
+    } = await authClient.auth.getUser();
+    if (!user) return { title: "OPS" };
+
+    const { shortName } = await resolveTenantIdentity(user);
+    const tabLabel = shortName ?? "FlowSight";
+    return { title: `${tabLabel} OPS` };
+  } catch {
+    return { title: "OPS" };
   }
 }
 
@@ -41,7 +81,7 @@ export default async function DashboardLayout({
   } = await authClient.auth.getUser();
   if (!user) redirect("/ops/login");
 
-  const tenantName = await resolveTenantName(user);
+  const { name: tenantName } = await resolveTenantIdentity(user);
 
   return (
     <OpsShell userEmail={user.email ?? ""} tenantName={tenantName ?? undefined}>

--- a/src/web/app/ops/(dashboard)/welcome/page.tsx
+++ b/src/web/app/ops/(dashboard)/welcome/page.tsx
@@ -99,7 +99,7 @@ export default async function WelcomePage() {
             Willkommen, {tenant.name}
           </h1>
           <p className="text-slate-400 text-base">
-            Ihr FlowSight Trial ist bereit. Testen Sie jetzt Ihre persönliche KI-Assistentin.
+            Ihr 14-Tage Trial ist bereit. Testen Sie jetzt Ihre persönliche KI-Assistentin.
           </p>
         </div>
 

--- a/src/web/src/lib/email/resend.ts
+++ b/src/web/src/lib/email/resend.ts
@@ -18,6 +18,7 @@ interface CaseEmailPayload {
   caseId: string;
   seqNumber?: number | null;
   tenantId: string;
+  tenantDisplayName?: string;
   source: string;
   category: string;
   urgency: string;
@@ -59,6 +60,17 @@ function escapeHtml(s: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
+}
+
+/**
+ * Build RFC 5322 From address with tenant branding.
+ * Identity Contract E4: "{display_name} via FlowSight <noreply@...>"
+ */
+function buildFromAddress(tenantDisplayName?: string): string {
+  const addr = process.env.MAIL_FROM ?? "noreply@send.flowsight.ch";
+  if (!tenantDisplayName) return addr;
+  const safe = tenantDisplayName.replace(/[<>"]/g, "");
+  return `${safe} via FlowSight <${addr}>`;
 }
 
 function buildOpsNotificationHtml(p: CaseEmailPayload, deepLink: string): string {
@@ -108,7 +120,7 @@ function buildOpsNotificationHtml(p: CaseEmailPayload, deepLink: string): string
 <!-- Gold accent bar -->
 <tr><td style="height:4px;background:#d4a853;font-size:0;line-height:0">&nbsp;</td></tr>
 <!-- Logo -->
-<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">FlowSight</td></tr>
+<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">${escapeHtml(p.tenantDisplayName ?? "FlowSight")}</td></tr>
 <!-- Urgency header -->
 <tr><td style="padding:0 24px">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:${urg.bg};border-radius:6px">
@@ -138,7 +150,7 @@ function buildOpsNotificationHtml(p: CaseEmailPayload, deepLink: string): string
 </td></tr>
 <!-- Footer -->
 <tr><td style="padding:20px 24px;border-top:1px solid #1e293b;margin-top:16px">
-  <div style="color:#64748b;font-size:12px;text-align:center">FlowSight GmbH &middot; flowsight.ch</div>
+  <div style="color:#64748b;font-size:12px;text-align:center">${escapeHtml(p.tenantDisplayName ?? "FlowSight")} &middot; via FlowSight</div>
 </td></tr>
 </table>
 </td></tr>
@@ -206,12 +218,11 @@ Freundliche Gr&uuml;sse<br>Ihr Service-Team
 export async function sendCaseNotification(
   payload: CaseEmailPayload
 ): Promise<boolean> {
-  const fromEnvValue = process.env.MAIL_FROM;
-  const from = fromEnvValue ?? "noreply@send.flowsight.ch";
+  const from = buildFromAddress(payload.tenantDisplayName);
   const to = process.env.MAIL_REPLY_TO;
-  const subjectPrefix = process.env.MAIL_SUBJECT_PREFIX ?? "[FlowSight]";
 
   // Base log fields — always present, no PII (no actual addresses)
+  const fromAddr = process.env.MAIL_FROM ?? "noreply@send.flowsight.ch";
   const base: Record<string, unknown> = {
     _tag: "resend",
     case_id: payload.caseId,
@@ -219,8 +230,8 @@ export async function sendCaseNotification(
     tenant_id: payload.tenantId,
     recipient_env: "MAIL_REPLY_TO",
     recipient_present: !!to,
-    from_env: fromEnvValue ? "MAIL_FROM" : "default",
-    from_domain: from.split("@")[1] ?? "unknown",
+    from_env: process.env.MAIL_FROM ? "MAIL_FROM" : "default",
+    from_domain: fromAddr.split("@")[1] ?? "unknown",
     ...(payload.reporterEmailSent !== undefined && {
       reporter_email_sent: payload.reporterEmailSent,
     }),
@@ -268,7 +279,7 @@ export async function sendCaseNotification(
     const { data, error } = await getResend().emails.send({
       from,
       to,
-      subject: `${subjectPrefix} ${urgencyLabel} – ${formatCaseLabel(payload.caseId, payload.seqNumber)} – ${payload.category} (${payload.city})`,
+      subject: `${urgencyLabel} – ${formatCaseLabel(payload.caseId, payload.seqNumber)} – ${payload.category} (${payload.city})`,
       html: buildOpsNotificationHtml(payload, deepLink),
       text: [
         `Neuer Fall erstellt`,
@@ -356,6 +367,7 @@ interface ReporterConfirmationPayload {
   caseId: string;
   seqNumber?: number | null;
   tenantId: string;
+  tenantDisplayName?: string;
   contactEmail: string;
   category: string;
 }
@@ -374,8 +386,8 @@ export async function sendReporterConfirmation(
 ): Promise<boolean> {
   if (!process.env.RESEND_API_KEY) return false;
 
-  const from = process.env.MAIL_FROM ?? "noreply@send.flowsight.ch";
-  const subjectPrefix = process.env.MAIL_SUBJECT_PREFIX ?? "[FlowSight]";
+  const from = buildFromAddress(payload.tenantDisplayName);
+  const tenantLabel = payload.tenantDisplayName ?? "FlowSight";
 
   try {
     const caseLabel = formatCaseLabel(payload.caseId, payload.seqNumber);
@@ -383,7 +395,7 @@ export async function sendReporterConfirmation(
     const { error } = await getResend().emails.send({
       from,
       to: payload.contactEmail,
-      subject: `${subjectPrefix} Ihre Meldung wurde erfasst`,
+      subject: `Ihre Meldung wurde erfasst — ${tenantLabel}`,
       html: buildReporterConfirmationHtml(caseLabel, payload.category),
       text: [
         `Guten Tag`,
@@ -441,6 +453,7 @@ export async function sendReporterConfirmation(
 interface ReviewRequestPayload {
   caseId: string;
   tenantId: string;
+  tenantDisplayName?: string;
   contactEmail: string;
   /** Our own review surface URL — always the primary link */
   reviewSurfaceUrl: string;
@@ -458,9 +471,8 @@ interface ReviewRequestPayload {
 export async function sendReviewRequest(
   payload: ReviewRequestPayload
 ): Promise<boolean> {
-  const fromEnvValue = process.env.MAIL_FROM;
-  const from = fromEnvValue ?? "noreply@send.flowsight.ch";
-  const subjectPrefix = process.env.MAIL_SUBJECT_PREFIX ?? "[FlowSight]";
+  const from = buildFromAddress(payload.tenantDisplayName);
+  const tenantLabel = payload.tenantDisplayName ?? "FlowSight";
 
   const base: Record<string, unknown> = {
     _tag: "resend",
@@ -480,7 +492,7 @@ export async function sendReviewRequest(
     const { error } = await getResend().emails.send({
       from,
       to: payload.contactEmail,
-      subject: `${subjectPrefix} Wie war unser Service?`,
+      subject: `Wie war unser Service? — ${tenantLabel}`,
       text: [
         `Guten Tag`,
         ``,
@@ -562,10 +574,9 @@ interface SalesLeadPayload {
 export async function sendSalesLeadNotification(
   payload: SalesLeadPayload
 ): Promise<boolean> {
-  const fromEnvValue = process.env.MAIL_FROM;
-  const from = fromEnvValue ?? "noreply@send.flowsight.ch";
+  const fromAddr = process.env.MAIL_FROM ?? "noreply@send.flowsight.ch";
+  const from = `FlowSight Sales <${fromAddr}>`;
   const to = process.env.MAIL_REPLY_TO;
-  const subjectPrefix = process.env.MAIL_SUBJECT_PREFIX ?? "[FlowSight]";
 
   const base: Record<string, unknown> = {
     _tag: "resend",
@@ -574,8 +585,8 @@ export async function sendSalesLeadNotification(
     retell_call_id: payload.retellCallId,
     recipient_env: "MAIL_REPLY_TO",
     recipient_present: !!to,
-    from_env: fromEnvValue ? "MAIL_FROM" : "default",
-    from_domain: from.split("@")[1] ?? "unknown",
+    from_env: process.env.MAIL_FROM ? "MAIL_FROM" : "default",
+    from_domain: fromAddr.split("@")[1] ?? "unknown",
   };
 
   if (!process.env.RESEND_API_KEY) {
@@ -598,7 +609,7 @@ export async function sendSalesLeadNotification(
     const { data, error } = await getResend().emails.send({
       from,
       to,
-      subject: `${subjectPrefix} Rückruf-Wunsch — ${companyLabel} (${payload.interestLevel})`,
+      subject: `Rückruf-Wunsch — ${companyLabel} (${payload.interestLevel})`,
       text: [
         `Neuer Anruf auf 044 552 09 19`,
         ``,


### PR DESCRIPTION
## Summary
- **Identity Contract E4 applied:** All emails now use `{display_name} via FlowSight` as sender name
- **R4 violation fixed:** Removed `[FlowSight]` subject prefix from all 7 email types
- **HTML templates:** Tenant name in logo/header instead of "FlowSight" (ops notification, Day-13, welcome, offboarding)
- **Tab title:** `{short_name} OPS` via dynamic `generateMetadata` (Identity Contract E1)
- **Welcome page:** Removed "FlowSight" from prospect-facing text
- **CLI scripts:** `send_email.mjs` supports `fromName` for tenant-branded sender

### Files changed (10)
- `resend.ts` — Core email refactor: new `buildFromAddress()`, tenant-branded subjects
- `cases/route.ts` — Fetches tenant name, passes to email functions
- `retell/webhook/route.ts` — Same pattern for voice-created cases
- `request-review/route.ts` — Passes tenant name to review request email
- `lifecycle/tick/route.ts` — Day-13 email: tenant sender + subject
- `(dashboard)/layout.tsx` — `generateMetadata` for dynamic tab title
- `welcome/page.tsx` — Remove "FlowSight" from trial text
- `provision_trial.mjs` — Welcome email: tenant logo + subject
- `offboard_tenant.mjs` — Offboarding email: tenant logo + subject
- `send_email.mjs` — `fromName` parameter support

## Test plan
- [ ] Case via Wizard → ops notification email shows tenant name in logo, no `[FlowSight]` in subject
- [ ] Reporter confirmation email: subject = "Ihre Meldung wurde erfasst — {tenant}"
- [ ] Review request email: subject = "Wie war unser Service? — {tenant}"
- [ ] Tab title in browser shows `{short_name} OPS` (e.g. "Weinberger OPS")
- [ ] Welcome page shows "Ihr 14-Tage Trial" not "Ihr FlowSight Trial"

🤖 Generated with [Claude Code](https://claude.com/claude-code)