### PR TITLE
fix: revert SMS to alphanumeric sender until eCall is live

### DIFF
--- a/src/web/src/lib/tenants/getTenantSmsConfig.ts
+++ b/src/web/src/lib/tenants/getTenantSmsConfig.ts
@@ -34,18 +34,10 @@ export async function getTenantSmsConfig(
     const senderName = modules.sms_sender_name;
     if (typeof senderName !== "string" || senderName.length === 0) return null;
 
-    // Fetch tenant's Twilio number for use as SMS sender (avoids spam filters)
-    let fromNumber: string | null = null;
-    const { data: numRow } = await supabase
-      .from("tenant_numbers")
-      .select("phone_number")
-      .eq("tenant_id", tenantId)
-      .eq("active", true)
-      .limit(1)
-      .single();
-    if (numRow?.phone_number) {
-      fromNumber = numRow.phone_number;
-    }
+    // fromNumber: will be populated once Swiss SMS provider (eCall) is configured.
+    // Twilio SIP trunk numbers are NOT SMS-capable — do not use them as sender.
+    // Until eCall is live, SMS sends via alphanumeric sender (spam risk accepted).
+    const fromNumber: string | null = null;
 
     return { senderName, fromNumber };
   } catch {


### PR DESCRIPTION
## Summary
- Twilio SIP trunk numbers are NOT SMS-capable (error 21661) — PR #190 broke SMS delivery
- Reverts to alphanumeric sender (delivers but lands in spam on some carriers)
- Permanent fix: switch to Swiss SMS provider (eCall.ch) — tracked in BAUPLAN Block 1

## Context
- PR #190 attempted to send from Twilio phone number to avoid spam
- Discovery: no Twilio number in this account has SMS capability
- No SMS-capable Swiss numbers available for purchase on Twilio
- eCall.ch (Swiss provider, direct carrier connections) is the proper solution

🤖 Generated with [Claude Code](https://claude.com/claude-code)