### PR TITLE
feat: start page Spiegel-Effekt + modus routing

### DIFF
--- a/src/web/app/start/[slug]/meldung/page.tsx
+++ b/src/web/app/start/[slug]/meldung/page.tsx
@@ -1,0 +1,51 @@
+import { notFound } from "next/navigation";
+import {
+  getCustomer,
+  getAllCustomerSlugs,
+} from "@/src/lib/customers/registry";
+import { CustomerWizardForm } from "@/app/kunden/[slug]/meldung/CustomerWizardForm";
+import type { Metadata } from "next";
+
+// ── Static generation ─────────────────────────────────────────────
+export function generateStaticParams() {
+  return getAllCustomerSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const c = getCustomer(slug);
+  if (!c) return {};
+  return {
+    title: `Anliegen melden — ${c.companyName}`,
+    description: `Melden Sie Ihr Anliegen direkt an ${c.companyName}. Schnell, unkompliziert, digital.`,
+    robots: { index: false },
+  };
+}
+
+// ── Page ──────────────────────────────────────────────────────────
+export default async function StartMeldungPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const c = getCustomer(slug);
+  if (!c) notFound();
+
+  return (
+    <CustomerWizardForm
+      companyName={c.companyName}
+      companySlug={c.slug}
+      phone={c.contact.phone}
+      phoneRaw={c.contact.phoneRaw}
+      emergency={c.emergency}
+      accent={c.brandColor ?? "#2b6cb0"}
+      categories={c.categories}
+      backUrl={`/start/${c.slug}`}
+    />
+  );
+}

--- a/src/web/app/start/[slug]/page.tsx
+++ b/src/web/app/start/[slug]/page.tsx
@@ -21,19 +21,52 @@ export async function generateMetadata({
   if (!c) return {};
   return {
     title: `${c.companyName} — Ihr Leitsystem`,
-    description: `Persönliche Telefonassistentin, Meldungsformular und Leitstand für ${c.companyName}.`,
+    description: c.metaDescription,
     robots: { index: false },
   };
 }
 
 // ── Helpers ───────────────────────────────────────────────────────
 function formatPhone(phone: string): string {
-  // +41435051101 → 043 505 11 01
   if (phone.startsWith("+41") && phone.length === 12) {
     const local = "0" + phone.slice(3);
     return `${local.slice(0, 3)} ${local.slice(3, 6)} ${local.slice(6, 8)} ${local.slice(8)}`;
   }
   return phone;
+}
+
+function Stars({ rating }: { rating: number }) {
+  const full = Math.floor(rating);
+  const half = rating - full >= 0.3;
+  const stars = [];
+  for (let i = 0; i < 5; i++) {
+    if (i < full) {
+      stars.push(
+        <svg key={i} className="w-4 h-4 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+      );
+    } else if (i === full && half) {
+      stars.push(
+        <svg key={i} className="w-4 h-4 text-yellow-400" viewBox="0 0 20 20">
+          <defs>
+            <linearGradient id="halfStar">
+              <stop offset="50%" stopColor="currentColor" />
+              <stop offset="50%" stopColor="#D1D5DB" />
+            </linearGradient>
+          </defs>
+          <path fill="url(#halfStar)" d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+      );
+    } else {
+      stars.push(
+        <svg key={i} className="w-4 h-4 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+      );
+    }
+  }
+  return <div className="flex items-center gap-0.5">{stars}</div>;
 }
 
 // ── Page ──────────────────────────────────────────────────────────
@@ -51,15 +84,37 @@ export default async function StartPage({
   const voicePhoneRaw = c.voicePhoneRaw ?? c.contact.phoneRaw;
   const voicePhoneFormatted = formatPhone(voicePhoneRaw);
   const hasEmergency = c.emergency?.enabled === true;
+  const isModus1 = (c.modus ?? 1) === 1;
+  const hasReviews = c.reviews && c.reviews.totalReviews > 0;
+  const addr = c.contact.address;
 
   return (
-    <div className="min-h-screen bg-white">
-      {/* ── Top Bar ────────────────────────────────────────────── */}
-      <header className="border-b border-gray-100">
-        <div className="max-w-2xl mx-auto px-6 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
+    <div className="min-h-screen bg-gray-50">
+      {/* ── Emergency Bar ──────────────────────────────────────── */}
+      {hasEmergency && (
+        <div className="bg-red-600 text-white">
+          <div className="max-w-2xl mx-auto px-6 py-2 flex items-center justify-between">
+            <span className="text-xs font-medium">
+              {c.emergency!.label} — {c.emergency!.description}
+            </span>
+            <a
+              href={`tel:${c.emergency!.phoneRaw}`}
+              className="text-xs font-bold underline whitespace-nowrap ml-4"
+            >
+              {c.emergency!.phone}
+            </a>
+          </div>
+        </div>
+      )}
+
+      {/* ── Main Content ───────────────────────────────────────── */}
+      <main className="max-w-2xl mx-auto px-6 py-10 sm:py-16">
+
+        {/* ── Spiegel: Firmenkarte ─────────────────────────────── */}
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-6 sm:p-8 mb-8">
+          <div className="flex items-start gap-4 mb-4">
             <div
-              className="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold text-sm"
+              className="w-14 h-14 rounded-xl flex items-center justify-center text-white font-bold text-lg flex-shrink-0"
               style={{ backgroundColor: accent }}
             >
               {c.companyName
@@ -68,38 +123,75 @@ export default async function StartPage({
                 .map((w) => w[0])
                 .join("")}
             </div>
-            <div>
-              <div className="font-semibold text-gray-900 text-sm leading-tight">
+            <div className="flex-1 min-w-0">
+              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 leading-tight">
                 {c.companyName}
-              </div>
-              <div className="text-xs text-gray-500">Ihr Leitsystem</div>
+              </h1>
+              <p className="text-sm text-gray-600 mt-0.5">{c.tagline}</p>
             </div>
           </div>
-          {hasEmergency && (
-            <a
-              href={`tel:${c.emergency!.phoneRaw}`}
-              className="text-xs font-semibold px-3 py-1.5 rounded-full bg-red-50 text-red-700 hover:bg-red-100 transition-colors"
-            >
-              {c.emergency!.label}
-            </a>
-          )}
-        </div>
-      </header>
 
-      {/* ── Main Content ───────────────────────────────────────── */}
-      <main className="max-w-2xl mx-auto px-6 py-10 sm:py-16">
-        {/* Hero */}
-        <div className="text-center mb-12">
-          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-3">
-            Willkommen bei Ihrem Leitsystem
-          </h1>
-          <p className="text-gray-600 text-base sm:text-lg max-w-md mx-auto">
-            Ihre persönliche Telefonassistentin Lisa, Ihr Meldungsformular und
-            Ihr Leitstand — alles an einem Ort.
+          {/* Google Stars */}
+          {hasReviews && (
+            <div className="flex items-center gap-2 mb-4">
+              <Stars rating={c.reviews!.averageRating} />
+              <span className="text-sm font-medium text-gray-700">
+                {c.reviews!.averageRating.toFixed(1)}
+              </span>
+              <span className="text-sm text-gray-500">
+                ({c.reviews!.totalReviews} Google-Bewertungen)
+              </span>
+            </div>
+          )}
+
+          {/* Services as pills */}
+          <div className="flex flex-wrap gap-2 mb-4">
+            {c.services.map((s) => (
+              <span
+                key={s.slug}
+                className="text-xs font-medium px-3 py-1 rounded-full border"
+                style={{
+                  borderColor: `${accent}40`,
+                  color: accent,
+                  backgroundColor: `${accent}08`,
+                }}
+              >
+                {s.name}
+              </span>
+            ))}
+          </div>
+
+          {/* Address + Region */}
+          <div className="flex items-center gap-1.5 text-xs text-gray-500">
+            <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" />
+            </svg>
+            <span>
+              {addr.street}, {addr.zip} {addr.city}
+              {c.serviceArea?.region ? ` — ${c.serviceArea.region}` : ""}
+            </span>
+          </div>
+        </div>
+
+        {/* ── Personal Message ─────────────────────────────────── */}
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-6 sm:p-8 mb-8">
+          <p className="text-base sm:text-lg text-gray-800 leading-relaxed">
+            Ich habe für die <strong>{c.companyName}</strong> eine persönliche
+            Telefonassistentin eingerichtet:{" "}
+            <strong style={{ color: accent }}>Lisa</strong>.
+          </p>
+          <p className="text-sm text-gray-600 mt-3">
+            Lisa nimmt ab — mit Ihrem Firmennamen. Sie erfasst das Anliegen,
+            erkennt Notfälle und schickt Ihnen innert Sekunden eine Zusammenfassung
+            aufs Handy. Jeder Fall landet im Leitstand.
+          </p>
+          <p className="text-sm text-gray-600 mt-2 font-medium">
+            Probieren Sie es aus — rufen Sie jetzt an.
           </p>
         </div>
 
-        {/* ── CTA 1: Anrufen ──────────────────────────────────── */}
+        {/* ── CTA 1: Lisa anrufen (Primary) ────────────────────── */}
         <div
           className="rounded-2xl p-6 sm:p-8 mb-4 border-2 relative overflow-hidden"
           style={{
@@ -107,15 +199,41 @@ export default async function StartPage({
             backgroundColor: `${accent}08`,
           }}
         >
-          <div className="relative">
-            <div className="flex items-start gap-4">
-              <div
-                className="w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0"
-                style={{ backgroundColor: `${accent}15` }}
+          <div className="flex items-start gap-4">
+            <div
+              className="w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0"
+              style={{ backgroundColor: `${accent}15` }}
+            >
+              <svg
+                className="w-6 h-6"
+                style={{ color: accent }}
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z"
+                />
+              </svg>
+            </div>
+            <div className="flex-1 min-w-0">
+              <h2 className="text-lg font-bold text-gray-900 mb-1">
+                Lisa anrufen
+              </h2>
+              <p className="text-sm text-gray-600 mb-4">
+                &laquo;Grüezi, hier ist Lisa von der {c.companyName}. Wie kann ich
+                Ihnen helfen?&raquo; — Rund um die Uhr.
+              </p>
+              <a
+                href={`tel:${voicePhoneRaw}`}
+                className="inline-flex items-center justify-center w-full sm:w-auto gap-2 text-white font-semibold text-base py-3 px-8 rounded-xl transition-all hover:opacity-90 hover:shadow-lg"
+                style={{ backgroundColor: accent }}
               >
                 <svg
-                  className="w-6 h-6"
-                  style={{ color: accent }}
+                  className="w-5 h-5"
                   fill="none"
                   viewBox="0 0 24 24"
                   strokeWidth={2}
@@ -127,43 +245,15 @@ export default async function StartPage({
                     d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z"
                   />
                 </svg>
-              </div>
-              <div className="flex-1 min-w-0">
-                <h2 className="text-lg font-bold text-gray-900 mb-1">
-                  Lisa anrufen
-                </h2>
-                <p className="text-sm text-gray-600 mb-4">
-                  Ihre persönliche Telefonassistentin nimmt ab — mit Ihrem
-                  Firmennamen. Rund um die Uhr.
-                </p>
-                <a
-                  href={`tel:${voicePhoneRaw}`}
-                  className="inline-flex items-center justify-center w-full sm:w-auto gap-2 text-white font-semibold text-base py-3 px-8 rounded-xl transition-all hover:opacity-90 hover:shadow-lg"
-                  style={{ backgroundColor: accent }}
-                >
-                  <svg
-                    className="w-5 h-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={2}
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z"
-                    />
-                  </svg>
-                  {voicePhoneFormatted}
-                </a>
-              </div>
+                {voicePhoneFormatted}
+              </a>
             </div>
           </div>
         </div>
 
-        {/* ── CTA 2: Meldung erfassen ─────────────────────────── */}
+        {/* ── CTA 2: Anliegen melden ───────────────────────────── */}
         <Link
-          href={`/kunden/${c.slug}/meldung`}
+          href={`/start/${c.slug}/meldung`}
           className="block rounded-2xl p-6 sm:p-8 mb-4 border border-gray-200 bg-white hover:border-gray-300 hover:shadow-sm transition-all group"
         >
           <div className="flex items-start gap-4">
@@ -198,19 +288,15 @@ export default async function StartPage({
               strokeWidth={2}
               stroke="currentColor"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8.25 4.5l7.5 7.5-7.5 7.5"
-              />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
             </svg>
           </div>
         </Link>
 
-        {/* ── CTA 3: Leitstand ────────────────────────────────── */}
+        {/* ── CTA 3: Leitstand ─────────────────────────────────── */}
         <Link
           href="/ops/cases"
-          className="block rounded-2xl p-6 sm:p-8 mb-10 border border-gray-200 bg-white hover:border-gray-300 hover:shadow-sm transition-all group"
+          className="block rounded-2xl p-6 sm:p-8 mb-4 border border-gray-200 bg-white hover:border-gray-300 hover:shadow-sm transition-all group"
         >
           <div className="flex items-start gap-4">
             <div className="w-12 h-12 rounded-xl bg-gray-50 flex items-center justify-center flex-shrink-0 group-hover:bg-gray-100 transition-colors">
@@ -244,17 +330,57 @@ export default async function StartPage({
               strokeWidth={2}
               stroke="currentColor"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8.25 4.5l7.5 7.5-7.5 7.5"
-              />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
             </svg>
           </div>
         </Link>
 
-        {/* ── How it works ────────────────────────────────────── */}
-        <div className="border-t border-gray-100 pt-10">
+        {/* ── CTA 4: Website (Modus 1 only) ────────────────────── */}
+        {isModus1 && (
+          <Link
+            href={`/kunden/${c.slug}`}
+            className="block rounded-2xl p-6 sm:p-8 mb-4 border border-gray-200 bg-white hover:border-gray-300 hover:shadow-sm transition-all group"
+          >
+            <div className="flex items-start gap-4">
+              <div className="w-12 h-12 rounded-xl bg-gray-50 flex items-center justify-center flex-shrink-0 group-hover:bg-gray-100 transition-colors">
+                <svg
+                  className="w-6 h-6 text-gray-700"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1 min-w-0">
+                <h2 className="text-lg font-bold text-gray-900 mb-1">
+                  Ihre Website
+                </h2>
+                <p className="text-sm text-gray-600">
+                  Ihr professioneller Webauftritt — Leistungen, Galerie, Kontakt.
+                  Bereit für Google.
+                </p>
+              </div>
+              <svg
+                className="w-5 h-5 text-gray-400 mt-1 flex-shrink-0 group-hover:text-gray-600 transition-colors"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+              </svg>
+            </div>
+          </Link>
+        )}
+
+        {/* ── So funktioniert's ────────────────────────────────── */}
+        <div className="border-t border-gray-200 pt-10 mt-6">
           <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-6 text-center">
             So funktioniert&apos;s
           </h3>
@@ -270,7 +396,7 @@ export default async function StartPage({
                 Anrufen
               </div>
               <div className="text-xs text-gray-500">
-                Rufen Sie die Nummer an. Lisa nimmt ab — mit Ihrem Firmennamen.
+                Rufen Sie die Nummer an. Lisa nimmt ab — mit &laquo;{c.companyName}&raquo;.
               </div>
             </div>
             <div className="text-center">
@@ -296,10 +422,11 @@ export default async function StartPage({
                 3
               </div>
               <div className="font-medium text-gray-900 text-sm mb-1">
-                Leitstand öffnen
+                Leitstand
               </div>
               <div className="text-xs text-gray-500">
                 Jeder Fall ist da — mit Kategorie, Adresse und Dringlichkeit.
+                Alles auf einen Blick.
               </div>
             </div>
           </div>
@@ -307,7 +434,7 @@ export default async function StartPage({
       </main>
 
       {/* ── Footer ─────────────────────────────────────────────── */}
-      <footer className="border-t border-gray-100 py-6">
+      <footer className="border-t border-gray-200 py-6">
         <div className="max-w-2xl mx-auto px-6 text-center">
           <p className="text-xs text-gray-400">
             Powered by{" "}

--- a/src/web/src/lib/customers/types.ts
+++ b/src/web/src/lib/customers/types.ts
@@ -43,6 +43,11 @@ export interface CustomerSite {
 
   /** Additional SEO keywords */
   seoKeywords?: string[];
+
+  /** Modus: 1 = Full (we build the website), 2 = Extend (prospect has own website).
+   *  Controls start page layout (website card shown only for modus 1).
+   *  Default: 1 */
+  modus?: 1 | 2;
 }
 
 // ── Contact ───────────────────────────────────────────────────────

--- a/src/web/src/lib/customers/weinberger-ag.ts
+++ b/src/web/src/lib/customers/weinberger-ag.ts
@@ -10,6 +10,7 @@ export const weinbergerAg: CustomerSite = {
   metaDescription:
     "Jul. Weinberger AG — Sanitär, Heizung, Lüftung und Badsanierung in Thalwil. Traditionsunternehmen seit 1912 mit 24h-Notdienst und persönlichem Service.",
   brandColor: "#004994",
+  modus: 2,
   seoKeywords: [
     "Sanitär Thalwil",
     "Heizung Thalwil",


### PR DESCRIPTION
## Summary
- Redesign `/start/[slug]` with **Spiegel-Effekt**: Firmenkarte zeigt Name, Tagline, Google-Sterne, Services als Pills, Adresse + Region
- Personal message introducing Lisa by company name — roter Faden vom Crawl bis zum Test
- Emergency bar (Notdienst) prominent at top
- **Modus-Routing**: Modus 1 shows "Ihre Website" CTA → `/kunden/[slug]`, Modus 2 hides it
- New `/start/[slug]/meldung` route with `backUrl → /start/[slug]` (fixes back-navigation to full website)
- `modus` field added to `CustomerSite` type, Weinberger set to `modus: 2`

## Test plan
- [ ] Visit `/start/weinberger-ag` — verify Firmenkarte shows "Jul. Weinberger AG", tagline, 4.4★, 5 service pills, address
- [ ] Verify NO "Ihre Website" card (Weinberger = Modus 2)
- [ ] Visit `/start/doerfler-ag` — verify "Ihre Website" card IS shown (Modus 1)
- [ ] Click "Anliegen schriftlich melden" → `/start/weinberger-ag/meldung`
- [ ] In wizard, click back → lands on `/start/weinberger-ag` (not `/kunden/weinberger-ag`)
- [ ] Emergency bar shows 24h Notdienst with phone link

🤖 Generated with [Claude Code](https://claude.com/claude-code)