### PR TITLE
fix: L4 KPI filter + L9 ICS email + L10 staff dropdown (Gold final)

### DIFF
--- a/docs/ticketlist.md
+++ b/docs/ticketlist.md
@@ -1,6 +1,6 @@
 # Ticketlist — FlowSight (SSOT)
 
-**Updated:** 2026-03-13 (Voice-Bugs + Leitstand-Redesign-Gap aus E2E-Walkthrough)
+**Updated:** 2026-03-13 (Renovation Gold Contact — Phasen 0-5 DONE)
 **Rule:** CC updates after every deliverable. Founder reviews weekly.
 **Einziger Ticket-Tracker.** Alle offenen Tickets leben hier.
 **Bug-Klassen:** `[STOPP]` = blockiert E2E/Proof/Versand. Wird sofort gefixt. Alles andere = Ticketliste.
@@ -12,7 +12,7 @@
 - **Produkt:** 17 Module LIVE (Website, Voice, Wizard, Ops, Reviews, Review Surface, Morning Report, Entitlements, Email, Peoplefone, Sales Agent, Demo Booking, Demo-Strang, SMS Channel, CoreBot, Customer Links Page, BigBen Pub)
 - **Kunden:** 7 Websites live (Doerfler, Brunner HT, Walter Leuthold, Orlandini, Widmer, **Weinberger AG**, BigBen Pub)
 - **BLOCKER:** 1 (V5: SMS-Spam — wartet auf eCall-Konto)
-- **Phase:** S1-S3 DONE. S4 Enablement DONE (CC). **E2E Verification + Leitstand-Redesign-Alignment.**
+- **Phase:** S1-S4 DONE. **Renovation Gold Contact DONE** (V1-V4, L1-L10). Naechster Schritt: Founder E2E-Verification.
 - **Redesign-Docs:** `docs/redesign/` — plan.md + 6 Zielbilder + 4 IST-Audits + identity_contract.md
 - **Gold Contact:** `docs/gtm/gold_contact.md` — Nordstern (unveraendert)
 - **CI/CD:** GitHub Actions (lint + build + Telegram notify + lifecycle-tick + morning-report). Branch Protection: PR required.
@@ -46,32 +46,31 @@
 
 | # | Titel | Root Cause | Schwere | Status |
 |---|-------|-----------|---------|--------|
-| V1 | **Voice auf Juniper umstellen (alle Agents)** — Weinberger hat noch ELA. Zielbild: Juniper als Default fuer alle Agents. | Agent-JSONs verwenden falsche voice_id | hoch | **CC FIXT** |
-| V2 | **"Jul" aus Greeting entfernen** — Lisa sagt "Jul Weinberger AG", klingt katastrophal. Nur "Weinberger AG" sagen. | Greeting-Text in Agent-JSON: `display_name` statt gesprochener Form | hoch | **CC FIXT** |
-| V3 | **Ortsnamen NICHT wiederholen** — Schweizerdeutsche Aussprache weicht von Hochdeutsch ab, klingt grauenhaft. Ort nur aufnehmen+niederschreiben, nicht zuruecklesen. | Agent-Prompt wiederholt erfasste Daten inkl. Ort | mittel | **CC FIXT** |
-| V4 | **Dringlichkeits-Echo korrigieren** — Melder sagt "Notfall", Lisa antwortet "verstehe, es ist dringend". Muss exakt das Echo des Melders sein ("Notfall" = "Notfall"). | Agent-Prompt mappt Urgency-Werte nicht 1:1 | mittel | **CC FIXT** |
-| V5 | **SMS landet im Spam** — Alphanumeric Sender via Twilio wird von CH-Carriern gefiltert. Fix: Schweizer SMS-Provider (eCall.ch). | Twilio routet ueber internationale Gateways | hoch | **FOUNDER** (eCall-Konto) + CC (Code) |
+| V1 | **Voice auf Juniper umstellen (alle Agents)** | Agent-JSONs verwenden falsche voice_id | hoch | **DONE** (PR #193, 4 DE Agents auf Juniper, retell_sync published) |
+| V2 | **"Jul" aus Greeting entfernen** | Greeting-Text in Agent-JSON | hoch | **DONE** (PR #193, Greeting war bereits korrekt) |
+| V3 | **Ortsnamen NICHT wiederholen** | Agent-Prompt wiederholt Ort | mittel | **DONE** (PR #193, Prompt: keine Ort-Wiederholung) |
+| V4 | **Dringlichkeits-Echo korrigieren** | Agent-Prompt mappt nicht 1:1 | mittel | **DONE** (PR #193, EXAKT-Echo-Regel) |
+| V5 | **SMS landet im Spam** — Schweizer SMS-Provider noetig. | Twilio routet ueber internationale Gateways | hoch | **FOUNDER** (eCall-Konto) + CC (Code) |
 
 ---
 
-## OFFEN — Leitstand-Redesign-Gap
+## DONE — Leitstand-Renovation (Gold Contact)
 
-> Founder-Fazit: "Das Redesign hat hier absolut null gezogen."
+> Renovation 13.03. — Alle 10 Tickets auf Gold Contact Standard.
 > Referenz: `docs/redesign/leitstand.md` (Zielbild) + `docs/redesign/identity_contract.md`
-> **Regel:** Zielbild ist der Massstab. Alles was dort steht und hier fehlt = Bug.
 
-| # | Titel | Zielbild-Ref | IST-Zustand | Schwere | Status |
-|---|-------|-------------|-------------|---------|--------|
-| L1 | **Sidebar: "FS FlowSight" → Tenant-Branding** — Links oben muss dynamisch Tenant-Initials + Name stehen, nicht FlowSight. | identity_contract R4, leitstand §8 | Fallback "FS"/"FlowSight" sichtbar bei fehlender Tenant-Aufloesung | hoch | **CC FIXT** |
-| L2 | **"Bald"-Badges entfernen** — Nav-Items (Anrufe, Reviews, Einstellungen) zeigen "Bald". Zielbild §10.8: "Kein Coming Soon in Nav". Nur funktionale Eintraege zeigen. | leitstand §10.8 | 3 Nav-Items mit Badge "Bald" sichtbar | hoch | **CC FIXT** |
-| L3 | **Puls statt KPI-Tabelle** — Startseite muss priorisierte Handlungsliste sein (Achtung → Heute → In Arbeit → Abschluss), nicht chronologische Tabelle mit KPI-Karten. | leitstand §5.1 | Chronologische Fallliste + 4 KPI-Cards | hoch | **CC PLANT** |
-| L4 | **KPI-Click filtert Tabelle** — Klick auf "Neu heute: 3" soll Tabelle auf diese 3 Faelle filtern. Gleiches fuer Total, In Bearbeitung, Erledigt. | leitstand §5.1 | KPIs sind Links, aber Filtermechanismus unklar fuer User | mittel | **CC PRUEFT** |
-| L5 | **Einsatzplan (Schedule)** — Liste nach Mitarbeiter gruppiert, nicht Kalender-Widget. Tages-/Wochenansicht. | leitstand §5.3 | Nicht vorhanden | mittel | **CC PLANT** |
-| L6 | **Zahlen (Metrics)** — 8 Kennzahlen, nur fuer Inhaber. Trends, nicht Echtzeit-Counter. | leitstand §5.4 | Nicht vorhanden | niedrig | **BACKLOG** |
-| L7 | **Einstellungen** — Mitarbeiter CRUD, Termin-Defaults, Benachrichtigungen, Google Review Link. | leitstand §5.5 | Nicht vorhanden | niedrig | **BACKLOG** |
-| L8 | **Case-ID-Prefix** — Tenant-spezifisch (WA-0001 statt FS-0001). | identity_contract, leitstand §8 | Hardcoded "FS"-Prefix | mittel | **CC FIXT** |
-| L9 | **Termin als eigenes Objekt** — appointments-Tabelle, Status-Lifecycle, ICS v2 (UID/SEQUENCE/CANCEL). | leitstand §6, §10.1 | scheduled_at auf cases, kein eigenes Objekt | hoch | **CC PLANT** |
-| L10 | **Mitarbeiter als eigenes Objekt** — staff-Tabelle, Dropdown statt Freitext. | leitstand §10.2 | Nicht vorhanden | hoch | **CC PLANT** |
+| # | Titel | Status | Evidence |
+|---|-------|--------|----------|
+| L1 | **Sidebar: Tenant-Branding** | **DONE** | PR #192 — Fallback "Leitstand"/"LS", kein FlowSight |
+| L2 | **"Bald"-Badges entfernt** | **DONE** | PR #192 — 3 Items weg, 5 funktionale Nav-Items |
+| L3 | **Puls-Ansicht** | **DONE** | PR #192 — PulsView mit 4 Prioritaets-Gruppen |
+| L4 | **KPI-Click filtert Tabelle** | **DONE** | PR #196 — Alle 4 KPIs filtern korrekt (inkl. "In Bearbeitung" → contacted+scheduled) |
+| L5 | **Einsatzplan** | **DONE** | PR #192 — ScheduleView, nach Mitarbeiter gruppiert, Heute/Woche |
+| L6 | **Zahlen (Metrics)** | **DONE** | PR #192 — 8 KPIs, MetricsView |
+| L7 | **Einstellungen** | **DONE** | PR #195 — Google Review URL, Termin-Defaults, Benachrichtigungen, Kalender-Email |
+| L8 | **Case-ID-Prefix** | **DONE** | PR #192 — Tenant-spezifisch (WB-0001), formatCaseId shared utility |
+| L9 | **Termin als eigenes Objekt** | **DONE** | PR #192+#196 — appointments-Tabelle, ICS v2, ICS-E-Mail bei Termin-Erstellung |
+| L10 | **Mitarbeiter als eigenes Objekt** | **DONE** | PR #192+#196 — staff-Tabelle, Staff-Dropdown in Fall-Detail (statt Freitext) |
 
 ---
 
@@ -139,6 +138,19 @@ Alle GTM Building Blocks (G1-G12, S1-S9) = DONE. Details → `docs/gtm/gtm_track
 ---
 
 ## Completed (Archiv — kondensiert)
+
+### Renovation Gold Contact (13.03.)
+
+| Deliverable | Evidence |
+|-------------|----------|
+| Phase 0: DB Migrations (staff, appointments, case_id_prefix) + shared utilities | PR #192 |
+| Phase 1: Identity Sweep R4 (FlowSight unsichtbar, Tenant-Branding) | PR #192 |
+| Phase 2: Voice V1-V4 (Juniper, no city echo, urgency 1:1) + Wizard Success Gold | PR #193, #195 |
+| Phase 3: Puls-Ansicht (4 Prioritaets-Gruppen) | PR #192 |
+| Phase 4: Staff CRUD + Appointments + Einsatzplan + ICS v2 | PR #192 |
+| Phase 5: Kennzahlen (8 KPIs) + Einstellungen (Google Review, Termine, Benachrichtigungen) | PR #192, #195 |
+| L4 KPI-Click Filter + L9 ICS-E-Mail + L10 Staff-Dropdown | PR #196 |
+| Voice Agents published (4 Tenants, retell_sync) | PR #194 |
 
 ### S4 Enablement (13.03.)
 

--- a/src/web/app/api/ops/appointments/route.ts
+++ b/src/web/app/api/ops/appointments/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/src/lib/supabase/server";
 import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
+import { generateIcs } from "@/src/lib/ics/generateIcs";
+import { sendAppointmentIcsEmail } from "@/src/lib/email/resend";
 
 /**
  * GET /api/ops/appointments — List appointments (optionally filtered by case_id or staff_id)
- * POST /api/ops/appointments — Create a new appointment
+ * POST /api/ops/appointments — Create a new appointment + send ICS email
  */
 
 export async function GET(req: NextRequest) {
@@ -64,6 +66,7 @@ export async function POST(req: NextRequest) {
 
   // Generate ICS UID for this appointment
   const icsUid = `${crypto.randomUUID()}@flowsight.ch`;
+  const effectiveDuration = duration_min ?? 60;
 
   const { data, error } = await supabase
     .from("appointments")
@@ -72,15 +75,71 @@ export async function POST(req: NextRequest) {
       case_id,
       staff_id,
       scheduled_at,
-      duration_min: duration_min ?? 60,
+      duration_min: effectiveDuration,
       notes: notes ?? null,
       ics_uid: icsUid,
       ics_sequence: 0,
     })
-    .select("*, staff:staff_id(id, display_name, role)")
+    .select("*, staff:staff_id(id, display_name, role, email)")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Fetch case info for ICS email context (fire-and-forget on failure)
+  const { data: caseRow } = await supabase
+    .from("cases")
+    .select("seq_number, category, city, plz, street, house_number")
+    .eq("id", case_id)
+    .single();
+
+  const { data: tenantRow } = await supabase
+    .from("tenants")
+    .select("name, case_id_prefix")
+    .eq("id", effectiveTenantId)
+    .single();
+
+  // Generate and send ICS email
+  const staffInfo = data.staff as { id: string; display_name: string; role: string; email?: string } | null;
+  const location = [caseRow?.street, caseRow?.house_number, caseRow?.plz, caseRow?.city]
+    .filter(Boolean)
+    .join(" ");
+
+  const caseLabel = caseRow?.seq_number
+    ? `${tenantRow?.case_id_prefix ?? "FS"}-${String(caseRow.seq_number).padStart(4, "0")}`
+    : case_id.slice(0, 8);
+
+  const icsContent = generateIcs({
+    uid: icsUid,
+    sequence: 0,
+    summary: `${caseLabel} — ${caseRow?.category ?? "Einsatz"}`,
+    description: notes ?? undefined,
+    location: location || undefined,
+    startAt: new Date(scheduled_at),
+    durationMin: effectiveDuration,
+    organizerName: tenantRow?.name,
+    organizerEmail: process.env.RESEND_FROM ?? "noreply@flowsight.ch",
+    attendeeName: staffInfo?.display_name,
+    attendeeEmail: staffInfo?.email ?? undefined,
+    method: "REQUEST",
+  });
+
+  // Send ICS email (fire-and-forget — don't block API response)
+  sendAppointmentIcsEmail({
+    appointmentId: data.id,
+    caseId: case_id,
+    seqNumber: caseRow?.seq_number,
+    caseIdPrefix: tenantRow?.case_id_prefix ?? "FS",
+    tenantDisplayName: tenantRow?.name,
+    staffName: staffInfo?.display_name ?? "Techniker",
+    staffEmail: staffInfo?.email ?? undefined,
+    scheduledAt: scheduled_at,
+    durationMin: effectiveDuration,
+    category: caseRow?.category,
+    city: caseRow?.city,
+    notes: notes ?? undefined,
+    icsContent,
+    method: "REQUEST",
+  }).catch(() => {}); // fire-and-forget
 
   return NextResponse.json(data, { status: 201 });
 }

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -92,6 +92,15 @@ export function CaseDetailForm({ initialData, isProspect = false, caseEvents = [
     house_number: initialData.house_number ?? "",
   });
 
+  // Staff members for assignee dropdown (L10)
+  const [staffMembers, setStaffMembers] = useState<{ display_name: string }[]>([]);
+  useEffect(() => {
+    fetch("/api/ops/staff")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: { display_name: string }[]) => setStaffMembers(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState("");
   const [inviteState, setInviteState] = useState<"idle" | "sending" | "sent" | "error">("idle");
@@ -437,7 +446,24 @@ export function CaseDetailForm({ initialData, isProspect = false, caseEvents = [
         </div>
         <div>
           <label htmlFor="assignee" className={lbl}>Zuständig</label>
-          <input id="assignee" type="text" value={assigneeText} onChange={(e) => setAssigneeText(e.target.value)} placeholder="z.B. Ramon D." className={inp} />
+          {staffMembers.length > 0 ? (
+            <select
+              id="assignee"
+              value={assigneeText}
+              onChange={(e) => setAssigneeText(e.target.value)}
+              className={inp}
+            >
+              <option value="">— Nicht zugewiesen —</option>
+              {staffMembers.map((s) => (
+                <option key={s.display_name} value={s.display_name}>{s.display_name}</option>
+              ))}
+              {assigneeText && !staffMembers.some((s) => s.display_name === assigneeText) && (
+                <option value={assigneeText}>{assigneeText} (manuell)</option>
+              )}
+            </select>
+          ) : (
+            <input id="assignee" type="text" value={assigneeText} onChange={(e) => setAssigneeText(e.target.value)} placeholder="z.B. Ramon D." className={inp} />
+          )}
         </div>
       </div>
 

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -124,7 +124,10 @@ export default async function OpsCasesPage({
   if (filterTenantId) listQuery = listQuery.eq("tenant_id", filterTenantId);
 
   // Default: open cases (exclude done + archived), unless showAll or explicit status filter
-  if (filterStatus) {
+  if (filterStatus === "in_progress") {
+    // Virtual status: contacted + scheduled (L4: KPI click → filter)
+    listQuery = listQuery.in("status", ["contacted", "scheduled"]);
+  } else if (filterStatus) {
     listQuery = listQuery.eq("status", filterStatus);
   } else if (!showAll) {
     listQuery = listQuery.not("status", "in", "(done,archived)");

--- a/src/web/src/components/ops/CaseListClient.tsx
+++ b/src/web/src/components/ops/CaseListClient.tsx
@@ -184,7 +184,7 @@ export function CaseListClient({
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
         <KpiCard label="Total Fälle" value={kpi.total} color="text-slate-900" accent="border-l-slate-400" href="/ops/cases?show=all" />
         <KpiCard label="Neu heute" value={kpi.todayNew} color="text-blue-700" accent="border-l-blue-500" href="/ops/cases?status=new" />
-        <KpiCard label="In Bearbeitung" value={kpi.inProgress} color="text-violet-700" accent="border-l-violet-500" href="/ops/cases" />
+        <KpiCard label="In Bearbeitung" value={kpi.inProgress} color="text-violet-700" accent="border-l-violet-500" href="/ops/cases?status=in_progress" />
         <KpiCard label="Erledigt (7d)" value={kpi.doneWeek} color="text-emerald-700" accent="border-l-emerald-500" href="/ops/cases?show=all&status=done" />
       </div>
 

--- a/src/web/src/lib/email/resend.ts
+++ b/src/web/src/lib/email/resend.ts
@@ -684,3 +684,86 @@ export async function sendSalesLeadNotification(
     return false;
   }
 }
+
+// ---------------------------------------------------------------------------
+// ICS Appointment Email (L9: ICS v2 per E-Mail)
+// ---------------------------------------------------------------------------
+
+interface AppointmentEmailPayload {
+  appointmentId: string;
+  caseId: string;
+  seqNumber?: number | null;
+  caseIdPrefix?: string;
+  tenantDisplayName?: string;
+  staffName: string;
+  staffEmail?: string;
+  scheduledAt: string;
+  durationMin: number;
+  category?: string;
+  city?: string;
+  notes?: string;
+  icsContent: string;
+  method?: "REQUEST" | "CANCEL";
+}
+
+export async function sendAppointmentIcsEmail(payload: AppointmentEmailPayload): Promise<boolean> {
+  const from = `${payload.tenantDisplayName ?? "Leitstand"} <${process.env.RESEND_FROM ?? "noreply@flowsight.ch"}>`;
+  const recipientEmail = payload.staffEmail || process.env.MAIL_REPLY_TO;
+  if (!recipientEmail) return false;
+
+  const prefix = payload.caseIdPrefix ?? "FS";
+  const caseLabel = payload.seqNumber
+    ? `${prefix}-${String(payload.seqNumber).padStart(4, "0")}`
+    : payload.caseId.slice(0, 8);
+
+  const isCancellation = payload.method === "CANCEL";
+  const subject = isCancellation
+    ? `Termin abgesagt — ${caseLabel} ${payload.category ?? ""}`
+    : `Termin — ${caseLabel} ${payload.category ?? ""} (${payload.city ?? ""})`;
+
+  const date = new Date(payload.scheduledAt);
+  const dateStr = date.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", timeZone: "Europe/Zurich" });
+  const timeStr = date.toLocaleTimeString("de-CH", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" });
+
+  const textBody = [
+    isCancellation ? `Termin abgesagt` : `Neuer Termin`,
+    ``,
+    `Fall:        ${caseLabel}`,
+    `Techniker:   ${payload.staffName}`,
+    `Datum:       ${dateStr}`,
+    `Uhrzeit:     ${timeStr}`,
+    `Dauer:       ${payload.durationMin} Min.`,
+    ...(payload.category ? [`Kategorie:   ${payload.category}`] : []),
+    ...(payload.city ? [`Ort:         ${payload.city}`] : []),
+    ...(payload.notes ? [`\nNotizen: ${payload.notes}`] : []),
+  ].join("\n");
+
+  try {
+    const { error } = await getResend().emails.send({
+      from,
+      to: recipientEmail,
+      subject,
+      text: textBody,
+      attachments: [
+        {
+          filename: "termin.ics",
+          content: Buffer.from(payload.icsContent, "utf-8").toString("base64"),
+          contentType: "text/calendar; method=" + (payload.method ?? "REQUEST"),
+        },
+      ],
+    });
+
+    if (error) {
+      Sentry.captureException(error, {
+        tags: { _tag: "resend", area: "ops", email_type: "appointment_ics", decision: "failed" },
+      });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { _tag: "resend", area: "ops", email_type: "appointment_ics", decision: "failed" },
+    });
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- **L4 KPI-Click:** "In Bearbeitung" KPI now correctly filters to contacted+scheduled cases (virtual `in_progress` status)
- **L9 ICS Email:** Appointment creation sends ICS calendar invite via email (RFC 5545, Resend attachment)
- **L10 Staff Dropdown:** Case detail "Zuständig" field is now a dropdown populated from staff table (falls back to text input if no staff configured)
- **SSOT:** ticketlist.md updated — all V1-V4 + L1-L10 marked DONE with PR evidence

## Test plan
- [ ] Click "In Bearbeitung" KPI → shows only contacted+scheduled cases (not Puls)
- [ ] Click "Neu heute" KPI → shows only new cases from today
- [ ] Create appointment → ICS email received with .ics attachment
- [ ] Open case detail → "Zuständig" shows dropdown with staff members
- [ ] Case detail with no staff configured → shows text input fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)