### PR TITLE
fix: S3 trial journey — expiry hard gate + follow-up noise

### DIFF
--- a/scripts/_ops/morning_report.mjs
+++ b/scripts/_ops/morning_report.mjs
@@ -132,11 +132,14 @@ if (eT1) console.error("Query active trials:", eT1.message);
 
 const activeTrialCount = activeTrials?.length ?? 0;
 
-// T2. Follow-ups due today: follow_up_at <= todayEnd AND trial_status = 'trial_active'
+// T2. Follow-ups due: follow_up_at within last 3 days AND trial_status = 'trial_active'
+// After 3 days without action the flag auto-expires (Founder either called or skipped)
+const d3ago = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString();
 const { data: followUpsDue, error: eT2 } = await supabase
   .from("tenants")
   .select("slug")
   .eq("trial_status", "trial_active")
+  .gte("follow_up_at", d3ago)
   .lte("follow_up_at", todayEnd.toISOString());
 if (eT2) console.error("Query follow-ups:", eT2.message);
 

--- a/src/web/app/ops/expired/page.tsx
+++ b/src/web/app/ops/expired/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Trial abgelaufen",
+};
+
+export default function TrialExpiredPage() {
+  return (
+    <div className="min-h-screen bg-[#0b1120] flex items-center justify-center px-4">
+      <div className="max-w-md w-full text-center">
+        <div className="text-5xl mb-6">⏱️</div>
+        <h1 className="text-2xl font-bold text-white mb-3">
+          Ihr Trial ist abgelaufen
+        </h1>
+        <p className="text-slate-400 mb-8 leading-relaxed">
+          Ihr 14-Tage Testzeitraum ist beendet. Falls Sie das System
+          weiterhin nutzen möchten, melden Sie sich bei uns &mdash; wir
+          kümmern uns um alles Weitere.
+        </p>
+        <div className="space-y-3">
+          <a
+            href="tel:+41445520919"
+            className="block w-full bg-[#d4a853] text-[#0b1120] font-semibold py-3 px-6 rounded-lg hover:bg-[#c49a48] transition-colors"
+          >
+            044 552 09 19 anrufen
+          </a>
+          <Link
+            href="/"
+            className="block text-slate-500 hover:text-slate-300 text-sm transition-colors"
+          >
+            Zurück zur Startseite
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -41,7 +41,54 @@ export async function middleware(request: NextRequest) {
   });
 
   // Refresh session — this writes updated tokens to cookies
-  await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // ── Trial expiry hard gate ──────────────────────────────────────────
+  // Prospects whose trial has ended cannot access /ops (except /ops/expired).
+  if (user && request.nextUrl.pathname.startsWith("/ops")) {
+    const meta = user.app_metadata ?? {};
+    const role = meta.role as string | undefined;
+    const tenantId = meta.tenant_id as string | undefined;
+
+    if (role === "prospect" && tenantId) {
+      // Skip if already heading to /ops/expired
+      if (!request.nextUrl.pathname.startsWith("/ops/expired")) {
+        const svcUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+        const svcKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+        if (svcUrl && svcKey) {
+          try {
+            const res = await fetch(
+              `${svcUrl}/rest/v1/tenants?select=trial_end,trial_status&id=eq.${tenantId}&limit=1`,
+              {
+                headers: {
+                  apikey: svcKey,
+                  Authorization: `Bearer ${svcKey}`,
+                },
+                signal: AbortSignal.timeout(3000),
+              }
+            );
+            if (res.ok) {
+              const rows = await res.json();
+              const tenant = rows?.[0];
+              if (
+                tenant?.trial_end &&
+                new Date(tenant.trial_end).getTime() < Date.now() &&
+                tenant.trial_status !== "live"
+              ) {
+                const expiredUrl = new URL("/ops/expired", request.url);
+                return NextResponse.redirect(expiredUrl);
+              }
+            }
+          } catch {
+            // On fetch error, allow access (fail-open) — Morning Report catches stale trials
+          }
+        }
+      }
+    }
+  }
 
   return supabaseResponse;
 }


### PR DESCRIPTION
## Summary
- **Trial Expiry Hard Gate (CRITICAL):** Middleware now checks `trial_end` for prospect users — expired trials redirect to `/ops/expired` page with branded CTA. Fail-open on error.
- **Follow-Up YELLOW Noise (MEDIUM):** Morning Report `follow_up_due` auto-expires after 3 days instead of flagging permanently.
- **S3 Journey Verification PASS:** Voice/Wizard/Review/SMS/Dashboard chains verified E2E. Milestone timestamp bug confirmed NOT present (code already handles correctly).

## Test plan
- [ ] Deploy to preview → verify `/ops/expired` page renders correctly
- [ ] Verify middleware does NOT block admin users
- [ ] Verify middleware does NOT block `trial_status=live` tenants
- [ ] Morning Report: confirm follow_up_due no longer shows for >3d old entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)