### PR TITLE
feat: S1.6 category unification — wizard + voice SSOT

### DIFF
--- a/src/web/app/kunden/[slug]/meldung/page.tsx
+++ b/src/web/app/kunden/[slug]/meldung/page.tsx
@@ -26,73 +26,6 @@ export async function generateMetadata({
   };
 }
 
-// ── Category derivation ───────────────────────────────────────────
-// Top row: 3 most common cases per business (dynamic from services).
-// Bottom row: "Allgemein" + "Angebot" + "Kontakt" (fixed, all customers).
-
-interface WizardCategory {
-  value: string;
-  label: string;
-  hint: string;
-  iconKey: string;
-  /** true = fixed bottom row */
-  fixed?: boolean;
-}
-
-/** Each case is triggered by service slugs/icons. Priority = array order. */
-const CASE_POOL: { value: string; label: string; hint: string; iconKey: string; triggers: string[] }[] = [
-  { value: "Verstopfung", label: "Verstopfung", hint: "Abfluss, WC, Leitung", iconKey: "drain", triggers: ["sanitaer", "sanitär", "bath"] },
-  { value: "Leck / Wasserschaden", label: "Leck / Wasserschaden", hint: "Tropft, feucht, nass", iconKey: "drop", triggers: ["sanitaer", "sanitär", "bath", "reparatur"] },
-  { value: "Heizungsausfall", label: "Heizungsausfall", hint: "Kalt, keine Wärme, Störung", iconKey: "flame", triggers: ["heizung", "flame", "heating"] },
-  { value: "Kein Warmwasser", label: "Kein Warmwasser", hint: "Boiler, Speicher defekt", iconKey: "thermo", triggers: ["heizung", "sanitaer", "sanitär", "wartung", "water", "bath"] },
-  { value: "Rohrbruch", label: "Rohrbruch", hint: "Akut, Wasseraustritt", iconKey: "burst", triggers: ["sanitaer", "sanitär", "bath", "reparatur", "pipe"] },
-  { value: "Dachschaden", label: "Dachschaden", hint: "Undicht, Sturmschaden", iconKey: "roof", triggers: ["spenglerei", "roof", "dach"] },
-  { value: "Fassadenschaden", label: "Fassadenschaden", hint: "Risse, Verkleidung lose", iconKey: "facade", triggers: ["fassade", "facade", "spenglerei"] },
-  { value: "Solaranlage defekt", label: "Solaranlage defekt", hint: "Kein Ertrag, Störung", iconKey: "solar", triggers: ["solar", "leaf"] },
-  { value: "Leitungsschaden", label: "Leitungsschaden", hint: "Gas, Wasser, Abwasser", iconKey: "pipe", triggers: ["leitungsbau", "pipe"] },
-  { value: "Blitzschutzprüfung", label: "Blitzschutzprüfung", hint: "Kontrolle, Wartung", iconKey: "bolt", triggers: ["blitzschutz"] },
-];
-
-/** Fixed bottom row — always shown on every wizard. */
-const FIXED_CATEGORIES: WizardCategory[] = [
-  { value: "Allgemein", label: "Allgemein", hint: "Sonstiges Anliegen", iconKey: "clipboard", fixed: true },
-  { value: "Angebot", label: "Angebot", hint: "Offerte, Beratung", iconKey: "document", fixed: true },
-  { value: "Kontakt", label: "Kontakt", hint: "Frage, Rückruf", iconKey: "chat", fixed: true },
-];
-
-function deriveWizardCategories(services: { slug: string; icon?: string }[]): WizardCategory[] {
-  const keys = new Set<string>();
-  for (const s of services) {
-    keys.add(s.slug.toLowerCase());
-    if (s.icon) keys.add(s.icon);
-    for (const part of s.slug.toLowerCase().split(/[-_]/)) {
-      keys.add(part);
-    }
-  }
-
-  // Pick top 3 dynamic cases matching this customer's services
-  const matched: WizardCategory[] = [];
-  for (const p of CASE_POOL) {
-    if (matched.length >= 3) break;
-    if (p.triggers.some((t) => keys.has(t))) {
-      matched.push({ value: p.value, label: p.label, hint: p.hint, iconKey: p.iconKey });
-    }
-  }
-
-  // If less than 3 matched, fill from pool
-  if (matched.length < 3) {
-    for (const p of CASE_POOL) {
-      if (matched.length >= 3) break;
-      if (!matched.some((m) => m.value === p.value)) {
-        matched.push({ value: p.value, label: p.label, hint: p.hint, iconKey: p.iconKey });
-      }
-    }
-  }
-
-  // Append fixed bottom row
-  return [...matched, ...FIXED_CATEGORIES];
-}
-
 // ── Page ──────────────────────────────────────────────────────────
 export default async function MeldungPage({
   params,
@@ -103,9 +36,6 @@ export default async function MeldungPage({
   const c = getCustomer(slug);
   if (!c) notFound();
 
-  // Derive top-3 dynamic cases from services + fixed bottom row
-  const categories = deriveWizardCategories(c.services);
-
   return (
     <CustomerWizardForm
       companyName={c.companyName}
@@ -114,7 +44,7 @@ export default async function MeldungPage({
       phoneRaw={c.contact.phoneRaw}
       emergency={c.emergency}
       accent={c.brandColor ?? "#2b6cb0"}
-      categories={categories}
+      categories={c.categories}
       backUrl={`/kunden/${c.slug}`}
     />
   );

--- a/src/web/src/lib/customers/brunner-haustechnik.ts
+++ b/src/web/src/lib/customers/brunner-haustechnik.ts
@@ -1,4 +1,5 @@
 import type { CustomerSite } from "./types";
+import { FIXED_CATEGORIES } from "./categories";
 
 const IMG = "/kunden/brunner-haustechnik";
 
@@ -347,6 +348,15 @@ export const brunnerHaustechnik: CustomerSite = {
       description:
         "Einführung von FlowSight — KI-gestützter Telefonassistent und digitales Fallmanagement.",
     },
+  ],
+
+  // Categories: values match voice agent (brunner_agent.json)
+  // Voice: Verstopfung, Leck, Heizung, Boiler, Rohrbruch, Sanitär allgemein
+  categories: [
+    { value: "Verstopfung", label: "Verstopfung", hint: "Abfluss, WC, Leitung", iconKey: "drain" },
+    { value: "Leck", label: "Leck", hint: "Tropft, feucht, Wasserschaden", iconKey: "drop" },
+    { value: "Heizung", label: "Heizung", hint: "Kalt, keine Wärme, Störung", iconKey: "flame" },
+    ...FIXED_CATEGORIES,
   ],
 
   careers: [

--- a/src/web/src/lib/customers/categories.ts
+++ b/src/web/src/lib/customers/categories.ts
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------------------
+// Shared category constants — SSOT for wizard + voice alignment (S1.6)
+// ---------------------------------------------------------------------------
+import type { CustomerCategory } from "./types";
+
+/** Fixed bottom row — identical for every customer wizard. */
+export const FIXED_CATEGORIES: CustomerCategory[] = [
+  { value: "Allgemein", label: "Allgemein", hint: "Sonstiges Anliegen", iconKey: "clipboard", fixed: true },
+  { value: "Angebot", label: "Angebot", hint: "Offerte, Beratung", iconKey: "document", fixed: true },
+  { value: "Kontakt", label: "Kontakt", hint: "Frage, Rückruf", iconKey: "chat", fixed: true },
+];

--- a/src/web/src/lib/customers/doerfler-ag.ts
+++ b/src/web/src/lib/customers/doerfler-ag.ts
@@ -1,4 +1,5 @@
 import type { CustomerSite } from "./types";
+import { FIXED_CATEGORIES } from "./categories";
 
 const IMG = "/kunden/doerfler-ag";
 
@@ -333,6 +334,15 @@ export const doerflerAg: CustomerSite = {
     { name: "Soltop", url: "https://www.soltop.ch" },
     { name: "Richner", url: "https://www.richner.ch" },
     { name: "Heim AG", url: "https://www.heim-ag.ch" },
+  ],
+
+  // Categories: values match voice agent (doerfler_agent.json)
+  // Voice: Verstopfung, Leck, Heizung, Boiler, Rohrbruch, Sanitär allgemein
+  categories: [
+    { value: "Verstopfung", label: "Verstopfung", hint: "Abfluss, WC, Leitung", iconKey: "drain" },
+    { value: "Leck", label: "Leck", hint: "Tropft, feucht, Wasserschaden", iconKey: "drop" },
+    { value: "Heizung", label: "Heizung", hint: "Kalt, keine Wärme, Störung", iconKey: "flame" },
+    ...FIXED_CATEGORIES,
   ],
 
   history: [

--- a/src/web/src/lib/customers/orlandini.ts
+++ b/src/web/src/lib/customers/orlandini.ts
@@ -1,4 +1,5 @@
 import type { CustomerSite } from "./types";
+import { FIXED_CATEGORIES } from "./categories";
 
 const IMG = "/kunden/orlandini";
 
@@ -274,6 +275,14 @@ export const orlandini: CustomerSite = {
         "Führerschein Kat. B",
       ],
     },
+  ],
+
+  // Categories: no voice agent — wizard-only (Sanitär + Heizung focus)
+  categories: [
+    { value: "Verstopfung", label: "Verstopfung", hint: "Abfluss, WC, Leitung", iconKey: "drain" },
+    { value: "Leck", label: "Leck", hint: "Tropft, feucht, Wasserschaden", iconKey: "drop" },
+    { value: "Heizung", label: "Heizung", hint: "Kalt, keine Wärme, Störung", iconKey: "flame" },
+    ...FIXED_CATEGORIES,
   ],
 
   /* History: Details nicht verifiziert → entfernt */

--- a/src/web/src/lib/customers/types.ts
+++ b/src/web/src/lib/customers/types.ts
@@ -37,6 +37,10 @@ export interface CustomerSite {
   history?: HistoryEntry[];
   careers?: JobListing[];
 
+  /** Wizard categories (top row = problem, fixed = bottom row).
+   *  Values MUST match voice agent post_call_analysis category values. */
+  categories: CustomerCategory[];
+
   /** Additional SEO keywords */
   seoKeywords?: string[];
 }
@@ -202,6 +206,21 @@ export interface HistoryEntry {
   title: string;
   description?: string;
   image?: string;
+}
+
+// ── Wizard Categories ─────────────────────────────────────────────
+
+export interface CustomerCategory {
+  /** Value stored in Supabase case.category — MUST match voice agent values */
+  value: string;
+  /** Display label in wizard UI */
+  label: string;
+  /** Short hint text below label */
+  hint: string;
+  /** Icon key for wizard card (maps to CategoryIcon in CustomerWizardForm) */
+  iconKey: string;
+  /** true = fixed bottom row (Allgemein, Angebot, Kontakt) */
+  fixed?: boolean;
 }
 
 // ── Careers ───────────────────────────────────────────────────────

--- a/src/web/src/lib/customers/walter-leuthold.ts
+++ b/src/web/src/lib/customers/walter-leuthold.ts
@@ -1,4 +1,5 @@
 import type { CustomerSite } from "./types";
+import { FIXED_CATEGORIES } from "./categories";
 
 const IMG = "/kunden/walter-leuthold";
 
@@ -254,6 +255,14 @@ export const walterLeuthold: CustomerSite = {
       name: "suissetec-Mitglied",
       issuer: "Schweizerisch-Liechtensteinischer Geb\u00e4udetechnikverband",
     },
+  ],
+
+  // Categories: no voice agent — wizard-only (Sanitär + Spenglerei focus)
+  categories: [
+    { value: "Verstopfung", label: "Verstopfung", hint: "Abfluss, WC, Leitung", iconKey: "drain" },
+    { value: "Leck", label: "Leck", hint: "Tropft, feucht, Wasserschaden", iconKey: "drop" },
+    { value: "Dachschaden", label: "Dachschaden", hint: "Undicht, Sturmschaden", iconKey: "roof" },
+    ...FIXED_CATEGORIES,
   ],
 
   history: [

--- a/src/web/src/lib/customers/weinberger-ag.ts
+++ b/src/web/src/lib/customers/weinberger-ag.ts
@@ -1,4 +1,5 @@
 import type { CustomerSite } from "./types";
+import { FIXED_CATEGORIES } from "./categories";
 
 const IMG = "/kunden/weinberger-ag";
 
@@ -269,6 +270,15 @@ export const weinbergerAg: CustomerSite = {
       description:
         "Seit 2007 gehören Sanitärinstallationen zu den Kernkompetenzen — von Badezimmern über Küchen bis zu Wellness-Einrichtungen.",
     },
+  ],
+
+  // Categories: values match voice agent (weinberger-ag_agent.json)
+  // Voice: Sanitär, Heizung, Lüftung, Badsanierung, Boiler, Rohrbruch, Verstopfung, Notfall
+  categories: [
+    { value: "Sanitär", label: "Sanitär", hint: "Installation, Reparatur", iconKey: "bath" },
+    { value: "Heizung", label: "Heizung", hint: "Wärmepumpe, Ausfall, Wartung", iconKey: "flame" },
+    { value: "Lüftung", label: "Lüftung", hint: "Raumklima, Komfortlüftung", iconKey: "snowflake" },
+    ...FIXED_CATEGORIES,
   ],
 
   careers: [

--- a/src/web/src/lib/customers/widmer-sanitaer.ts
+++ b/src/web/src/lib/customers/widmer-sanitaer.ts
@@ -1,4 +1,5 @@
 import type { CustomerSite } from "./types";
+import { FIXED_CATEGORIES } from "./categories";
 
 const IMG = "/kunden/widmer-sanitaer";
 
@@ -209,6 +210,14 @@ export const widmerSanitaer: CustomerSite = {
       role: "Geschäftsführer",
       bio: "Führt den Familienbetrieb in Horgen mit technischem Know-how und persönlichem Engagement.",
     },
+  ],
+
+  // Categories: no voice agent — wizard-only (Sanitär + Spenglerei focus)
+  categories: [
+    { value: "Verstopfung", label: "Verstopfung", hint: "Abfluss, WC, Leitung", iconKey: "drain" },
+    { value: "Leck", label: "Leck", hint: "Tropft, feucht, Wasserschaden", iconKey: "drop" },
+    { value: "Dachschaden", label: "Dachschaden", hint: "Undicht, Sturmschaden", iconKey: "roof" },
+    ...FIXED_CATEGORIES,
   ],
 
   history: [


### PR DESCRIPTION
## Summary
- **Remove `CASE_POOL` + `deriveWizardCategories()`** — eliminated the trigger-based derivation that produced values mismatched with voice agents ("Leck / Wasserschaden" vs "Leck", "Heizungsausfall" vs "Heizung")
- **Add explicit `categories` array to each `CustomerSite`** — per-customer wizard categories defined in the registry, values aligned with voice agent `post_call_analysis` fields
- **Shared `FIXED_CATEGORIES`** — bottom row (Allgemein, Angebot, Kontakt) defined once in `categories.ts`
- **New `CustomerCategory` type** in `types.ts` with value/label/hint/iconKey/fixed

### Category alignment (wizard ↔ voice)
| Customer | Wizard Top 3 | Voice Agent Values |
|----------|-------------|-------------------|
| Dörfler AG | Verstopfung, Leck, Heizung | Verstopfung, Leck, Heizung, Boiler, Rohrbruch, Sanitär allgemein |
| Brunner HT | Verstopfung, Leck, Heizung | Verstopfung, Leck, Heizung, Boiler, Rohrbruch, Sanitär allgemein |
| Weinberger AG | Sanitär, Heizung, Lüftung | Sanitär, Heizung, Lüftung, Badsanierung, Boiler, Rohrbruch, Verstopfung, Notfall |
| Walter Leuthold | Verstopfung, Leck, Dachschaden | — (no voice) |
| Orlandini | Verstopfung, Leck, Heizung | — (no voice) |
| Widmer | Verstopfung, Leck, Dachschaden | — (no voice) |

## Test plan
- [ ] Build passes (verified locally)
- [ ] `/kunden/doerfler-ag/meldung` — 3 top + 3 fixed categories render correctly
- [ ] `/kunden/weinberger-ag/meldung` — Sanitär/Heizung/Lüftung top row
- [ ] Voice intake → wizard case categories use same values in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)