### PR TITLE
fix: S2.4 Voice Agent Gold-QA — agent IDs + publish

### DIFF
--- a/retell/agent_ids.json
+++ b/retell/agent_ids.json
@@ -4,27 +4,27 @@
     "de_flow_id": "conversation_flow_e2c3a7cec528",
     "intl_agent_id": "agent_01fad4217f8b0697f0c26c69d5",
     "intl_flow_id": "conversation_flow_3c7d423226a9",
-    "last_synced": "2026-03-10T08:38:50.914Z"
+    "last_synced": "2026-03-12T14:38:17.164Z"
   },
   "doerfler": {
     "de_agent_id": "agent_d7dfe45ab444e1370e836c3e0f",
     "de_flow_id": "conversation_flow_8170ad3c2ca9",
     "intl_agent_id": "agent_fb4b956eec31db9c591880fdeb",
     "intl_flow_id": "conversation_flow_608d542979bb",
-    "last_synced": "2026-03-10T08:38:57.024Z"
+    "last_synced": "2026-03-12T14:38:29.730Z"
   },
   "flowsight_sales": {
     "de_agent_id": "agent_6515d8d1f23072ce61db806901",
     "de_flow_id": "conversation_flow_1f30bf247bf3",
     "intl_agent_id": "agent_e03666c402209716fb2c5b41d6",
     "intl_flow_id": "conversation_flow_dd3212a90e6e",
-    "last_synced": "2026-03-10T08:39:11.575Z"
+    "last_synced": "2026-03-12T14:38:33.047Z"
   },
   "weinberger-ag": {
     "de_agent_id": "agent_d568564d51ccb908dadf032e7d",
     "de_flow_id": "conversation_flow_4254de993a58",
     "intl_agent_id": "agent_0976aabe2c12ab0ca4d48933a5",
     "intl_flow_id": "conversation_flow_ac5b3603b478",
-    "last_synced": "2026-03-11T07:08:35.470Z"
+    "last_synced": "2026-03-12T14:38:25.213Z"
   }
 }

--- a/retell/exports/brunner_agent.json
+++ b/retell/exports/brunner_agent.json
@@ -360,7 +360,7 @@
         "tools": [
           {
             "type": "agent_swap",
-            "agent_id": "REPLACE_WITH_BRUNNER_INTL_AGENT_ID",
+            "agent_id": "agent_01fad4217f8b0697f0c26c69d5",
             "name": "swap_to_intl_agent",
             "description": "Transfer the caller to the multilingual (EN/FR/IT) agent. Execute this tool IMMEDIATELY — the caller does not speak German.",
             "post_call_analysis_setting": "only_destination_agent"

--- a/retell/exports/brunner_agent_intl.json
+++ b/retell/exports/brunner_agent_intl.json
@@ -295,7 +295,7 @@
         "tools": [
           {
             "type": "agent_swap",
-            "agent_id": "REPLACE_WITH_BRUNNER_DE_AGENT_ID",
+            "agent_id": "agent_47deec4bdc891126de71dd42be",
             "name": "swap_to_de_agent",
             "description": "Transfer the caller back to the German-speaking agent (Susi). Execute this tool IMMEDIATELY — the caller wants German.",
             "post_call_analysis_setting": "only_destination_agent"

--- a/retell/exports/weinberger-ag_agent.json
+++ b/retell/exports/weinberger-ag_agent.json
@@ -360,7 +360,7 @@
         "tools": [
           {
             "type": "agent_swap",
-            "agent_id": "REPLACE_WITH_WEINBERGER_INTL_AGENT_ID",
+            "agent_id": "agent_0976aabe2c12ab0ca4d48933a5",
             "name": "swap_to_intl_agent",
             "description": "Transfer the caller to the multilingual (EN/FR/IT) agent. Execute this tool IMMEDIATELY — the caller does not speak German.",
             "post_call_analysis_setting": "only_destination_agent"

--- a/retell/exports/weinberger-ag_agent_intl.json
+++ b/retell/exports/weinberger-ag_agent_intl.json
@@ -327,7 +327,7 @@
         "tools": [
           {
             "type": "agent_swap",
-            "agent_id": "REPLACE_WITH_WEINBERGER_DE_AGENT_ID",
+            "agent_id": "agent_d568564d51ccb908dadf032e7d",
             "name": "swap_to_de_agent",
             "description": "Transfer the caller back to the German-speaking agent (Susi). Execute this tool IMMEDIATELY — the caller wants German.",
             "post_call_analysis_setting": "only_destination_agent"


### PR DESCRIPTION
## Summary
- Fix placeholder agent IDs (`REPLACE_WITH_*`) in Brunner + Weinberger transfer tools
- Sync + publish all 8 voice agents (Brunner, Dörfler, Weinberger, Sales × DE/INTL)
- Language transfer DE↔INTL now functional for all customers

## What was broken
Brunner and Weinberger agents had `REPLACE_WITH_*` placeholders instead of real Retell agent IDs in their language swap tools. This meant DE→INTL and INTL→DE transfers would fail silently.

## Test plan
- [ ] CI passes
- [ ] All agents published (verified via retell_sync.mjs output)
- [ ] Brunner: call DE number, speak English → should transfer to INTL agent
- [ ] Weinberger: call DE number, speak English → should transfer to INTL agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)