### PR TITLE
feat: Wizard Notfall + Review Surface Gold + Nachlauf-System (Block B)

### DIFF
--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -8,9 +8,13 @@ import { generateVerifyToken } from "@/src/lib/sms/verifySmsToken";
 
 // ---------------------------------------------------------------------------
 // POST /api/ops/cases/[id]/request-review
-// Gate: status=done AND (contact_email OR contact_phone) AND review_sent_at IS NULL
+// Gate: status=done AND (contact_email OR contact_phone)
+// Max 2 requests per case, 7-day cooldown between requests (NS3)
 // Allowed: admin, tenant, prospect (prospect can trigger reviews)
 // ---------------------------------------------------------------------------
+
+const MAX_REVIEW_REQUESTS = 2;
+const RESEND_COOLDOWN_DAYS = 7;
 
 export async function POST(
   _request: NextRequest,
@@ -53,9 +57,45 @@ export async function POST(
     return NextResponse.json({ error: "no_contact_info" }, { status: 400 });
   }
 
-  if (row.review_sent_at) {
+  // ── Resend logic (NS3): max 2 requests, 7-day cooldown ──────────────
+  const { data: reviewEvents } = await supabase
+    .from("case_events")
+    .select("created_at")
+    .eq("case_id", id)
+    .eq("event_type", "review_requested")
+    .order("created_at", { ascending: false });
+
+  const reviewCount = reviewEvents?.length ?? 0;
+
+  if (reviewCount >= MAX_REVIEW_REQUESTS) {
     return NextResponse.json(
-      { error: "review_already_sent", sent_at: row.review_sent_at },
+      { error: "max_reviews_reached", count: reviewCount },
+      { status: 409 },
+    );
+  }
+
+  if (reviewCount > 0 && reviewEvents?.[0]) {
+    const lastSent = new Date(reviewEvents[0].created_at);
+    const daysSince = (Date.now() - lastSent.getTime()) / (1000 * 60 * 60 * 24);
+    if (daysSince < RESEND_COOLDOWN_DAYS) {
+      return NextResponse.json(
+        { error: "cooldown_active", days_remaining: Math.ceil(RESEND_COOLDOWN_DAYS - daysSince) },
+        { status: 429 },
+      );
+    }
+  }
+
+  // Check for explicit skip
+  const { data: skipEvents } = await supabase
+    .from("case_events")
+    .select("id")
+    .eq("case_id", id)
+    .eq("event_type", "review_skipped")
+    .limit(1);
+
+  if (skipEvents && skipEvents.length > 0) {
+    return NextResponse.json(
+      { error: "review_skipped" },
       { status: 409 },
     );
   }

--- a/src/web/app/api/ops/cases/[id]/skip-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/skip-review/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceClient } from "@/src/lib/supabase/server";
+import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
+
+// POST /api/ops/cases/[id]/skip-review — Mark case as "Kein Review"
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const scope = await resolveTenantScope();
+  if (!scope) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const supabase = getServiceClient();
+
+  // Verify case exists and belongs to tenant
+  const { data: row, error } = await supabase
+    .from("cases")
+    .select("id, tenant_id")
+    .eq("id", id)
+    .single();
+
+  if (error || !row) {
+    return NextResponse.json({ error: "case_not_found" }, { status: 404 });
+  }
+
+  if (!scope.isAdmin && scope.tenantId && row.tenant_id !== scope.tenantId) {
+    return NextResponse.json({ error: "case_not_found" }, { status: 404 });
+  }
+
+  // Insert skip event
+  await supabase.from("case_events").insert({
+    case_id: id,
+    event_type: "review_skipped",
+    title: "Review \u00fcbersprungen",
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/web/app/api/review/[caseId]/track/route.ts
+++ b/src/web/app/api/review/[caseId]/track/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceClient } from "@/src/lib/supabase/server";
+
+// POST /api/review/[caseId]/track — fire-and-forget CTA click tracking
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ caseId: string }> }
+) {
+  const { caseId } = await params;
+  const supabase = getServiceClient();
+
+  await supabase.from("case_events").insert({
+    case_id: caseId,
+    event_type: "review_cta_clicked",
+    title: "Google-Bewertung ge\u00f6ffnet",
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/web/app/kunden/[slug]/meldung/CustomerWizardForm.tsx
+++ b/src/web/app/kunden/[slug]/meldung/CustomerWizardForm.tsx
@@ -425,7 +425,54 @@ export function CustomerWizardForm({
                 </div>
               </div>
 
-              <NavButtons accent={accent} onNext={goNext} nextDisabled={!step1Valid} />
+              {/* ── Notfall-Screen (N1-N7) ─────────────────── */}
+              {urgency === "notfall" && emergency?.enabled ? (
+                <div className="rounded-xl border-2 border-red-200 bg-red-50 p-5 space-y-4">
+                  <div className="text-center">
+                    <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+                      <svg className="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                      </svg>
+                    </div>
+                    <h3 className="text-lg font-semibold text-red-800">Notfall? Rufen Sie jetzt an.</h3>
+                    <p className="mt-1 text-sm text-red-600">
+                      Bei einem Notfall ist ein Anruf der schnellste Weg. {companyName} hilft Ihnen sofort.
+                    </p>
+                  </div>
+
+                  {/* N2: Primary CTA = Phone call (largest button) */}
+                  <a
+                    href={`tel:${emergency.phoneRaw}`}
+                    className="flex items-center justify-center gap-2 w-full rounded-lg bg-red-600 px-6 py-3.5 text-base font-semibold text-white transition hover:bg-red-700"
+                  >
+                    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z" />
+                    </svg>
+                    {companyName} anrufen — {emergency.phone}
+                  </a>
+
+                  {/* N3: Secondary = "Schriftlich melden" */}
+                  {/* N4: Goes to Step 2 with Notfall pre-selected */}
+                  <button
+                    type="button"
+                    onClick={goNext}
+                    disabled={!category}
+                    className="w-full text-center text-sm text-gray-500 hover:text-gray-700 transition-colors disabled:opacity-40"
+                  >
+                    Schriftlich melden {!category && "(bitte Anliegen wählen)"}
+                  </button>
+                </div>
+              ) : urgency === "notfall" && (!emergency || !emergency.enabled) ? (
+                /* N5: emergency not enabled → inline warning, normal flow */
+                <div>
+                  <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                    <span className="font-medium">Hinweis:</span> Bei akuten Notfällen empfehlen wir einen direkten Anruf bei {companyName}: <a href={`tel:${phoneRaw}`} className="font-semibold underline">{phone}</a>
+                  </div>
+                  <NavButtons accent={accent} onNext={goNext} nextDisabled={!step1Valid} />
+                </div>
+              ) : (
+                <NavButtons accent={accent} onNext={goNext} nextDisabled={!step1Valid} />
+              )}
             </div>
           )}
 

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type { CaseDetail } from "./page";
+import { deriveReviewStatus } from "@/src/lib/reviews/deriveReviewStatus";
+import type { CaseEvent } from "@/src/components/ops/CaseTimeline";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -52,7 +54,7 @@ function formatDate(iso: string): string {
 // Component
 // ---------------------------------------------------------------------------
 
-export function CaseDetailForm({ initialData, isProspect = false }: { initialData: CaseDetail; isProspect?: boolean }) {
+export function CaseDetailForm({ initialData, isProspect = false, caseEvents = [] }: { initialData: CaseDetail; isProspect?: boolean; caseEvents?: CaseEvent[] }) {
   // All fields as state — always editable, no toggle
   const [status, setStatus] = useState(initialData.status);
   const [urgency, setUrgency] = useState(initialData.urgency);
@@ -94,10 +96,9 @@ export function CaseDetailForm({ initialData, isProspect = false }: { initialDat
   const [errorMsg, setErrorMsg] = useState("");
   const [inviteState, setInviteState] = useState<"idle" | "sending" | "sent" | "error">("idle");
   const [inviteMsg, setInviteMsg] = useState("");
-  const [reviewState, setReviewState] = useState<"idle" | "sending" | "sent" | "error">(
-    initialData.review_sent_at ? "sent" : "idle"
-  );
+  const [reviewState, setReviewState] = useState<"idle" | "sending" | "sent" | "error">("idle");
   const [reviewMsg, setReviewMsg] = useState("");
+  const [localEvents, setLocalEvents] = useState(caseEvents);
 
   const isDirty =
     status !== baseline.status ||
@@ -212,11 +213,15 @@ export function CaseDetailForm({ initialData, isProspect = false }: { initialDat
 
   const canSendInvite = !!scheduledAt && inviteState !== "sending";
   const hasContactInfo = !!contactEmail.trim() || !!contactPhone.trim();
-  const canRequestReview =
-    status === "done" &&
-    hasContactInfo &&
-    reviewState !== "sent" &&
-    reviewState !== "sending";
+
+  // Derive review status from events (NS1)
+  const reviewInfo = deriveReviewStatus({
+    caseStatus: status,
+    hasContactInfo,
+    reviewSentAt: initialData.review_sent_at,
+    events: localEvents.map(e => ({ event_type: e.event_type, created_at: e.created_at })),
+  });
+  const canRequestReview = reviewInfo.canRequest || reviewInfo.canResend;
 
   async function handleSendInvite() {
     if (isDirty) {
@@ -249,9 +254,32 @@ export function CaseDetailForm({ initialData, isProspect = false }: { initialDat
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
       setReviewState("sent");
+      setTimeout(() => setReviewState("idle"), 2000);
+      // Add synthetic event to re-derive status
+      setLocalEvents(prev => [...prev, {
+        id: crypto.randomUUID(),
+        event_type: "review_requested",
+        title: "Review-Anfrage gesendet",
+        created_at: new Date().toISOString(),
+      }]);
     } catch (err) {
       setReviewState("error");
       setReviewMsg(err instanceof Error ? err.message : "Senden fehlgeschlagen.");
+    }
+  }
+
+  async function handleSkipReview() {
+    try {
+      const res = await fetch(`/api/ops/cases/${initialData.id}/skip-review`, { method: "POST" });
+      if (!res.ok) throw new Error("Fehler");
+      setLocalEvents(prev => [...prev, {
+        id: crypto.randomUUID(),
+        event_type: "review_skipped",
+        title: "Review \u00fcbersprungen",
+        created_at: new Date().toISOString(),
+      }]);
+    } catch {
+      // silent
     }
   }
 
@@ -301,7 +329,7 @@ export function CaseDetailForm({ initialData, isProspect = false }: { initialDat
           </div>
         </div>
 
-        {/* Action bar — Status save + Review only */}
+        {/* Action bar — Status save */}
         <div className="flex items-center gap-2 flex-wrap border-t border-gray-100 pt-3">
           <button
             onClick={performSave}
@@ -317,16 +345,35 @@ export function CaseDetailForm({ initialData, isProspect = false }: { initialDat
             >Erledigt</button>
           )}
 
-          <button onClick={handleRequestReview} disabled={!canRequestReview}
-            title={!hasContactInfo ? "Keine Kontaktdaten" : reviewState === "sent" ? "Bereits gesendet" : undefined}
-            className="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >{reviewState === "sending" ? "Sende\u2026" : reviewState === "sent" ? "Review gesendet" : "Review anfragen"}</button>
-
           {saveState === "saved" && <span className="text-emerald-600 text-xs ml-2">Gespeichert</span>}
           {saveState === "error" && <span className="text-red-600 text-xs ml-2">{errorMsg}</span>}
-          {reviewState === "sent" && <span className="text-emerald-600 text-xs ml-2">Review gesendet</span>}
-          {reviewState === "error" && <span className="text-red-600 text-xs ml-2">{reviewMsg}</span>}
         </div>
+
+        {/* Review Nachlauf — prospect view */}
+        {status === "done" && reviewInfo.status !== "nicht_bereit" && (
+          <div className="border-t border-gray-100 pt-3 mt-3">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${reviewInfo.color}`}>
+                {reviewInfo.label}
+              </span>
+              {canRequestReview && (
+                <button onClick={handleRequestReview} disabled={reviewState === "sending"}
+                  className="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:opacity-40 transition-colors"
+                >
+                  {reviewState === "sending" ? "Sende\u2026" :
+                    reviewInfo.canResend ? "Nochmals anfragen" : "Review anfragen"}
+                </button>
+              )}
+              {reviewInfo.canSkip && (
+                <button onClick={handleSkipReview}
+                  className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-500 hover:bg-gray-50 transition-colors"
+                >Kein Review</button>
+              )}
+              {reviewState === "sent" && <span className="text-emerald-600 text-xs">Gesendet</span>}
+              {reviewState === "error" && <span className="text-red-600 text-xs">{reviewMsg}</span>}
+            </div>
+          </div>
+        )}
       </section>
     );
   }
@@ -433,7 +480,7 @@ export function CaseDetailForm({ initialData, isProspect = false }: { initialDat
         </div>
       </div>
 
-      {/* Action bar — Speichern, Erledigt, Review */}
+      {/* Action bar — Speichern, Erledigt */}
       <div className="flex items-center gap-2 flex-wrap border-t border-gray-100 pt-3">
         <button
           onClick={performSave}
@@ -449,20 +496,46 @@ export function CaseDetailForm({ initialData, isProspect = false }: { initialDat
           >Erledigt</button>
         )}
 
-        <button onClick={handleRequestReview} disabled={!canRequestReview}
-          title={!hasContactInfo ? "Keine Kontaktdaten" : reviewState === "sent" ? "Bereits gesendet" : undefined}
-          className="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >{reviewState === "sending" ? "Sende\u2026" : reviewState === "sent" ? "Review gesendet" : "Review anfragen"}</button>
-
-        {/* Feedback inline */}
         {saveState === "saved" && <span className="text-emerald-600 text-xs ml-2">Gespeichert</span>}
         {saveState === "error" && <span className="text-red-600 text-xs ml-2">{errorMsg}</span>}
         {inviteState === "error" && <span className="text-red-600 text-xs ml-2">{inviteMsg}</span>}
-        {reviewState === "sent" && initialData.review_sent_at && (
-          <span className="text-emerald-600 text-xs ml-2">Review gesendet ({formatDate(initialData.review_sent_at)})</span>
-        )}
-        {reviewState === "error" && <span className="text-red-600 text-xs ml-2">{reviewMsg}</span>}
       </div>
+
+      {/* Review Nachlauf (S1.9) — only when case is done */}
+      {status === "done" && reviewInfo.status !== "nicht_bereit" && (
+        <div className="border-t border-gray-100 pt-3 mt-3">
+          <div className="flex items-center gap-2 flex-wrap">
+            {/* Review badge */}
+            <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${reviewInfo.color}`}>
+              {reviewInfo.label}
+            </span>
+
+            {/* Actions based on derived state */}
+            {canRequestReview && (
+              <button onClick={handleRequestReview} disabled={reviewState === "sending"}
+                className="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:opacity-40 transition-colors"
+              >
+                {reviewState === "sending" ? "Sende\u2026" :
+                  reviewInfo.canResend ? "Nochmals anfragen" : "Review anfragen"}
+              </button>
+            )}
+
+            {reviewInfo.canSkip && (
+              <button onClick={handleSkipReview}
+                className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-500 hover:bg-gray-50 transition-colors"
+              >
+                Kein Review
+              </button>
+            )}
+
+            {reviewState === "sent" && <span className="text-emerald-600 text-xs">Gesendet</span>}
+            {reviewState === "error" && <span className="text-red-600 text-xs">{reviewMsg}</span>}
+            {reviewInfo.reviewCount > 0 && (
+              <span className="text-gray-400 text-xs">{reviewInfo.reviewCount}/2 Anfragen</span>
+            )}
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -132,7 +132,7 @@ export default async function CaseDetailPage({
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
         {/* Left: form (all fields, always editable) */}
         <div className="lg:col-span-3">
-          <CaseDetailForm initialData={caseData} isProspect={scope?.isProspect ?? false} />
+          <CaseDetailForm initialData={caseData} isProspect={scope?.isProspect ?? false} caseEvents={caseEvents} />
         </div>
 
         {/* Right: contact + timeline + attachments */}

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -99,7 +99,7 @@ export default async function OpsCasesPage({
   let listQuery = supabase
     .from("cases")
     .select(
-      "id, seq_number, created_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name",
+      "id, seq_number, created_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, review_sent_at",
       { count: "exact" }
     )
     .eq("is_demo", showDemo)

--- a/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
+++ b/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  companyName: string;
+  brandColor: string;
+  category: string;
+  location: string;
+  caseDate: string;
+  defaultText: string;
+  googleReviewUrl: string | null;
+  trackUrl: string | null;
+}
+
+export function ReviewSurfaceClient({
+  companyName,
+  brandColor,
+  category,
+  location,
+  caseDate,
+  defaultText,
+  googleReviewUrl,
+  trackUrl,
+}: Props) {
+  const [text, setText] = useState(defaultText);
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopyAndOpen() {
+    // Copy text to clipboard
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch {
+      // Fallback: select text
+      setCopied(true);
+    }
+
+    // Track CTA click (fire-and-forget)
+    if (trackUrl) {
+      fetch(trackUrl, { method: "POST" }).catch(() => {});
+    }
+
+    // Open Google Review URL in new tab
+    if (googleReviewUrl) {
+      window.open(googleReviewUrl, "_blank", "noopener,noreferrer");
+    }
+  }
+
+  async function handleCopyOnly() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch {
+      setCopied(true);
+    }
+  }
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-gray-100 p-4">
+      <div className="w-full max-w-[440px]">
+        {/* Card */}
+        <div className="rounded-2xl bg-white shadow-lg overflow-hidden">
+          {/* Brand bar */}
+          <div className="h-1.5" style={{ backgroundColor: brandColor }} />
+
+          {/* Header: Company name in brand color */}
+          <div className="px-6 pt-5 pb-3">
+            <h1
+              className="text-xl font-bold"
+              style={{ color: brandColor }}
+            >
+              {companyName}
+            </h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Wie war unser Service?
+            </p>
+          </div>
+
+          {/* Case reference block (RS2) */}
+          <div className="mx-6 rounded-lg bg-gray-50 border border-gray-100 px-4 py-3 mb-4">
+            <div className="grid grid-cols-2 gap-y-1.5 text-sm">
+              <span className="text-gray-400">Auftrag</span>
+              <span className="text-gray-700 font-medium">{category}</span>
+              <span className="text-gray-400">Ort</span>
+              <span className="text-gray-700">{location}</span>
+              <span className="text-gray-400">Datum</span>
+              <span className="text-gray-700">{caseDate}</span>
+            </div>
+          </div>
+
+          {/* Editable review text (RS3) */}
+          <div className="px-6 mb-4">
+            <label className="block text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">
+              Ihr Bewertungstext
+            </label>
+            <textarea
+              className="h-[110px] w-full resize-none rounded-lg border border-gray-200 bg-white px-4 py-3 text-[14px] leading-relaxed text-gray-700 outline-none transition-colors focus:border-gray-400 focus:ring-1 focus:ring-gray-400"
+              value={text}
+              onChange={(e) => { setText(e.target.value); setCopied(false); }}
+              placeholder="Beschreiben Sie Ihre Erfahrung..."
+            />
+            <p className="mt-1 text-xs text-gray-400">
+              Sie k&ouml;nnen den Text anpassen, bevor Sie ihn auf Google einf&uuml;gen.
+            </p>
+          </div>
+
+          {/* Primary CTA (RS4) */}
+          <div className="px-6 pb-2">
+            {googleReviewUrl ? (
+              <button
+                type="button"
+                onClick={handleCopyAndOpen}
+                className="flex w-full items-center justify-center gap-2 rounded-lg px-6 py-3 text-[15px] font-semibold text-white transition-colors hover:opacity-90"
+                style={{ backgroundColor: brandColor }}
+              >
+                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+                </svg>
+                Auf Google bewerten
+              </button>
+            ) : (
+              /* RS9: No Google URL → "Text kopieren" only */
+              <button
+                type="button"
+                onClick={handleCopyOnly}
+                className="flex w-full items-center justify-center gap-2 rounded-lg px-6 py-3 text-[15px] font-semibold text-white transition-colors hover:opacity-90"
+                style={{ backgroundColor: brandColor }}
+              >
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
+                </svg>
+                Text kopieren
+              </button>
+            )}
+          </div>
+
+          {/* RS5: Inline confirmation after click */}
+          {copied && (
+            <div className="px-6 pb-2">
+              <p className="text-center text-sm text-emerald-600 font-medium">
+                Text kopiert{googleReviewUrl ? " \u2014 Sie k\u00f6nnen ihn auf Google einf\u00fcgen." : "."}
+              </p>
+            </div>
+          )}
+
+          {/* RS6: No Cancel. Instead: dismissal text */}
+          <div className="px-6 pb-5 pt-2">
+            <p className="text-center text-xs text-gray-400">
+              Kein Interesse? Sie m&uuml;ssen nichts tun.
+            </p>
+          </div>
+        </div>
+
+        {/* RS10: Footer */}
+        <p className="mt-4 text-center text-xs text-gray-400">
+          Website powered by{" "}
+          <a href="https://flowsight.ch" className="text-gray-500 hover:text-gray-600">
+            FlowSight
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/web/app/review/[caseId]/page.tsx
+++ b/src/web/app/review/[caseId]/page.tsx
@@ -1,5 +1,7 @@
 import { getServiceClient } from "@/src/lib/supabase/server";
 import { validateVerifyToken } from "@/src/lib/sms/verifySmsToken";
+import { getCustomer } from "@/src/lib/customers/registry";
+import { ReviewSurfaceClient } from "./ReviewSurfaceClient";
 
 interface PageProps {
   params: Promise<{ caseId: string }>;
@@ -15,7 +17,7 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
 
   // ── Invalid link shell ──────────────────────────────────────────────
   const invalidShell = (
-    <div className="flex min-h-dvh items-center justify-center bg-[#e8eaed] p-4">
+    <div className="flex min-h-dvh items-center justify-center bg-gray-100 p-4">
       <div className="w-full max-w-[420px] rounded-2xl bg-white p-8 text-center shadow-lg">
         <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
@@ -34,7 +36,7 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
   const supabase = getServiceClient();
   const { data: caseRow, error } = await supabase
     .from("cases")
-    .select("id, created_at, tenant_id, reporter_name")
+    .select("id, created_at, tenant_id, category, plz, city")
     .eq("id", caseId)
     .single();
 
@@ -48,6 +50,7 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
   // ── Resolve tenant ─────────────────────────────────────────────────
   let companyName = "Ihr Dienstleister";
   let googleReviewUrl: string | null = null;
+  let tenantSlug: string | null = null;
   {
     const { data: tenant } = await supabase
       .from("tenants")
@@ -56,6 +59,7 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
       .single();
 
     if (tenant?.name) companyName = tenant.name;
+    if (tenant?.slug) tenantSlug = tenant.slug;
 
     const modules = tenant?.modules as Record<string, unknown> | null;
     if (typeof modules?.google_review_url === "string" && modules.google_review_url.length > 0) {
@@ -63,11 +67,26 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
     }
   }
 
-  // ── Display values ─────────────────────────────────────────────────
-  const displayName = "Max Mustermann";
-  const initial = "M";
+  // ── Brand color from customer registry ──────────────────────────────
+  const customer = tenantSlug ? getCustomer(tenantSlug) : undefined;
+  const brandColor = customer?.brandColor ?? "#d4a853"; // FlowSight gold as fallback
 
-  // High-quality 3-liner as default review text
+  // ── Track surface opened (fire-and-forget) ─────────────────────────
+  await supabase.from("case_events").insert({
+    case_id: caseId,
+    event_type: "review_surface_opened",
+    title: "Bewertungsseite ge\u00f6ffnet",
+  }).then(() => {});
+
+  // ── Display values ─────────────────────────────────────────────────
+  const location = [caseRow.plz, caseRow.city].filter(Boolean).join(" ") || "\u2014";
+  const caseDate = new Date(caseRow.created_at).toLocaleDateString("de-CH", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    timeZone: "Europe/Zurich",
+  });
+
   const defaultReviewText = [
     "Sehr kompetenter und zuverl\u00e4ssiger Service.",
     "Schnelle Reaktion, saubere Arbeit, faire Preise.",
@@ -75,123 +94,15 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
   ].join("\n");
 
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-[#e8eaed] p-4">
-      {/* Google-style review card — matches reference image exactly */}
-      <div className="w-full max-w-[420px] rounded-2xl bg-white shadow-xl">
-
-        {/* Header — dynamic company name */}
-        <div className="border-b border-gray-100 px-6 pt-6 pb-4">
-          <h1 className="text-center text-[17px] font-medium text-gray-900">
-            {companyName}
-          </h1>
-        </div>
-
-        {/* User avatar + name */}
-        <div className="flex flex-col items-center px-6 pt-5">
-          {/* Avatar — magenta circle with initial */}
-          <div className="flex h-[52px] w-[52px] items-center justify-center rounded-full bg-[#e91e8c]">
-            <span className="text-xl font-medium text-white">{initial}</span>
-          </div>
-          <p className="mt-2.5 text-[15px] font-medium text-gray-900">
-            {displayName}
-          </p>
-          {/* Google disclosure */}
-          <div className="mt-1 flex items-center gap-1">
-            <p className="text-xs text-gray-500">
-              Beitrag wird Google-weit ver&ouml;ffentlicht
-            </p>
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              className="text-gray-400"
-            >
-              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
-              <path
-                d="M12 16v-4m0-4h.01"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </div>
-        </div>
-
-        {/* Stars — 5 gold stars */}
-        <div className="flex justify-center gap-1.5 px-6 pt-4 pb-2">
-          {[1, 2, 3, 4, 5].map((star) => (
-            <svg
-              key={star}
-              width="36"
-              height="36"
-              viewBox="0 0 24 24"
-              fill="#fbbc04"
-              className="cursor-pointer transition-transform hover:scale-110"
-            >
-              <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-            </svg>
-          ))}
-        </div>
-
-        {/* Text area — high-quality 3-liner pre-filled */}
-        <div className="px-6 pt-3">
-          <textarea
-            className="h-[110px] w-full resize-none rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-[14px] leading-relaxed text-gray-700 outline-none transition-colors focus:border-blue-400 focus:bg-white focus:ring-1 focus:ring-blue-400"
-            placeholder="Schildere anderen deine Eindr&uuml;cke von diesem Ort"
-            defaultValue={defaultReviewText}
-            readOnly
-          />
-        </div>
-
-        {/* Add photos button — dark, full-width, matching reference */}
-        <div className="px-6 pt-3">
-          <button
-            type="button"
-            className="flex w-full items-center justify-center gap-2 rounded-full bg-[#303134] px-4 py-3 text-[13px] font-medium text-white transition-colors hover:bg-[#404144]"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="text-white">
-              <rect x="3" y="3" width="18" height="18" rx="2" stroke="currentColor" strokeWidth="2" />
-              <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" />
-              <path d="M21 15l-5-5L5 21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-            Fotos und Videos hinzuf&uuml;gen
-          </button>
-        </div>
-
-        {/* Bottom actions — Abbrechen + Posten */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-6">
-          <button
-            type="button"
-            className="text-[14px] font-medium text-blue-600 hover:text-blue-700"
-          >
-            Abbrechen
-          </button>
-          {/*
-            Primary: our Review Surface IS the experience.
-            "Posten" → Google Review URL if configured (production),
-            otherwise stays on our surface (demo — the surface itself is the proof).
-          */}
-          {googleReviewUrl ? (
-            <a
-              href={googleReviewUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-full bg-[#1a73e8] px-6 py-2.5 text-[14px] font-medium text-white shadow-sm transition-colors hover:bg-[#1557b0]"
-            >
-              Posten
-            </a>
-          ) : (
-            <button
-              type="button"
-              className="rounded-full bg-[#1a73e8] px-6 py-2.5 text-[14px] font-medium text-white shadow-sm transition-colors hover:bg-[#1557b0]"
-            >
-              Posten
-            </button>
-          )}
-        </div>
-      </div>
-    </div>
+    <ReviewSurfaceClient
+      companyName={companyName}
+      brandColor={brandColor}
+      category={caseRow.category || "\u2014"}
+      location={location}
+      caseDate={caseDate}
+      defaultText={defaultReviewText}
+      googleReviewUrl={googleReviewUrl}
+      trackUrl={`/api/review/${caseId}/track`}
+    />
   );
 }

--- a/src/web/src/components/ops/CaseListClient.tsx
+++ b/src/web/src/components/ops/CaseListClient.tsx
@@ -24,6 +24,7 @@ export interface CaseRow {
   source: string;
   assignee_text: string | null;
   reporter_name: string | null;
+  review_sent_at: string | null;
 }
 
 export interface KpiData {
@@ -302,11 +303,23 @@ export function CaseListClient({
                       </span>
                     </td>
                     <td className="px-4 py-3">
-                      <span
-                        className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-500"}`}
-                      >
-                        {STATUS_LABELS[c.status] ?? c.status}
-                      </span>
+                      <div className="flex items-center gap-1.5">
+                        <span
+                          className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-500"}`}
+                        >
+                          {STATUS_LABELS[c.status] ?? c.status}
+                        </span>
+                        {c.status === "done" && !c.review_sent_at && (
+                          <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-50 text-emerald-600 border border-emerald-200" title="Review m\u00f6glich">
+                            R
+                          </span>
+                        )}
+                        {c.status === "done" && c.review_sent_at && (
+                          <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-100 text-emerald-700 border border-emerald-300" title="Review gesendet">
+                            R&#10003;
+                          </span>
+                        )}
+                      </div>
                     </td>
                     <td className="px-4 py-3 text-gray-500 text-xs">
                       {formatDate(c.created_at)}

--- a/src/web/src/lib/reviews/deriveReviewStatus.ts
+++ b/src/web/src/lib/reviews/deriveReviewStatus.ts
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------------
+// Review Status Derivation (NS1: computed from case_events, not stored)
+// ---------------------------------------------------------------------------
+
+export type ReviewStatus =
+  | "moeglich"        // done + contact data + no review sent → green
+  | "angefragt"       // review_sent_at set, no surface opened → yellow
+  | "geoeffnet"       // surface_opened event → blue
+  | "geklickt"        // cta_clicked event → strong green
+  | "kein_kontakt"    // done + no contact data → gray
+  | "uebersprungen"   // explicit skip → gray
+  | "nicht_bereit"    // not done yet → hidden
+  ;
+
+export interface ReviewStatusInfo {
+  status: ReviewStatus;
+  label: string;
+  color: string; // Tailwind color class
+  canRequest: boolean;
+  canResend: boolean;
+  canSkip: boolean;
+  reviewCount: number;
+}
+
+const MAX_REVIEW_REQUESTS = 2;
+const RESEND_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+interface CaseEvent {
+  event_type: string;
+  created_at: string;
+}
+
+export function deriveReviewStatus(opts: {
+  caseStatus: string;
+  hasContactInfo: boolean;
+  reviewSentAt: string | null;
+  events: CaseEvent[];
+}): ReviewStatusInfo {
+  const { caseStatus, hasContactInfo, events } = opts;
+
+  // Not done → not ready for review
+  if (caseStatus !== "done") {
+    return {
+      status: "nicht_bereit",
+      label: "",
+      color: "",
+      canRequest: false,
+      canResend: false,
+      canSkip: false,
+      reviewCount: 0,
+    };
+  }
+
+  const reviewRequests = events.filter(e => e.event_type === "review_requested");
+  const reviewCount = reviewRequests.length;
+  const hasSkipped = events.some(e => e.event_type === "review_skipped");
+  const hasSurfaceOpened = events.some(e => e.event_type === "review_surface_opened");
+  const hasCtaClicked = events.some(e => e.event_type === "review_cta_clicked");
+
+  // Explicit skip
+  if (hasSkipped) {
+    return {
+      status: "uebersprungen",
+      label: "\u00dcbersprungen",
+      color: "bg-gray-100 text-gray-500",
+      canRequest: false,
+      canResend: false,
+      canSkip: false,
+      reviewCount,
+    };
+  }
+
+  // No contact data
+  if (!hasContactInfo) {
+    return {
+      status: "kein_kontakt",
+      label: "Kein Kontakt",
+      color: "bg-gray-100 text-gray-500",
+      canRequest: false,
+      canResend: false,
+      canSkip: true,
+      reviewCount,
+    };
+  }
+
+  // Never requested
+  if (reviewCount === 0) {
+    return {
+      status: "moeglich",
+      label: "Review m\u00f6glich",
+      color: "bg-emerald-50 text-emerald-700 border-emerald-200",
+      canRequest: true,
+      canResend: false,
+      canSkip: true,
+      reviewCount,
+    };
+  }
+
+  // Resend eligibility
+  const lastRequest = reviewRequests[0]; // already sorted desc by query
+  const canResend = reviewCount < MAX_REVIEW_REQUESTS &&
+    (Date.now() - new Date(lastRequest.created_at).getTime()) >= RESEND_COOLDOWN_MS;
+
+  // CTA clicked → strongest signal
+  if (hasCtaClicked) {
+    return {
+      status: "geklickt",
+      label: "Google ge\u00f6ffnet",
+      color: "bg-emerald-100 text-emerald-800 border-emerald-300",
+      canRequest: false,
+      canResend: false,
+      canSkip: false,
+      reviewCount,
+    };
+  }
+
+  // Surface opened
+  if (hasSurfaceOpened) {
+    return {
+      status: "geoeffnet",
+      label: "Ge\u00f6ffnet",
+      color: "bg-blue-50 text-blue-700 border-blue-200",
+      canRequest: false,
+      canResend,
+      canSkip: true,
+      reviewCount,
+    };
+  }
+
+  // Requested but not opened
+  return {
+    status: "angefragt",
+    label: "Angefragt",
+    color: "bg-amber-50 text-amber-700 border-amber-200",
+    canRequest: false,
+    canResend,
+    canSkip: true,
+    reviewCount,
+  };
+}


### PR DESCRIPTION
## Summary
Block B — 4 Zielbild-Specs implementiert:

- **S1.5 Wizard Notfall-Logik (N1-N7):** Bei Notfall-Auswahl → sofortiger Phone-CTA-Screen mit Firmenname + Notrufnummer. "Schriftlich melden" als sekundäre Option. Fallback-Warnung wenn kein Notdienst konfiguriert.
- **S1.7 Review Surface Gold (RS1-RS10):** Komplette Neufassung. Editierbares Textarea, Auftrags-Block (Kategorie/Ort/Datum), Clipboard+Google-CTA, Tenant-Branding (brand_color), keine Sterne, keine Fake-Buttons, Event-Tracking (surface_opened + cta_clicked).
- **S1.8 Nachlauf-System (NS1-NS3):** 6 Review-Status abgeleitet aus case_events (möglich → angefragt → geöffnet → geklickt / übersprungen / kein_kontakt). Max 2 Anfragen, 7-Tage-Cooldown. "Kein Review" Skip-Action.
- **S1.9 Leitstand Review-Badges:** Badge prominent im Falldetail neben Status. Aktionen: "Review anfragen" / "Nochmals anfragen" / "Kein Review". Review-Indikator (R / R✓) in Case-Liste.

## Test plan
- [ ] Wizard: Notfall auswählen → Phone-CTA-Screen erscheint (bei emergency.enabled)
- [ ] Wizard: Notfall ohne emergency → Inline-Warnung + normaler Flow
- [ ] Review Surface: Auftrags-Block zeigt Kategorie + Ort + Datum
- [ ] Review Surface: Textarea editierbar, Text kopierbar
- [ ] Review Surface: "Auf Google bewerten" öffnet Google + kopiert Text
- [ ] Case Detail: Review-Badge erscheint bei status=done
- [ ] Case Detail: "Review anfragen" → Badge wechselt zu "Angefragt"
- [ ] Case Detail: "Kein Review" → Badge wechselt zu "Übersprungen"
- [ ] Case List: R-Badge bei done Cases sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)