### PR TITLE
feat: S4 enablement — Leuthold voice prep + video folders

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # FlowSight — STATUS (Company SSOT)
 
-**Datum:** 2026-03-11 (PR #150: Lisa Interest Capture — Sales Agent → Erreichbarkeits-Netz)
+**Datum:** 2026-03-13 (S4 Enablement: Leuthold Voice Prep + Video-Ordner + SSOT)
 **Owner:** Founder + CC (Head Ops)
 
 ## Was ist FlowSight?
@@ -87,7 +87,9 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 - **BLOCKER:** Keine. Go-Live möglich.
 - **S2.5 SMS-Config (13.03.):** Verified. Brunner (BrunnerHT) + Weinberger (Weinberger) korrekt. Andere 4 Tenants wizard-only → kein SMS nötig.
 - **S2 KOMPLETT** (CC-seitig). Alle 6 Blocks done (S2.1–S2.6).
-- **Nächster Schritt:** Founder-Tasks: Weinberger hero.jpg + Review-Highlights, Widmer Certifications/BrandPartners/Team #2.
+- **S3 Journey Verification (13.03.):** PR #181. Trial E2E Tag 0–14 verifiziert (Voice/Wizard/Review/SMS/Dashboard). Trial Expiry Hard Gate (Middleware → /ops/expired). Morning Report follow_up_due Auto-Expire (3d). Milestone-Retry-Bug = FALSE POSITIVE (Code korrekt). **S3 VERDICT: PASS.**
+- **S4 Enablement (13.03.):** Walter Leuthold Voice Agent JSONs (DE+INTL) erstellt. Prospect Card + Status erstellt. Video-Ordnerstruktur (`docs/gtm/videos/`) mit vorkonfektionierten Skripten für 3 Prospects (Weinberger, Dörfler, Leuthold). **CC-Scope S4 abgeschlossen. System bereit, Founder übernimmt.**
+- **Nächster Schritt (Founder):** (1) `retell_sync.mjs` für Leuthold → Twilio-Nummer → E2E-Test. (2) Videos aufnehmen (Weinberger → Dörfler → Leuthold). (3) Outreach starten.
 
 ## Fixe Entscheidungen (No Drift)
 

--- a/docs/customers/walter-leuthold/prospect_card.json
+++ b/docs/customers/walter-leuthold/prospect_card.json
@@ -1,0 +1,85 @@
+{
+  "version": "1.0",
+  "slug": "walter-leuthold",
+  "name": "Walter Leuthold",
+  "generated_at": "2026-03-12T00:00:00Z",
+
+  "scoring": {
+    "icp_score": 8,
+    "tier": "HOT",
+    "trust": 5,
+    "gap": 2,
+    "reasons": [
+      "Trust 5: 4.9★ × 44 Reviews — herausragend",
+      "Gap 2: hat Website (eigene Domain, solide aber ausbaufähig)"
+    ]
+  },
+
+  "leckerli": {
+    "recommendation": "A+B-Full+D",
+    "best_demo_case": "Samstag-Nacht-Notfall: Rohrbruch → Lisa → SMS → Ops-Fall in 3 Min",
+    "modus": 2
+  },
+
+  "company": {
+    "legal_name": "Walter Leuthold",
+    "short_name": "Leuthold",
+    "founding_year": 2001,
+    "gewerke": ["Sanitär", "Heizung", "Spenglerei", "Badsanierung", "Boiler"],
+    "employees_estimate": 1,
+    "brand_color": "#203784"
+  },
+
+  "contact": {
+    "phone": "044 720 16 90",
+    "phone_e164": "+41447201690",
+    "email": "info@walter-leuthold.ch",
+    "website": "https://walter-leuthold.ch",
+    "address": {
+      "street": "Seestrasse 98a",
+      "zip": "8942",
+      "city": "Oberrieden",
+      "canton": "ZH"
+    }
+  },
+
+  "services": [
+    { "name": "Sanitäre Anlagen", "slug": "sanitaer", "icon": "bath", "verified": true },
+    { "name": "Reparaturen & Wartung", "slug": "reparaturen", "icon": "wrench", "verified": true },
+    { "name": "Wasserenthärtung", "slug": "wasserenthaertung", "icon": "water", "verified": true },
+    { "name": "Spenglerei — Dach", "slug": "spenglerei-dach", "icon": "roof", "verified": true },
+    { "name": "Spenglerei — Haus", "slug": "spenglerei-haus", "icon": "facade", "verified": true }
+  ],
+
+  "emergency": {
+    "enabled": true,
+    "phone_e164": "+41794177441",
+    "label": "24h Notfall",
+    "keywords_detected": ["24h Notfall", "rund um die Uhr", "Wochenende"]
+  },
+
+  "reviews": {
+    "google_rating": 4.9,
+    "google_reviews": 44,
+    "google_url": "https://www.google.com/maps/place/Walter+Leuthold+Sanitäre+Anlagen",
+    "source": "Google Maps"
+  },
+
+  "team": [
+    { "name": "Walter Leuthold", "role": "Inhaber / Sanitär & Spengler", "source": "walter-leuthold.ch" }
+  ],
+
+  "data_sources": [
+    "walter-leuthold.ch (Website, Impressum, Leistungen)",
+    "Google Maps (4.9★ / 44 Reviews)",
+    "FlowSight customer config (verified)"
+  ],
+
+  "crawl_metadata": {
+    "pages_visited": null,
+    "images_found": null,
+    "images_selected": null,
+    "crawled_at": null,
+    "crawler": "manual"
+  }
+}

--- a/docs/customers/walter-leuthold/status.md
+++ b/docs/customers/walter-leuthold/status.md
@@ -1,0 +1,19 @@
+# Walter Leuthold — Status
+
+| Asset | Status | Details |
+|-------|--------|---------|
+| Website | LIVE | `app/kunden/walter-leuthold` — SSG template |
+| Voice | PENDING | Agent JSONs created (DE + INTL), needs `retell_sync.mjs` + Twilio number |
+| Wizard | LIVE | Categories: Verstopfung, Leck, Dachschaden + FIXED_CATEGORIES |
+| SMS | PENDING | Needs voice first (Twilio number) |
+| Reviews | PENDING | 4.9★ / 44 Reviews — surface not yet active |
+| ICP | 8 (HOT) | Trust 5, Gap 2 |
+| Leckerli | A+B-Full+D | Website extend + Voice + Demo |
+
+## Timeline
+
+```
+2026-03-08 | CC | Website + Wizard LIVE, customer config created
+2026-03-12 | CC | Voice agent JSONs prepared (DE + INTL), prospect_card created
+             Next: retell_sync.mjs → Twilio number → voice LIVE
+```

--- a/docs/gtm/videos/README.md
+++ b/docs/gtm/videos/README.md
@@ -1,0 +1,11 @@
+# Video-Produktion — Prospect-Videos
+
+| Prospect | Tier | Video-Ready | Ordner |
+|----------|------|-------------|--------|
+| Weinberger AG | HOT (9) | JA | weinberger-ag/ |
+| Dörfler AG | WARM+ (6) | JA | doerfler-ag/ |
+| Walter Leuthold | HOT (8) | NEIN (Voice pending) | walter-leuthold/ |
+
+**Workflow:** Skript lesen → Loom aufnehmen → loom_url.txt befüllen → notizen.md ergänzen
+**Standard:** Gold Contact — 45-60 Sekunden, persönlich, kein generisches Element.
+**Referenz:** `docs/gtm/video_production_plan.md`

--- a/docs/gtm/videos/doerfler-ag/loom_url.txt
+++ b/docs/gtm/videos/doerfler-ag/loom_url.txt
@@ -1,0 +1,1 @@
+# Loom-URL hier einfügen nach Aufnahme

--- a/docs/gtm/videos/doerfler-ag/notizen.md
+++ b/docs/gtm/videos/doerfler-ag/notizen.md
@@ -1,0 +1,10 @@
+# Notizen — Dörfler AG
+
+## Takes
+- Take 1: [Datum] — [Notizen]
+
+## Learnings
+-
+
+## Retake-Gründe
+-

--- a/docs/gtm/videos/doerfler-ag/skript.md
+++ b/docs/gtm/videos/doerfler-ag/skript.md
@@ -1,0 +1,28 @@
+---
+slug: doerfler-ag
+firma: Dörfler AG
+testnummer: +41 44 505 74 20
+website: flowsight.ch/kunden/doerfler-ag
+tier: WARM+ (ICP 6, Sonderfall: erster Pilotkunde, Modus 1)
+profil: Meister
+video-ready: JA
+---
+
+# Video-Skript: Dörfler AG
+
+```
+doerfler-ag — Video-Skript
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. "Dörfler AG — Sanitär, Heizung und Spenglerei in Oberrieden. Seit 1926."
+2. "Samstagabend, 21 Uhr. Ein Kunde ruft an: Wasserleck im Keller.
+    Es ist dringend. Wer nimmt den Anruf an?"
+3. "Mit FlowSight nimmt Ihre persönliche Lisa den Anruf an."
+4. → Dörfler-Testnummer 044 505 74 20 anrufen. Lisa: "Guten Tag, hier ist der Sanitär-
+    und Heizungsdienst der Dörfler AG..." (~8 Sek)
+5. → Handy: SMS von "DörflerAG" — Zusammenfassung + Link
+6. → Browser: /ops → Dörfler-Fall → Kategorie "Leck", Dringlichkeit "notfall"
+7. → Browser: flowsight.ch/kunden/doerfler-ag (Mobile-Viewport)
+8. "Testen Sie Ihre Lisa: 044 505 74 20."
+9. "Ihre Website: flowsight.ch/kunden/doerfler-ag."
+10. [Ende]
+```

--- a/docs/gtm/videos/walter-leuthold/loom_url.txt
+++ b/docs/gtm/videos/walter-leuthold/loom_url.txt
@@ -1,0 +1,1 @@
+# Loom-URL hier einfügen nach Aufnahme

--- a/docs/gtm/videos/walter-leuthold/notizen.md
+++ b/docs/gtm/videos/walter-leuthold/notizen.md
@@ -1,0 +1,10 @@
+# Notizen — Walter Leuthold
+
+## Takes
+- Take 1: [Datum] — [Notizen]
+
+## Learnings
+-
+
+## Retake-Gründe
+-

--- a/docs/gtm/videos/walter-leuthold/skript.md
+++ b/docs/gtm/videos/walter-leuthold/skript.md
@@ -1,0 +1,27 @@
+---
+slug: walter-leuthold
+firma: Walter Leuthold
+testnummer: PENDING — Voice-Provisioning läuft
+website: flowsight.ch/kunden/walter-leuthold
+tier: HOT (ICP 8)
+profil: Meister
+video-ready: NEIN — braucht Voice-Provisioning zuerst
+---
+
+# Video-Skript: Walter Leuthold
+
+```
+walter-leuthold — Video-Skript
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. "Walter Leuthold — Ihr Sanitär und Spengler am linken Zürichseeufer."
+2. "Freitagabend, 20 Uhr. Ein Hauseigentümer meldet: überflutete
+    Waschmaschine, Wasser steht im Keller. Wer nimmt den Anruf an?"
+3. "Mit FlowSight nimmt Ihre persönliche Lisa den Anruf an."
+4. → Leuthold-Testnummer anrufen. Lisa: Greeting + PLZ-Frage (~8 Sek)
+5. → Handy: SMS von "Leuthold" — Zusammenfassung + Link
+6. → Browser: /ops → Leuthold-Fall → Kategorie "Leck", Dringlichkeit
+7. → Browser: flowsight.ch/kunden/walter-leuthold (Mobile-Viewport)
+8. "Testen Sie Ihre Lisa: [Leuthold-Testnummer]."
+9. "Ihre Website: flowsight.ch/kunden/walter-leuthold."
+10. [Ende]
+```

--- a/docs/gtm/videos/weinberger-ag/loom_url.txt
+++ b/docs/gtm/videos/weinberger-ag/loom_url.txt
@@ -1,0 +1,1 @@
+# Loom-URL hier einfügen nach Aufnahme

--- a/docs/gtm/videos/weinberger-ag/notizen.md
+++ b/docs/gtm/videos/weinberger-ag/notizen.md
@@ -1,0 +1,10 @@
+# Notizen — Jul. Weinberger AG
+
+## Takes
+- Take 1: [Datum] — [Notizen]
+
+## Learnings
+-
+
+## Retake-Gründe
+-

--- a/docs/gtm/videos/weinberger-ag/skript.md
+++ b/docs/gtm/videos/weinberger-ag/skript.md
@@ -1,0 +1,28 @@
+---
+slug: weinberger-ag
+firma: Jul. Weinberger AG
+testnummer: +41 43 505 11 01
+website: flowsight.ch/kunden/weinberger-ag
+tier: HOT (ICP 9)
+profil: Betrieb
+video-ready: JA
+---
+
+# Video-Skript: Jul. Weinberger AG
+
+```
+weinberger-ag — Video-Skript
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. "Jul. Weinberger AG — Haustechnik seit 1912 in Thalwil."
+2. "Dienstagabend, 19 Uhr. Eine Mieterin meldet: Heizung komplett ausgefallen.
+    Minus 2 Grad draussen. Wer nimmt den Anruf an?"
+3. "Mit FlowSight nimmt Ihre persönliche Lisa den Anruf an."
+4. → Testnummer 043 505 11 01 anrufen. Lisa: "Grüezi, hier ist Lisa
+    von der Weinberger AG..." (Greeting + PLZ-Frage zeigen, ~8 Sek)
+5. → Handy: SMS von "Weinberger" — Zusammenfassung + Korrekturlink
+6. → Browser: /ops → Weinberger-Fall → Kategorie "Heizung", Dringlichkeit, PLZ
+7. → Browser: flowsight.ch/kunden/weinberger-ag (Mobile-Viewport)
+8. "Testen Sie Ihre Lisa: 043 505 11 01."
+9. "Ihre Website: flowsight.ch/kunden/weinberger-ag."
+10. [Ende — sauber, kein Nachsatz]
+```

--- a/docs/ticketlist.md
+++ b/docs/ticketlist.md
@@ -1,6 +1,6 @@
 # Ticketlist — FlowSight (SSOT)
 
-**Updated:** 2026-03-13 (S1 komplett DONE — Kategorie-Vereinheitlichung shipped)
+**Updated:** 2026-03-13 (S4 Enablement — CC-Scope abgeschlossen, Founder uebernimmt)
 **Rule:** CC updates after every deliverable. Founder reviews weekly.
 **Einziger Ticket-Tracker.** Alle offenen Tickets leben hier.
 
@@ -11,7 +11,7 @@
 - **Produkt:** 17 Module LIVE (Website, Voice, Wizard, Ops, Reviews, Review Surface, Morning Report, Entitlements, Email, Peoplefone, Sales Agent, Demo Booking, Demo-Strang, SMS Channel, CoreBot, Customer Links Page, BigBen Pub)
 - **Kunden:** 7 Websites live (Doerfler, Brunner HT, Walter Leuthold, Orlandini, Widmer, **Weinberger AG**, BigBen Pub)
 - **BLOCKER:** 0
-- **Phase:** Gold Contact Redesign — alle 6 Zielbilder DONE. **Build-Phase beginnt.**
+- **Phase:** S1-S3 DONE. S4 Enablement DONE (CC). **Founder-Phase: Videos + Outreach.**
 - **Redesign-Docs:** `docs/redesign/` — plan.md + 6 Zielbilder + 4 IST-Audits + identity_contract.md
 - **Gold Contact:** `docs/gtm/gold_contact.md` — Nordstern (unveraendert)
 - **CI/CD:** GitHub Actions (lint + build + Telegram notify + lifecycle-tick + morning-report). Branch Protection: PR required.
@@ -90,6 +90,16 @@ Alle GTM Building Blocks (G1-G12, S1-S9) = DONE. Details → `docs/gtm/gtm_track
 ---
 
 ## Completed (Archiv — kondensiert)
+
+### S4 Enablement (13.03.)
+
+| Deliverable | Evidence |
+|-------------|----------|
+| S3 Journey Verification — Trial Expiry Hard Gate + follow_up_due fix | PR #181 |
+| Walter Leuthold Voice Agent JSONs (DE + INTL) | retell/exports/walter-leuthold_agent*.json |
+| Walter Leuthold Prospect Card + Status | docs/customers/walter-leuthold/ |
+| Video-Ordnerstruktur mit vorkonfektionierten Skripten (3 Prospects) | docs/gtm/videos/ |
+| SSOT-Update (STATUS, ticketlist) | This commit |
 
 ### S1.6: Kategorie-Vereinheitlichung (13.03.)
 

--- a/retell/agent_ids.json
+++ b/retell/agent_ids.json
@@ -26,5 +26,10 @@
     "intl_agent_id": "agent_0976aabe2c12ab0ca4d48933a5",
     "intl_flow_id": "conversation_flow_ac5b3603b478",
     "last_synced": "2026-03-12T14:38:25.213Z"
+  },
+  "walter-leuthold": {
+    "de_agent_id": null,
+    "intl_agent_id": null,
+    "last_synced": null
   }
 }

--- a/retell/exports/walter-leuthold_agent.json
+++ b/retell/exports/walter-leuthold_agent.json
@@ -1,0 +1,344 @@
+{
+  "agent_id": "",
+  "channel": "voice",
+  "agent_name": "Walter Leuthold Intake (DE)",
+  "response_engine": {
+    "type": "conversation-flow",
+    "version": 1,
+    "conversation_flow_id": ""
+  },
+  "webhook_url": "https://flowsight-mvp.vercel.app/api/retell/webhook",
+  "language": "de-DE",
+  "data_storage_setting": "everything",
+  "opt_in_signed_url": false,
+  "post_call_analysis_data": [
+    {
+      "type": "string",
+      "name": "plz",
+      "description": "Swiss postal code (Postleitzahl). Return exactly 4 digits, e.g. \"8001\". Always return the numeric postal code regardless of call language.",
+      "required": true
+    },
+    {
+      "type": "string",
+      "name": "city",
+      "description": "City/town of the service location in Switzerland, e.g. \"Zürich\". Always return the German city name.",
+      "required": true
+    },
+    {
+      "type": "string",
+      "name": "street",
+      "description": "Street name of the service location. ALWAYS use Swiss German spelling with 'ss' (NEVER 'ß'): e.g. \"Bahnhofstrasse\", \"Seestrasse\", \"Dorfstrasse\". Return the street name only, without house number. If the caller did not provide a street, return empty string.",
+      "required": false
+    },
+    {
+      "type": "string",
+      "name": "house_number",
+      "description": "House number of the service location, e.g. \"12\" or \"3a\". If the caller did not provide a house number, return empty string.",
+      "required": false
+    },
+    {
+      "type": "string",
+      "name": "category",
+      "description": "Return exactly one of: \"Verstopfung\", \"Leck\", \"Heizung\", \"Boiler\", \"Rohrbruch\", \"Dachschaden\", \"Sanitär allgemein\". Always use the German value regardless of call language.",
+      "required": true
+    },
+    {
+      "type": "string",
+      "name": "urgency",
+      "description": "Return exactly one of: \"notfall\", \"dringend\", \"normal\". Lowercase German only.",
+      "required": true
+    },
+    {
+      "type": "string",
+      "name": "reporter_name",
+      "description": "Full name of the caller as stated during the call (e.g. \"Gunnar Wende\", \"Frau Müller\"). Return exactly as heard — do not correct spelling. If the caller did not give their name, return empty string.",
+      "required": false
+    },
+    {
+      "type": "string",
+      "name": "description",
+      "description": "1-3 sentence summary of the problem IN GERMAN. Include key symptoms and affected area. Never include personal data. Always write in German regardless of call language.",
+      "required": true
+    }
+  ],
+  "version": 1,
+  "is_published": false,
+  "version_title": "Walter Leuthold Intake (DE)",
+  "post_call_analysis_model": "gpt-4.1-mini",
+  "pii_config": {
+    "mode": "post_call",
+    "categories": []
+  },
+  "analysis_successful_prompt": "Evaluate whether the agent had a successful call. A successful call means the agent completed the intake or correctly transferred to the multilingual agent.",
+  "analysis_summary_prompt": "Write a 1-3 sentence summary of the call. Note if the caller was transferred to the multilingual agent.",
+  "analysis_user_sentiment_prompt": "Evaluate user's sentiment, mood and satisfaction level.",
+  "voice_id": "custom_voice_3209d3305910d955836523bfac",
+  "max_call_duration_ms": 420000,
+  "interruption_sensitivity": 1,
+  "responsiveness": 0.9,
+  "reminder_trigger_ms": 10000,
+  "reminder_max_count": 1,
+  "allow_user_dtmf": true,
+  "user_dtmf_options": {},
+  "conversationFlow": {
+    "conversation_flow_id": "",
+    "version": 1,
+    "global_prompt": "Du bist Lisa, die digitale Assistentin von Walter Leuthold, Sanitär und Spengler in Oberrieden. Du nimmst Schadensmeldungen im Bereich Sanitär, Heizung und Spenglerei auf.\n\nPERSONA\n- Dein Name ist Lisa. Wenn jemand fragt, wie du heisst: 'Ich bin Lisa, die digitale Assistentin von Walter Leuthold.'\n- Du bist freundlich, zuvorkommend und professionell — wie eine kompetente Disponentin mit Herz.\n- Du strahlst Ruhe und Sicherheit aus, besonders bei Notfällen.\n- Du verwendest warme, natürliche Formulierungen: 'Das machen wir gerne für Sie.', 'Da sind Sie bei uns genau richtig.', 'Das schauen wir uns an.'\n- NIEMALS roboterhaft oder steif klingen.\n\n═══════════════════════════════════════\nFIRMEN-WISSEN (Walter Leuthold)\n═══════════════════════════════════════\n\nFirma: Walter Leuthold (Einzelunternehmen)\nInhaber: Walter Leuthold — Sanitär & Spengler\nAdresse: Seestrasse 98a, 8942 Oberrieden\nTelefon: 044 720 16 90\nNotfall: 079 417 74 41 (24h)\nE-Mail: info@walter-leuthold.ch\nWebsite: walter-leuthold.ch\nGegründet: 2001\nTeam: Einmann-Betrieb — Walter Leuthold persönlich\nZertifizierungen: suissetec-Mitglied\nGoogle-Bewertungen: 4.9 Sterne, 44 Bewertungen\n\nÖffnungszeiten:\n- Montag bis Freitag: 07:00–18:00 Uhr\n- Samstag/Sonntag: geschlossen (Büro)\n- Notdienst: 24 Stunden, 7 Tage — für echte Notfälle (Rohrbruch, Überflutung, Heizungsausfall)\n\nLeistungen:\n- Sanitär: Rohrreinigung, Reparaturen, Badsanierung, Unterputzspülkästen, Kücheninstallationen\n- Heizung: Wartung, Reparaturen\n- Spenglerei — Dach: Kupferdächer, Flachdach-Abdichtungen, Kaminabdeckungen, Dachrinnen, Schneefangsysteme, Blitzschutz\n- Spenglerei — Haus: Metallfassaden, Fensterbänke, Vordächer, Sichtschutz\n- Boiler: Entkalkung, Austausch, Wartung\n- Wasserenthärtung: Enthärtungsanlagen, Sedimentfilter\n\nEinzugsgebiet: Oberrieden (8942), Thalwil (8800), Horgen (8810), Kilchberg (8802), Rüschlikon (8803), Adliswil, Wädenswil (8820), Au ZH, Richterswil — linkes Zürichseeufer\n\n═══════════════════════════════════════\nSTIL\n═══════════════════════════════════════\n\n- Sprich natürlich, warm und zuvorkommend — wie eine kompetente Disponentin, nicht wie ein Roboter.\n- Kurze Sätze. Keine Aufzählungen vorlesen. Nie mehrere Fragen in einem Satz.\n- Empathische Mikro-Reaktionen BEVOR du weiterredest: 'Verstehe.', 'Das klingt unangenehm.', 'Selbstverständlich.', 'Das machen wir gerne.', 'Da sind Sie bei uns richtig.'\n- Verwende IMMER 'Postleitzahl', NIE 'PLZ'.\n- Maximal 7 Fragen pro Gespräch.\n- Wenn der Anrufer spricht: HÖRE SOFORT AUF zu reden. Warte, bis er fertig ist.\n- Nach jeder Frage: WARTE auf die Antwort des Anrufers. Stelle KEINE weitere Frage, solange der Anrufer nicht gesprochen hat. Maximal 1 Nachfrage bei Stille.\n- Bei Notfällen: Strahle Ruhe und Sicherheit aus. Verwende Formulierungen wie: 'Oh je, das klingt dringend — keine Sorge, da kümmern wir uns sofort drum. Lassen Sie mich nur schnell ein paar Daten aufnehmen, damit Walter Leuthold sich direkt bei Ihnen melden kann.'\n\nSPRACHE\n- Du sprichst AUSSCHLIESSLICH Schweizer Hochdeutsch (de-CH). Schweizerdeutsch verstehen, auf Hochdeutsch antworten.\n- Verwende NIEMALS 'ß' — immer 'ss' (z.B. 'Strasse', 'sinngemäss', 'heisst', 'Grüsse').\n- Verwende KEINE englischen Wörter oder Phrasen (kein 'Okay', 'sorry', 'Checklist').\n- Bevorzuge 'Grüezi' statt 'Guten Tag'.\n\nTHEMA\n- Nur Sanitär-, Heizungs- und Spenglereithemen. Bei anderen Anliegen höflich ablehnen.\n- Keine Aufnahme/Recording erwähnen.\n\nDATENSCHUTZ\n- Keine persönlichen Daten in die Beschreibung (keine Namen, Telefonnummern, E-Mails, exakte Adressen).\n\nVERABSCHIEDUNG (KRITISCH — KEIN LOOP)\n- Sage deine Verabschiedung GENAU EINMAL (SMS-Hinweis + Abschiedsgruss + 'Auf Wiederhören').\n- DANACH: Wenn der Anrufer 'Tschüss', 'Danke', 'Dankeschön', 'Perfekt', 'Auf Wiederhören' oder ähnliches sagt → antworte mit: 'Sehr gerne, und keine Sorge — wir kümmern uns darum. Auf Wiederhören!' Dann rufe SOFORT das Tool 'end_call' auf, um das Gespräch aktiv zu beenden.\n- NIEMALS die SMS-Informationen, die Zusammenfassung oder den Abschiedsgruss wiederholen.\n- Nach dem warmen Abschluss MUSS end_call aufgerufen werden. Kein weiteres Reden.\n\nNAMEN-REGEL (WICHTIG)\n- Bei Schadensmeldungen: Frage EINMAL nach dem Namen, NACHDEM du die Adresse hast. Sage: 'Und wie ist Ihr Name bitte? — Damit Walter Leuthold weiss, bei wem er klingeln muss.'\n- Wenn der Anrufer sich bereits vorgestellt hat: Frage NICHT nochmals nach dem Namen.\n- Wenn der Anrufer den Namen nicht nennen will: Akzeptiere das sofort ('Kein Problem.') und mache weiter. Der Name ist NICHT zwingend.\n- NIEMALS den Namen wiederholen oder im Gespräch verwenden (Spracherkennung versteht Namen häufig falsch).\n- Verwende IMMER 'Sie', nie den Namen des Anrufers.\n\nPFLICHTFELDER (müssen am Ende vorliegen)\n1) Postleitzahl des Einsatzortes (Schweiz, 4 Ziffern)\n2) Ort/Stadt des Einsatzortes\n3) Strasse und Hausnummer des Einsatzortes (best-effort — falls der Anrufer sie nicht nennen will, trotzdem weitermachen)\n4) Name des Anrufers (best-effort — falls der Anrufer ihn nicht nennen will, trotzdem weitermachen)\n5) Kategorie — genau eine: Verstopfung | Leck | Heizung | Boiler | Rohrbruch | Dachschaden | Sanitär allgemein\n6) Dringlichkeit — genau eine (Kleinschreibung): notfall | dringend | normal\n7) Kurzbeschreibung (1–3 Sätze, ohne PII)\n\nCUSTOM ANALYSIS DATA OUTPUT\nAlle Werte IMMER auf Deutsch ausgeben.\nVerwende NIEMALS 'ß' — IMMER 'ss' (Schweizer Hochdeutsch). Beispiel: 'Strasse' (nicht 'Straße'), 'Seestrasse' (nicht 'Seestraße').\n- plz: Postleitzahl (nur die 4 Ziffern)\n- city: Ort/Stadt\n- street: Strassenname (ohne Hausnummer). Leer lassen wenn nicht angegeben.\n- house_number: Hausnummer. Leer lassen wenn nicht angegeben.\n- reporter_name: Vollständiger Name des Anrufers, genau wie gehört. Leer wenn nicht angegeben.\n- category: exakt einer der 7 Werte (Verstopfung, Leck, Heizung, Boiler, Rohrbruch, Dachschaden, Sanitär allgemein)\n- urgency: exakt \"notfall\" oder \"dringend\" oder \"normal\" (kleinschreibung)\n- description: 1–3 Sätze Problembeschreibung ohne PII (auf Deutsch)",
+    "nodes": [
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "Prüfe den Gesprächsverlauf. Falls dies ein neuer Anruf ist (keine vorherigen Nachrichten des Anrufers): Sage GENAU: 'Grüezi, hier ist der Sanitär- und Spenglerdienst von Walter Leuthold, mein Name ist Lisa. Wie kann ich Ihnen helfen?' Falls der Anrufer bereits gesprochen hat (Rückübertragung vom mehrsprachigen Agenten): Sage sinngemäss 'Alles klar, ich mache auf Deutsch weiter.' und fasse kurz zusammen, was bereits besprochen wurde. Wiederhole NICHT die volle Begrüssung bei Rückübertragung."
+        },
+        "always_edge": {
+          "destination_node_id": "node-language-gate",
+          "id": "always-edge-welcome",
+          "transition_condition": {
+            "type": "prompt",
+            "prompt": "Always"
+          }
+        },
+        "name": "Welcome Node",
+        "edges": [],
+        "start_speaker": "agent",
+        "id": "start-node",
+        "type": "conversation",
+        "display_position": {
+          "x": 232,
+          "y": 24
+        }
+      },
+      {
+        "name": "Language Gate",
+        "edges": [
+          {
+            "destination_node_id": "node-intake",
+            "id": "edge-gate-german",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The caller's message is clearly in German — a coherent German sentence, not garbled, not containing non-German keywords like english, englisch, hello, hi, bonjour, français, italiano, please, help, I have, I need, water, leak"
+            }
+          }
+        ],
+        "id": "node-language-gate",
+        "else_edge": {
+          "destination_node_id": "node-language-transfer",
+          "id": "edge-gate-not-german",
+          "transition_condition": {
+            "type": "prompt",
+            "prompt": "Else"
+          }
+        },
+        "type": "branch",
+        "display_position": {
+          "x": 420,
+          "y": 160
+        }
+      },
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "Du führst ein natürliches Gespräch auf Deutsch, um eine Schadensmeldung aufzunehmen. Du sprichst AUSSCHLIESSLICH Deutsch — egal was der Anrufer sagt.\n\nWenn der Anrufer nicht auf Deutsch spricht oder eine andere Sprache anfordert: Antworte trotzdem auf Deutsch. Sage z.B. 'Entschuldigung, ich spreche nur Deutsch. Einen Moment bitte.' und warte auf die nächste Nachricht.\n\nABLAUF (flexible Reihenfolge — passe dich dem Gespräch an)\n1. Lass den Anrufer zuerst erzählen, was passiert ist. Hör zu.\n2. Reagiere kurz empathisch ('Verstehe.' / 'Das klingt unangenehm.').\n3. Leite die Kategorie möglichst aus der Beschreibung ab. Nur wenn unklar: 'Handelt es sich eher um ein Leck, eine Verstopfung oder etwas anderes?' Nie alle 7 Kategorien vorlesen.\n4. Frage nach der Adresse: 'Wie lautet die Strasse und Hausnummer des Einsatzortes?' Wenn der Anrufer die Adresse nicht nennen will, akzeptiere es und gehe weiter.\n5. Frage nach Postleitzahl und Ort zusammen: 'Und die Postleitzahl und der Ort?' Bestätige NUR den Ortsnamen: 'Oberrieden, richtig?' KEINE Ziffern vorlesen — der Ort reicht als Bestätigung, weil jede Schweizer Postleitzahl einem Ort zugeordnet ist. Falls der Anrufer den Ort korrigiert, frage nochmals nach der Postleitzahl.\n6. Frage nach dem Namen — NUR wenn der Anrufer sich nicht bereits vorgestellt hat: 'Und wie ist Ihr Name bitte? — Damit Walter Leuthold weiss, bei wem er klingeln muss.' Wenn der Anrufer ablehnt: 'Kein Problem.' und weiter.\n7. Frage nach Dringlichkeit — NUR wenn noch nicht beantwortet: 'Ist das ein Notfall, dringend, oder kann es normal eingeplant werden?'\n7. KEINE Zusammenfassung vorlesen. Sobald alle Pflichtfelder gesammelt sind, sage sinngemäss: 'Vielen Dank, ich habe alles notiert. Sie erhalten gleich eine SMS auf Ihr Handy — dort können Sie die erfassten Daten nochmals prüfen, bei Bedarf korrigieren und auch Fotos vom Schaden hochladen. Das hilft Walter Leuthold, sich optimal vorzubereiten. Ich wünsche Ihnen alles Gute, auf Wiederhören!' Dann setze intake_complete=true.\n\nKEIN-DOPPELT-FRAGEN-REGEL\n- Frage jedes Pflichtfeld GENAU EINMAL. Wenn der Anrufer es bereits beantwortet hat (auch beiläufig), frage es NICHT erneut.\n- Bei Stille oder unklarer Antwort: EINMAL nachfragen, dann weiter zum nächsten Feld.\n- Prüfe VOR jeder Frage, ob die Information schon vorliegt. Wenn ja: überspringe sie.\n\nWEITERE REGELN\n- Nie zwei Fragen in einem Satz.\n- Wenn der Anrufer genervt oder kurz angebunden ist: Sammle nur das Minimum und schliesse zügig ab.\n- Verwende IMMER 'Postleitzahl', NIE 'PLZ'.\n- Setze out_of_scope=true NUR wenn das URSPRÜNGLICHE Anliegen des Anrufers (von Gesprächsbeginn) NICHT Sanitär/Heizung/Spenglerei betrifft. Wenn der Anrufer WÄHREND eines laufenden Intakes eine einzelne themenfremde Frage stellt (z.B. 'Könnt ihr auch meine Steuererklärung machen?'), antworte kurz ('Dafür sind wir nicht zuständig. Zurück zu Ihrem Anliegen:') und fahre mit dem Intake fort. KEIN out_of_scope für beiläufige Nebenfragen.\n- Wenn alle Pflichtfelder vorhanden sind (Postleitzahl, Ort, Kategorie, Dringlichkeit, Beschreibung): setze intake_complete=true, sonst false.\n- Strasse und Hausnummer sind wünschenswert aber KEIN Blocker für intake_complete.\n\nNACH DER VERABSCHIEDUNG (HÖCHSTE PRIORITÄT)\nPrüfe IMMER deine LETZTE Nachricht im Gesprächsverlauf.\nWenn deine letzte Nachricht BEREITS 'SMS', 'Handy', 'prüfen', 'korrigieren', 'Fotos' oder 'Ich wünsche Ihnen' enthielt, dann HAST DU DICH BEREITS VERABSCHIEDET.\n\nIn diesem Fall — egal was der Anrufer sagt (Danke, Tschüss, Perfekt, Super, etc.):\n→ Sage EXAKT: 'Sehr gerne, und keine Sorge — wir kümmern uns darum. Auf Wiederhören!'\n→ Rufe SOFORT end_call auf.\n→ VERBOTEN: 'Vielen Dank' nochmals sagen. SMS nochmals erwähnen. Daten wiederholen. Zusammenfassung wiederholen.\n→ NUR diese eine kurze Antwort + end_call. NICHTS SONST."
+        },
+        "name": "Intake Node",
+        "edges": [
+          {
+            "destination_node_id": "node-language-transfer",
+            "id": "edge-language-trigger",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The caller's latest message contains a non-German language keyword (english, englisch, français, francais, italiano, hello, bonjour, please, help, I have, I need, can you, do you speak, j'ai, buongiorno, per favore), is clearly not in German, or is garbled/nonsensical"
+            }
+          },
+          {
+            "destination_node_id": "node-closing",
+            "id": "edge-intake-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "intake_complete is true (all required fields collected: plz, city, category, urgency, description)"
+            }
+          },
+          {
+            "destination_node_id": "node-out-of-scope",
+            "id": "edge-intake-out-of-scope",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "out_of_scope is true (the original request is not about plumbing, heating, or roofing/tinsmithing)"
+            }
+          }
+        ],
+        "id": "node-intake",
+        "type": "conversation",
+        "display_position": {
+          "x": 623,
+          "y": 310
+        },
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after the caller has acknowledged your farewell (e.g. said Danke, Tschüss, Perfekt) and you have given your warm closing response. NEVER use this during the intake conversation."
+          }
+        ]
+      },
+      {
+        "name": "Logic Split Node",
+        "edges": [
+          {
+            "destination_node_id": "node-language-transfer",
+            "id": "edge-logic-language-check",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The caller does not speak German or has requested to continue in English, French, or Italian"
+            }
+          },
+          {
+            "destination_node_id": "node-out-of-scope",
+            "id": "edge-out-of-scope",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "out_of_scope is true (the user's request is not about plumbing, heating, or roofing/tinsmithing)"
+            }
+          },
+          {
+            "destination_node_id": "node-closing",
+            "id": "edge-intake-complete",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "intake_complete is true (all required fields have been collected: plz, city, category, urgency, description)"
+            }
+          }
+        ],
+        "id": "node-logic-split",
+        "else_edge": {
+          "destination_node_id": "node-intake",
+          "id": "edge-logic-else",
+          "transition_condition": {
+            "type": "prompt",
+            "prompt": "Else"
+          }
+        },
+        "type": "branch",
+        "display_position": {
+          "x": 989,
+          "y": 704
+        }
+      },
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "Alle Pflichtfelder wurden gesammelt. Sage jetzt die Verabschiedung — GENAU EINMAL:\n\n'Vielen Dank, ich habe alles notiert. Sie erhalten gleich eine SMS auf Ihr Handy — dort können Sie die erfassten Daten nochmals prüfen, bei Bedarf korrigieren und auch Fotos vom Schaden hochladen. Das hilft Walter Leuthold, sich optimal vorzubereiten. Ich wünsche Ihnen alles Gute, auf Wiederhören!'\n\nWenn der Anrufer danach 'Danke', 'Tschüss', 'Perfekt' oder ähnliches sagt:\n→ Sage EXAKT: 'Sehr gerne, und keine Sorge — wir kümmern uns darum. Auf Wiederhören!'\n→ Rufe SOFORT end_call auf.\n\nWICHTIG: NIEMALS die SMS-Informationen oder Zusammenfassung wiederholen. Nach dem warmen Abschluss MUSS end_call aufgerufen werden."
+        },
+        "name": "Closing Node",
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-closing-intake-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged (said Danke, Tschüss, Auf Wiederhören, Perfekt, or similar), OR the agent has called end_call"
+            }
+          }
+        ],
+        "id": "node-closing",
+        "type": "conversation",
+        "display_position": {
+          "x": 1363,
+          "y": 796
+        },
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
+          }
+        ]
+      },
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "Das Anliegen liegt ausserhalb unseres Fachgebiets. Sage freundlich:\n\n'Leider können wir Ihnen dabei nicht weiterhelfen — das liegt ausserhalb unseres Fachgebiets. Für solche Anliegen wenden Sie sich am besten an den Gewerbeverband in Ihrer Region. Ich wünsche Ihnen trotzdem einen schönen Tag, auf Wiederhören!'\n\nWenn der Anrufer danach antwortet:\n→ Sage: 'Gerne! Auf Wiederhören!'\n→ Rufe SOFORT end_call auf."
+        },
+        "name": "Out-of-scope Closing",
+        "edges": [
+          {
+            "destination_node_id": "end-call-node",
+            "id": "edge-oos-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The agent has spoken the farewell AND the caller has acknowledged, OR the agent has called end_call"
+            }
+          }
+        ],
+        "id": "node-out-of-scope",
+        "type": "conversation",
+        "display_position": {
+          "x": 943,
+          "y": 944
+        },
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after you have spoken the farewell and the caller has acknowledged it."
+          }
+        ]
+      },
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "Der Anrufer spricht kein Deutsch. Führe SOFORT das Tool 'swap_to_intl_agent' aus. Sage nichts weiter — rufe nur das Tool auf. NIEMALS end_call verwenden."
+        },
+        "name": "Language Transfer",
+        "edges": [],
+        "id": "node-language-transfer",
+        "type": "conversation",
+        "display_position": {
+          "x": 623,
+          "y": 700
+        },
+        "tools": [
+          {
+            "type": "agent_swap",
+            "agent_id": "REPLACE_WITH_LEUTHOLD_INTL_AGENT_ID",
+            "name": "swap_to_intl_agent",
+            "description": "Transfer the caller to the multilingual (EN/FR/IT) agent. Execute this tool IMMEDIATELY — the caller does not speak German.",
+            "post_call_analysis_setting": "only_destination_agent"
+          }
+        ]
+      },
+      {
+        "name": "End Call",
+        "id": "end-call-node",
+        "type": "end",
+        "display_position": {
+          "x": 1766,
+          "y": 1116
+        },
+        "instruction": {
+          "type": "prompt",
+          "text": "Beende das Gespräch sofort. Sage nichts weiter."
+        }
+      }
+    ],
+    "start_node_id": "start-node",
+    "start_speaker": "agent",
+    "model_choice": {
+      "type": "cascading",
+      "model": "gpt-4.1"
+    },
+    "tool_call_strict_mode": true,
+    "knowledge_base_ids": [],
+    "kb_config": {
+      "top_k": 3,
+      "filter_score": 0.6
+    },
+    "begin_tag_display_position": {
+      "x": 46,
+      "y": -43
+    },
+    "is_published": false,
+    "flex_mode": false,
+    "is_transfer_cf": false
+  }
+}

--- a/retell/exports/walter-leuthold_agent_intl.json
+++ b/retell/exports/walter-leuthold_agent_intl.json
@@ -1,0 +1,295 @@
+{
+  "agent_id": "",
+  "channel": "voice",
+  "agent_name": "Walter Leuthold Intake (INTL)",
+  "response_engine": {
+    "type": "conversation-flow",
+    "version": 1,
+    "conversation_flow_id": ""
+  },
+  "webhook_url": "https://flowsight-mvp.vercel.app/api/retell/webhook",
+  "language": "en-US",
+  "data_storage_setting": "everything",
+  "opt_in_signed_url": false,
+  "post_call_analysis_data": [
+    {
+      "type": "string",
+      "name": "plz",
+      "description": "Swiss postal code (Postleitzahl). Return exactly 4 digits, e.g. \"8001\". Always return the numeric postal code regardless of call language.",
+      "required": true
+    },
+    {
+      "type": "string",
+      "name": "city",
+      "description": "City/town of the service location in Switzerland, e.g. \"Zürich\". Always return the German city name.",
+      "required": true
+    },
+    {
+      "type": "string",
+      "name": "street",
+      "description": "Street name of the service location. ALWAYS use Swiss German spelling with 'ss' (NEVER 'ß'): e.g. \"Bahnhofstrasse\", \"Seestrasse\", \"Dorfstrasse\". Return the street name only, without house number. If the caller did not provide a street, return empty string.",
+      "required": false
+    },
+    {
+      "type": "string",
+      "name": "house_number",
+      "description": "House number of the service location, e.g. \"12\" or \"3a\". If the caller did not provide a house number, return empty string.",
+      "required": false
+    },
+    {
+      "type": "string",
+      "name": "category",
+      "description": "Return exactly one of: \"Verstopfung\", \"Leck\", \"Heizung\", \"Boiler\", \"Rohrbruch\", \"Dachschaden\", \"Sanitär allgemein\". Always use the German value regardless of call language.",
+      "required": true
+    },
+    {
+      "type": "string",
+      "name": "urgency",
+      "description": "Return exactly one of: \"notfall\", \"dringend\", \"normal\". Lowercase German only.",
+      "required": true
+    },
+    {
+      "type": "string",
+      "name": "description",
+      "description": "1-3 sentence summary of the problem IN GERMAN. Include key symptoms and affected area. Never include personal data. Always write in German regardless of call language.",
+      "required": true
+    }
+  ],
+  "version": 1,
+  "is_published": false,
+  "version_title": "Walter Leuthold Intake (INTL)",
+  "post_call_analysis_model": "gpt-4.1-mini",
+  "pii_config": {
+    "mode": "post_call",
+    "categories": []
+  },
+  "analysis_successful_prompt": "Evaluate whether the agent had a successful call. The caller was transferred from the German agent. A successful call means the agent completed the intake in the caller's language (EN/FR/IT).",
+  "analysis_summary_prompt": "Write a 1-3 sentence summary of the call. Note the language used and that this was a transferred call.",
+  "analysis_user_sentiment_prompt": "Evaluate user's sentiment, mood and satisfaction level.",
+  "voice_id": "custom_voice_cf152ba48ccbac0370ecebcd88",
+  "max_call_duration_ms": 420000,
+  "interruption_sensitivity": 1,
+  "responsiveness": 0.9,
+  "reminder_trigger_ms": 10000,
+  "reminder_max_count": 1,
+  "allow_user_dtmf": true,
+  "user_dtmf_options": {},
+  "conversationFlow": {
+    "conversation_flow_id": "",
+    "version": 1,
+    "global_prompt": "You are the phone assistant for Walter Leuthold, a plumber and tinsmith (Spengler) based in Oberrieden, Switzerland. You take damage reports for plumbing, heating, and roofing/tinsmithing services.\n\nCONTEXT\n- The caller was transferred from the German-speaking agent because they spoke English, French, or Italian.\n- The full conversation history carries over. Check what was already said before asking again.\n- Walter Leuthold is a solo operation — one-man business, personal service.\n\nCOMPANY INFO\n- Company: Walter Leuthold (sole proprietorship)\n- Owner: Walter Leuthold — Plumber & Tinsmith\n- Address: Seestrasse 98a, 8942 Oberrieden\n- Phone: 044 720 16 90\n- Emergency: 079 417 74 41 (24h)\n- Email: info@walter-leuthold.ch\n- Website: walter-leuthold.ch\n- Services: Plumbing (pipe cleaning, repairs, bathroom renovation), Heating (maintenance, repairs), Roofing/Tinsmithing (copper roofs, flat roof sealing, chimney covers, metal facades), Water heater (descaling, replacement)\n- Service area: Oberrieden (8942), Thalwil (8800), Horgen (8810), Kilchberg (8802), Rüschlikon (8803), Adliswil, Wädenswil (8820), Au ZH, Richterswil — left shore of Lake Zurich\n- Hours: Mon-Fri 07:00-18:00, 24h emergency service\n\nSTYLE\n- Speak naturally and calmly — like an experienced dispatcher, not a robot.\n- Short sentences. No lists. Never ask multiple questions at once.\n- Empathetic micro-reactions: \"I understand.\", \"That sounds unpleasant.\", \"Got it.\" — before your next question.\n- Maximum 7 questions per call.\n- When the caller speaks: STOP talking immediately. Wait until they finish.\n- After each question: WAIT for the caller to respond. Do NOT ask another question until the caller has spoken. Maximum 1 reprompt if no response.\n\nLANGUAGE (FOLLOW MODE — NO LOCK)\n- Detect the caller's language from the conversation history or their first message after transfer.\n- Supported: English, French, Italian, German (Hochdeutsch).\n- ALWAYS follow the caller's LATEST language. If they switch mid-call, switch with them immediately.\n- If the caller asks you to repeat something in a different language: do it, then ask 'Shall I continue in <language>?' and continue in whatever they choose.\n- If the caller mixes languages: use the dominant language of their last message.\n- You may speak German if the caller requests it. German callers transferred by mistake are handled gracefully.\n- NEVER refuse a language switch. NEVER say 'I must stay in <language>'.\n- Post-call analysis values (category, urgency, description) must ALWAYS be in German — regardless of conversation language.\n\nGERMAN BACK-TRANSFER\n- If the caller switches to German or requests German (e.g. 'Deutsch bitte', 'auf Deutsch', 'German please'), transfer them back to the German agent using swap_to_de_agent immediately.\n- Do NOT speak German yourself — the German agent has a native German voice.\n- Transfer immediately — do not ask for confirmation.\n\nTOPIC\n- Plumbing, heating, and roofing/tinsmithing only. Politely decline other requests.\n- Never mention recording.\n\nPRIVACY\n- No personal data in the description (no names, phone numbers, emails, exact addresses).\n\nGOODBYE RULE (CRITICAL — NO LOOP)\n- Say your goodbye EXACTLY ONCE (SMS info + farewell wish + 'goodbye').\n- AFTER THAT: If the caller says 'bye', 'thanks', 'thank you', 'goodbye', 'perfect', 'great', 'okay' or similar → respond with: 'You're very welcome, and don't worry — we'll take care of it. Goodbye!' Then IMMEDIATELY call the 'end_call' tool to actively end the conversation.\n- NEVER repeat the SMS information, summary, or farewell wish.\n- After the warm closing, end_call MUST be called. No further talking.\n\nREQUIRED FIELDS (must be collected by end of call)\n1) Postal code of the service location (Switzerland, 4 digits)\n2) City/town of the service location\n3) Street and house number of the service location (best-effort — if the caller refuses, continue without it)\n4) Category — exactly one: Verstopfung | Leck | Heizung | Boiler | Rohrbruch | Dachschaden | Sanitär allgemein\n5) Urgency — exactly one (lowercase German): notfall | dringend | normal\n6) Short description (1–3 sentences, no PII)\n\nCUSTOM ANALYSIS DATA OUTPUT\nEven though the call is in English/French/Italian: ALL values must be in GERMAN.\nNEVER use 'ß' — ALWAYS use 'ss' (Swiss German). Example: 'Strasse' (not 'Straße'), 'Seestrasse' (not 'Seestraße').\n- plz: Postal code (4 digits only)\n- city: City/town (German name)\n- street: Street name (without house number). Leave empty if not provided.\n- house_number: House number. Leave empty if not provided.\n- category: exactly one of the 7 German values\n- urgency: exactly \"notfall\" or \"dringend\" or \"normal\" (lowercase)\n- description: 1–3 sentences in German summarizing the problem, no PII",
+    "nodes": [
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "You were transferred from the German agent. Check the conversation history to understand what language the caller speaks and what they already said. Greet them warmly in their language (English, French, or Italian) and let them know you are here to help. If they already described their problem, acknowledge it briefly."
+        },
+        "always_edge": {
+          "destination_node_id": "node-intake",
+          "id": "always-edge-welcome",
+          "transition_condition": {
+            "type": "prompt",
+            "prompt": "Always"
+          }
+        },
+        "name": "Welcome Node",
+        "edges": [],
+        "start_speaker": "agent",
+        "id": "start-node",
+        "type": "conversation",
+        "display_position": {
+          "x": 232,
+          "y": 24
+        }
+      },
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "You are continuing an intake conversation. The caller was transferred from the German agent.\n\nCHECK CONVERSATION HISTORY FIRST\n- Review what the caller already said to the German agent before transfer.\n- Do NOT re-ask information that was already provided.\n- If the caller already described their problem, acknowledge it and continue with missing fields only.\n\nGREETING (only on your first turn after transfer)\n- Greet warmly in the detected language. Acknowledge what they already said.\n- English: \"Hello! I'll be happy to help you. [Acknowledge what they said]. Let me just confirm a few details.\"\n- French: \"Bonjour ! Je suis là pour vous aider. [Acknowledge]. Permettez-moi de confirmer quelques détails.\"\n- Italian: \"Buongiorno! Sono qui per aiutarla. [Acknowledge]. Mi permetta di confermare alcuni dettagli.\"\n\nWORKFLOW (flexible order — adapt to conversation)\n1. Let the caller explain what happened. Listen.\n2. React briefly with empathy.\n3. Derive category from description if possible. Only if unclear: ask (never list all 7).\n4. Ask for the street address: 'What is the street and house number at the service location?' If the caller refuses, accept and move on.\n5. Ask for postal code and city together: 'And the postal code and city?' Confirm ONLY the city name: 'Oberrieden, correct?' Do NOT read back digits — the city name is sufficient confirmation for Swiss postal codes. If the caller corrects the city, re-ask the postal code.\n6. Ask about urgency — ONLY if not yet answered.\n7. NO summary. Once all required fields are collected, say something like: 'Thank you, I have everything noted. You will receive an SMS shortly — you can verify the details, make corrections if needed, and also upload photos of the damage. This helps Walter Leuthold prepare. Take care, goodbye!' Then set intake_complete=true.\n\nNO-DOUBLE-ASKING RULE\n- Ask each required field EXACTLY ONCE. If the caller already answered (even casually), do NOT ask again.\n- On silence or unclear answer: ask ONCE more, then move on.\n- Before each question: check if the information is already available. If yes: skip.\n\nADDITIONAL RULES\n- Never ask two questions in one sentence.\n- If the caller is impatient: collect minimum and wrap up quickly.\n- If the request is not plumbing/heating/roofing: set out_of_scope=true.\n- When all required fields are collected (postal code, city, category, urgency, description): set intake_complete=true.\n- Street and house number are desirable but NOT a blocker for intake_complete.\n\nLANGUAGE (FOLLOW — NO LOCK)\n- Follow the caller's latest language for ALL turns. If they switch, switch with them.\n- Never refuse a language change. Never say 'I must stay in <language>'.\n- If speech is unclear: ask ONCE 'Sorry, I didn't catch that. Could you repeat?' If still unclear after 1 retry, summarize what you have and close gracefully.\n- Post-call analysis values (category, urgency, description) always in German.\n\nAFTER FAREWELL (HIGHEST PRIORITY)\nCheck your LAST message in the conversation history.\nIf your last message ALREADY contained 'SMS', 'verify', 'corrections', 'photos' or 'Take care' or 'goodbye', then YOU HAVE ALREADY SAID GOODBYE.\n\nIn that case — no matter what the caller says (thanks, bye, perfect, great, etc.):\n→ Say EXACTLY: 'You're very welcome, and don't worry — we'll take care of it. Goodbye!'\n→ IMMEDIATELY call end_call.\n→ FORBIDDEN: Say 'thank you' again. Mention SMS again. Repeat any data or summary.\n→ ONLY this short response + end_call. NOTHING ELSE."
+        },
+        "name": "Intake Node",
+        "edges": [
+          {
+            "destination_node_id": "node-de-transfer",
+            "id": "edge-intake-german-trigger",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The caller's latest message is clearly in German (a coherent German sentence or phrase), or the caller explicitly requests German (e.g. 'Deutsch bitte', 'auf Deutsch', 'German please', 'in German')"
+            }
+          },
+          {
+            "destination_node_id": "node-closing",
+            "id": "edge-intake-done",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "intake_complete is true (all required fields collected: postal code, city, category, urgency, description)"
+            }
+          },
+          {
+            "destination_node_id": "node-out-of-scope",
+            "id": "edge-intake-out-of-scope",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "out_of_scope is true (the request is not about plumbing, heating, or roofing/tinsmithing)"
+            }
+          }
+        ],
+        "id": "node-intake",
+        "type": "conversation",
+        "display_position": {
+          "x": 623,
+          "y": 310
+        },
+        "tools": [
+          {
+            "type": "end_call",
+            "name": "end_call",
+            "description": "End the phone call. Use this ONLY after the caller has acknowledged your farewell (e.g. said thanks, bye, perfect) and you have given your warm closing response. NEVER use this during the intake conversation."
+          }
+        ]
+      },
+      {
+        "name": "Logic Split Node",
+        "edges": [
+          {
+            "destination_node_id": "node-de-transfer",
+            "id": "edge-logic-german-check",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "The caller speaks German or has requested to continue in German"
+            }
+          },
+          {
+            "destination_node_id": "node-out-of-scope",
+            "id": "edge-out-of-scope",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "out_of_scope is true (the user's request is not about plumbing, heating, or roofing/tinsmithing)"
+            }
+          },
+          {
+            "destination_node_id": "node-closing",
+            "id": "edge-intake-complete",
+            "transition_condition": {
+              "type": "prompt",
+              "prompt": "intake_complete is true (all required fields have been collected: plz, city, category, urgency, description)"
+            }
+          }
+        ],
+        "id": "node-logic-split",
+        "else_edge": {
+          "destination_node_id": "node-intake",
+          "id": "edge-logic-else",
+          "transition_condition": {
+            "type": "prompt",
+            "prompt": "Else"
+          }
+        },
+        "type": "branch",
+        "display_position": {
+          "x": 989,
+          "y": 704
+        }
+      },
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
+        },
+        "name": "Closing Node",
+        "edges": [],
+        "id": "node-closing",
+        "type": "conversation",
+        "display_position": {
+          "x": 1363,
+          "y": 796
+        },
+        "skip_response_edge": {
+          "destination_node_id": "end-call-node",
+          "id": "skip-response-edge-closing",
+          "transition_condition": {
+            "type": "prompt",
+            "prompt": "Skip response"
+          }
+        }
+      },
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "The goodbye was already spoken in the conversation. Say NOTHING. Stay completely silent. The call is over."
+        },
+        "name": "Out-of-scope Closing",
+        "edges": [],
+        "id": "node-out-of-scope",
+        "type": "conversation",
+        "display_position": {
+          "x": 943,
+          "y": 944
+        },
+        "skip_response_edge": {
+          "destination_node_id": "end-call-node",
+          "id": "skip-response-edge-oos",
+          "transition_condition": {
+            "type": "prompt",
+            "prompt": "Skip response"
+          }
+        }
+      },
+      {
+        "instruction": {
+          "type": "prompt",
+          "text": "The caller wants to continue in German. Call the 'swap_to_de_agent' tool IMMEDIATELY. Say nothing else — just call the tool. NEVER use end_call."
+        },
+        "name": "DE Transfer",
+        "edges": [],
+        "id": "node-de-transfer",
+        "type": "conversation",
+        "display_position": {
+          "x": 200,
+          "y": 700
+        },
+        "tools": [
+          {
+            "type": "agent_swap",
+            "agent_id": "REPLACE_WITH_LEUTHOLD_DE_AGENT_ID",
+            "name": "swap_to_de_agent",
+            "description": "Transfer the caller back to the German-speaking agent (Lisa). Execute this tool IMMEDIATELY — the caller wants German.",
+            "post_call_analysis_setting": "only_destination_agent"
+          }
+        ]
+      },
+      {
+        "name": "End Call",
+        "id": "end-call-node",
+        "type": "end",
+        "display_position": {
+          "x": 1766,
+          "y": 1116
+        },
+        "instruction": {
+          "type": "prompt",
+          "text": "End the call immediately. Say nothing else."
+        }
+      }
+    ],
+    "start_node_id": "start-node",
+    "start_speaker": "agent",
+    "model_choice": {
+      "type": "cascading",
+      "model": "gpt-4.1"
+    },
+    "tool_call_strict_mode": true,
+    "knowledge_base_ids": [],
+    "kb_config": {
+      "top_k": 3,
+      "filter_score": 0.6
+    },
+    "begin_tag_display_position": {
+      "x": 46,
+      "y": -43
+    },
+    "is_published": false,
+    "flex_mode": false,
+    "is_transfer_cf": true
+  }
+}

--- a/src/web/src/lib/customers/walter-leuthold.ts
+++ b/src/web/src/lib/customers/walter-leuthold.ts
@@ -257,7 +257,10 @@ export const walterLeuthold: CustomerSite = {
     },
   ],
 
-  // Categories: no voice agent — wizard-only (Sanitär + Spenglerei focus)
+  voicePhone: "+41 XX XXX XX XX", // TODO: assign Twilio number
+  voicePhoneRaw: "+41XXXXXXXXX", // TODO: assign Twilio number
+
+  // Categories: Sanitär + Spenglerei focus
   categories: [
     { value: "Verstopfung", label: "Verstopfung", hint: "Abfluss, WC, Leitung", iconKey: "drain" },
     { value: "Leck", label: "Leck", hint: "Tropft, feucht, Wasserschaden", iconKey: "drop" },


### PR DESCRIPTION
## Summary
- **Walter Leuthold Voice Agent:** DE + INTL agent JSONs from Doerfler template, prospect_card.json (ICP 8 HOT), status.md, voicePhone placeholder. Needs `retell_sync.mjs` + Twilio number to go live.
- **Video Production Folders:** `docs/gtm/videos/{weinberger-ag,doerfler-ag,walter-leuthold}/` with pre-filled skript.md (frontmatter: slug, firma, testnummer, tier, video-ready), loom_url.txt placeholders, notizen.md templates.
- **SSOT Update:** STATUS.md + ticketlist.md reflect S1-S3 DONE + S4 Enablement complete.

CC-Scope S4 abgeschlossen. System bereit, Founder übernimmt.

## Test plan
- [ ] Verify walter-leuthold agent JSONs have correct company data
- [ ] Verify video skript frontmatter matches pipeline data
- [ ] After merge: run `retell_sync.mjs --prefix walter-leuthold` to create agents on Retell

🤖 Generated with [Claude Code](https://claude.com/claude-code)