### PR TITLE
feat: Day-5 nudge, Day-7 snapshot, welcome countdown, demo tabs (Block A, Sub-PR 2)

### DIFF
--- a/src/web/app/api/lifecycle/tick/route.ts
+++ b/src/web/app/api/lifecycle/tick/route.ts
@@ -9,14 +9,16 @@ import { getServiceClient } from "@/src/lib/supabase/server";
 // Auth: Bearer token must match LIFECYCLE_TICK_SECRET env var.
 //
 // Milestones:
-//   Day 7  — Engagement check → log (no email yet, just marks checked)
+//   Day 5  — Engagement nudge → email if prospect inactive (< 3 cases)
+//   Day 7  — Engagement snapshot → JSONB with cases_created, calls_count
 //   Day 10 — Founder alert (follow-up due) → updates follow_up_at awareness
 //   Day 13 — Trial expiry reminder to prospect → sends email
 //   Day 14 — Status → decision_pending (no auto-offboard)
 // ---------------------------------------------------------------------------
 
 const MILESTONES = [
-  { day: 7, column: "day7_checked_at", action: "check" },
+  { day: 5, column: "day5_nudge_sent_at", action: "nudge_prospect" },
+  { day: 7, column: "day7_checked_at", action: "engagement_snapshot" },
   { day: 10, column: "day10_alerted_at", action: "alert_founder" },
   { day: 13, column: "day13_reminder_sent_at", action: "remind_prospect" },
   { day: 14, column: "day14_marked_at", action: "mark_decision_pending" },
@@ -54,7 +56,7 @@ export async function POST(req: NextRequest) {
   const { data: trials, error: fetchErr } = await supabase
     .from("tenants")
     .select(
-      "id, slug, name, trial_start, trial_end, trial_status, prospect_email, prospect_phone, day7_checked_at, day10_alerted_at, day13_reminder_sent_at, day14_marked_at"
+      "id, slug, name, trial_start, trial_end, trial_status, prospect_email, prospect_phone, day5_nudge_sent_at, day7_checked_at, day10_alerted_at, day13_reminder_sent_at, day14_marked_at"
     )
     .in("trial_status", ["trial_active", "live_dock"]);
 
@@ -130,9 +132,74 @@ async function executeMilestone(
 
   try {
     switch (milestone.action) {
-      case "check":
-        // Day 7: Just mark as checked. Future: engagement metrics.
+      case "nudge_prospect": {
+        // Day 5: Send engagement nudge if prospect has < 3 cases
+        const { count: caseCount } = await supabase
+          .from("cases")
+          .select("id", { count: "exact", head: true })
+          .eq("tenant_id", tenant.id)
+          .eq("is_demo", false);
+
+        if ((caseCount ?? 0) >= 3) {
+          // Active prospect — suppress nudge, just mark as done
+          break;
+        }
+
+        if (tenant.prospect_email) {
+          const emailOk = await sendDay5Email(
+            tenant.prospect_email,
+            tenant.name
+          );
+          if (!emailOk) {
+            return { ...base, ok: false, error: "day5_email_failed" };
+          }
+        }
         break;
+      }
+
+      case "engagement_snapshot": {
+        // Day 7: Collect engagement metrics and store as JSONB
+        const [
+          { count: totalCases },
+          { count: voiceCases },
+          { count: wizardCases },
+        ] = await Promise.all([
+          supabase
+            .from("cases")
+            .select("id", { count: "exact", head: true })
+            .eq("tenant_id", tenant.id)
+            .eq("is_demo", false),
+          supabase
+            .from("cases")
+            .select("id", { count: "exact", head: true })
+            .eq("tenant_id", tenant.id)
+            .eq("is_demo", false)
+            .eq("source", "voice"),
+          supabase
+            .from("cases")
+            .select("id", { count: "exact", head: true })
+            .eq("tenant_id", tenant.id)
+            .eq("is_demo", false)
+            .eq("source", "wizard"),
+        ]);
+
+        const snapshot = {
+          cases_created: totalCases ?? 0,
+          cases_voice: voiceCases ?? 0,
+          cases_wizard: wizardCases ?? 0,
+          captured_at: now.toISOString(),
+        };
+
+        const { error: snapErr } = await supabase
+          .from("tenants")
+          .update({ day7_snapshot: snapshot })
+          .eq("id", tenant.id);
+
+        if (snapErr) {
+          return { ...base, ok: false, error: `snapshot_failed: ${snapErr.message}` };
+        }
+        break;
+      }
 
       case "alert_founder":
         // Day 10: Log awareness. Morning Report already shows follow_up_due.
@@ -189,6 +256,84 @@ async function executeMilestone(
       ok: false,
       error: err instanceof Error ? err.message : String(err),
     };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Day 5 email — Engagement nudge for inactive prospects
+// ---------------------------------------------------------------------------
+
+async function sendDay5Email(
+  to: string,
+  companyName: string
+): Promise<boolean> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return false;
+
+  const fromAddr = process.env.MAIL_FROM || "noreply@send.flowsight.ch";
+  const safeName = companyName.replace(/[<>"]/g, "");
+  const from = `${safeName} via FlowSight <${fromAddr}>`;
+
+  const html = `<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:24px 0">
+<tr><td align="center">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#0b1120;border-radius:8px;overflow:hidden">
+<tr><td style="height:4px;background:#d4a853;font-size:0;line-height:0">&nbsp;</td></tr>
+<tr><td style="padding:20px 24px 12px;color:#d4a853;font-size:20px;font-weight:700;letter-spacing:0.5px">${companyName}</td></tr>
+<tr><td style="padding:0 24px;color:#e2e8f0;font-size:22px;font-weight:700">Ihr System wartet auf Sie</td></tr>
+<tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
+Guten Tag,<br><br>
+Ihre Einsatzzentrale f&uuml;r <strong style="color:#e2e8f0">${companyName}</strong> ist seit 5 Tagen aktiv &mdash; aber wir haben bisher wenige Testanrufe gesehen.
+</td></tr>
+<tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
+<strong style="color:#e2e8f0">Testen Sie es jetzt:</strong> Rufen Sie einfach Ihre Testnummer an, oder nutzen Sie das Auftragsformular auf Ihrer Website. Lisa nimmt ab und leitet alles strukturiert weiter.
+</td></tr>
+<tr><td style="padding:16px 24px 0;color:#94a3b8;font-size:15px;line-height:1.6">
+Sie haben noch 9 Tage in Ihrem Trial. Nutzen Sie die Zeit, um zu sehen, wie das System Ihren Arbeitsalltag ver&auml;ndert.
+</td></tr>
+<tr><td style="padding:28px 24px 20px;border-top:1px solid #1e293b;margin-top:24px">
+  <div style="color:#64748b;font-size:13px;line-height:1.6;text-align:center">Gunnar Wende &mdash; 044 552 09 19 &mdash; flowsight.ch</div>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+  const text = [
+    "Guten Tag,",
+    "",
+    `Ihre Einsatzzentrale für ${companyName} ist seit 5 Tagen aktiv — aber wir haben bisher wenige Testanrufe gesehen.`,
+    "",
+    "Testen Sie es jetzt: Rufen Sie einfach Ihre Testnummer an, oder nutzen Sie das Auftragsformular auf Ihrer Website.",
+    "",
+    "Sie haben noch 9 Tage in Ihrem Trial.",
+    "",
+    "---",
+    "Gunnar Wende — 044 552 09 19 — flowsight.ch",
+  ].join("\n");
+
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to,
+        subject: `Ihr System wartet auf Sie — ${companyName}`,
+        html,
+        text,
+      }),
+    });
+    return res.ok;
+  } catch {
+    return false;
   }
 }
 

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -51,6 +51,7 @@ export default async function OpsCasesPage({
   const filterTenantSlug = params.tenant;
   const showAll = params.show === "all";
   const filterQuery = params.q ?? "";
+  const showDemo = params.tab === "demo";
   const currentPage = Math.max(1, parseInt(params.page ?? "1", 10) || 1);
   const PAGE_SIZE = 15;
 
@@ -90,6 +91,7 @@ export default async function OpsCasesPage({
   let statsQuery = supabase
     .from("cases")
     .select("id, status, created_at, updated_at")
+    .eq("is_demo", showDemo)
     .limit(1000);
   if (filterTenantId) statsQuery = statsQuery.eq("tenant_id", filterTenantId);
 
@@ -100,6 +102,7 @@ export default async function OpsCasesPage({
       "id, seq_number, created_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name",
       { count: "exact" }
     )
+    .eq("is_demo", showDemo)
     .order("created_at", { ascending: false });
   if (filterTenantId) listQuery = listQuery.eq("tenant_id", filterTenantId);
 
@@ -172,6 +175,7 @@ export default async function OpsCasesPage({
   function filterHref(key: string, value: string): string {
     const p = new URLSearchParams();
     if (filterTenantSlug) p.set("tenant", filterTenantSlug);
+    if (showDemo) p.set("tab", "demo");
     if (key === "status") { if (value) p.set("status", value); }
     else if (filterStatus) p.set("status", filterStatus);
     if (key === "urgency") { if (value) p.set("urgency", value); }
@@ -194,9 +198,11 @@ export default async function OpsCasesPage({
         <div>
           <h1 className="text-xl font-bold text-gray-900">Fälle</h1>
           <p className="text-sm text-gray-500 mt-0.5">
-            {filterTenantName
-              ? `Tenant: ${filterTenantName}`
-              : "Übersicht aller eingehenden Aufträge"}
+            {showDemo
+              ? "Demo-Fälle zur Veranschaulichung"
+              : filterTenantName
+                ? `Tenant: ${filterTenantName}`
+                : "Übersicht aller eingehenden Aufträge"}
           </p>
         </div>
       </div>
@@ -204,10 +210,36 @@ export default async function OpsCasesPage({
       {/* Filters row — dropdowns */}
       <div className="bg-white border border-gray-200 rounded-xl p-3 mb-5">
         <div className="flex flex-wrap items-center gap-3">
-          {/* View toggle */}
+          {/* Demo/Real tab toggle */}
           <div className="flex rounded-lg border border-gray-200 overflow-hidden">
             <Link
               href={filterTenantSlug ? `/ops/cases?tenant=${filterTenantSlug}` : "/ops/cases"}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                !showDemo
+                  ? "bg-amber-500 text-white"
+                  : "bg-white text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              Ihre Fälle
+            </Link>
+            <Link
+              href={filterTenantSlug ? `/ops/cases?tenant=${filterTenantSlug}&tab=demo` : "/ops/cases?tab=demo"}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                showDemo
+                  ? "bg-amber-500 text-white"
+                  : "bg-white text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              Demo
+            </Link>
+          </div>
+
+          <span className="border-l border-gray-200 h-6 inline-block" />
+
+          {/* View toggle */}
+          <div className="flex rounded-lg border border-gray-200 overflow-hidden">
+            <Link
+              href={filterTenantSlug ? `/ops/cases?tenant=${filterTenantSlug}${showDemo ? "&tab=demo" : ""}` : `/ops/cases${showDemo ? "?tab=demo" : ""}`}
               className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                 !showAll && !filterStatus
                   ? "bg-slate-700 text-white"
@@ -217,7 +249,7 @@ export default async function OpsCasesPage({
               Offen
             </Link>
             <Link
-              href={filterTenantSlug ? `/ops/cases?tenant=${filterTenantSlug}&show=all` : "/ops/cases?show=all"}
+              href={filterTenantSlug ? `/ops/cases?tenant=${filterTenantSlug}&show=all${showDemo ? "&tab=demo" : ""}` : `/ops/cases?show=all${showDemo ? "&tab=demo" : ""}`}
               className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                 showAll && !filterStatus
                   ? "bg-slate-700 text-white"

--- a/src/web/app/ops/(dashboard)/welcome/page.tsx
+++ b/src/web/app/ops/(dashboard)/welcome/page.tsx
@@ -87,6 +87,17 @@ export default async function WelcomePage() {
   const trialEndFmt = formatDate(tenant.trial_end);
   const trialStartFmt = formatDate(tenant.trial_start);
 
+  // Calculate days remaining for countdown
+  const daysRemaining = tenant.trial_end
+    ? Math.max(
+        0,
+        Math.ceil(
+          (new Date(tenant.trial_end).getTime() - Date.now()) /
+            (1000 * 60 * 60 * 24)
+        )
+      )
+    : null;
+
   return (
     <div className="min-h-[80vh] flex items-center justify-center px-4">
       <div className="max-w-lg w-full">
@@ -137,9 +148,16 @@ export default async function WelcomePage() {
           <div className="text-xs uppercase tracking-wider text-slate-500 mb-3">
             Trial-Zeitraum
           </div>
-          <div className="text-slate-300 text-sm font-medium mb-4">
-            {trialStartFmt} — {trialEndFmt} (14 Tage)
+          <div className="text-slate-300 text-sm font-medium mb-1">
+            {trialStartFmt} — {trialEndFmt}
           </div>
+          {daysRemaining !== null && (
+            <div className="text-amber-400 text-sm font-semibold mb-4">
+              {daysRemaining > 0
+                ? `${daysRemaining} ${daysRemaining === 1 ? "Tag" : "Tage"} verbleibend`
+                : "Trial abgelaufen"}
+            </div>
+          )}
 
           <div className="text-xs uppercase tracking-wider text-slate-500 mb-3">
             Das ist enthalten

--- a/supabase/migrations/20260313000000_block_a_lifecycle_demo.sql
+++ b/supabase/migrations/20260313000000_block_a_lifecycle_demo.sql
@@ -1,0 +1,11 @@
+-- Block A: Day-5 nudge + Day-7 engagement snapshot + Demo-case flag
+-- Safe to re-run: all ADD COLUMN IF NOT EXISTS
+
+-- Day-5 nudge timestamp (lifecycle tick milestone)
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS day5_nudge_sent_at timestamptz;
+
+-- Day-7 engagement snapshot (JSONB: cases_created, calls_count, statuses)
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS day7_snapshot jsonb;
+
+-- Demo-case flag on cases table (for tab separation in Leitstand)
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS is_demo boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- **Lifecycle tick:** Day-5 engagement nudge email (suppressed if prospect has ≥3 non-demo cases) + Day-7 JSONB engagement snapshot (cases_created, cases_voice, cases_wizard)
- **Welcome page:** Trial countdown — shows "X Tage verbleibend" or "Trial abgelaufen"
- **Cases page:** "Ihre Fälle" / "Demo" tab toggle — filters on `is_demo` boolean, preserves all other filters
- **Migration:** `day5_nudge_sent_at`, `day7_snapshot` on tenants + `is_demo` on cases

Completes Block A (Identity + Lifecycle). Sub-PR 1 merged as #168.

## Test plan
- [ ] Lifecycle tick: verify Day-5 fires only for prospects with < 3 cases
- [ ] Lifecycle tick: verify Day-7 stores snapshot JSONB correctly
- [ ] Welcome page: check countdown renders for active trial
- [ ] Cases page: toggle between "Ihre Fälle" and "Demo" tabs
- [ ] Migration: columns exist after `supabase db push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)