### PR TITLE
fix: add Weinberger SIP trunk to TWILIO_OWNED_NUMBERS

### DIFF
--- a/src/web/app/api/retell/webhook/route.ts
+++ b/src/web/app/api/retell/webhook/route.ts
@@ -136,6 +136,7 @@ function normalizePlz(v: unknown): string | undefined {
 const TWILIO_OWNED_NUMBERS = [
   "+41445053019", // Dörfler SIP trunk
   "+41445520919", // FlowSight Sales number
+  "+41435051101", // Weinberger SIP trunk
 ];
 
 function resolveSmsTarget(


### PR DESCRIPTION
## Summary
- Adds `+41435051101` (Weinberger SIP trunk) to `TWILIO_OWNED_NUMBERS` in `webhook/route.ts`
- **Root cause:** Number missing → `resolveSmsTarget()` treated SIP call as real caller → SMS sent to Twilio number instead of Founder phone
- Closes STOPP S1 from ticketlist.md

## Test plan
- [ ] Founder: E2E Testanruf auf Weinberger Testnummer wiederholen
- [ ] SMS muss auf Founder-Handy ankommen (via DEMO_SIP_CALLER_ID)
- [ ] Verify S2 (SMS_ALLOWED_NUMBERS) doesn't block

🤖 Generated with [Claude Code](https://claude.com/claude-code)