### PR TITLE
feat: eCall.ch Swiss SMS gateway integration (V5)

### DIFF
--- a/docs/architecture/env_vars.md
+++ b/docs/architecture/env_vars.md
@@ -45,6 +45,11 @@ Diese Datei ist eine Liste aller benötigten Env Vars + Herkunft. Keine Werte ei
 - Portal-Zugang: my.peoplefone.ch (Credentials in Bitwarden)
 - Siehe: docs/runbooks/peoplefone_front_door.md
 
+## eCall.ch (Swiss SMS Gateway — Primary)
+- ECALL_API_URL -> https://rest.ecall.ch/api/message (eCall REST endpoint)
+- ECALL_API_USERNAME -> eCall Portal → REST API User
+- ECALL_API_PASSWORD -> eCall Portal → REST API Passwort
+
 ## SMS (Post-Call Verification)
 - SMS_HMAC_SECRET -> selbst generiert (Bitwarden), für HMAC-SHA256 Token in Korrektur-Links
 - SMS_ALLOWED_NUMBERS -> (optional) Komma-separierte E.164 Whitelist. Wenn gesetzt, gehen SMS nur an diese Nummern. Leer/fehlend = senden an alle. Testphase: nur Founder-Handy.

--- a/src/web/src/lib/sms/sendSms.ts
+++ b/src/web/src/lib/sms/sendSms.ts
@@ -1,13 +1,19 @@
 import "server-only";
 
+import { sendSmsEcall } from "./sendSmsEcall";
+
 /**
- * Send an SMS via Twilio REST API.
- * Supports both E.164 phone numbers and alphanumeric sender IDs.
- * Phone number senders avoid carrier spam filters in Switzerland.
+ * Send an SMS — routes to the best available provider:
+ *   1. eCall.ch (Swiss gateway, no spam) — if ECALL_API_* env vars are set
+ *   2. Twilio (international) — fallback
  *
- * Env vars:
- * - TWILIO_ACCOUNT_SID
- * - TWILIO_AUTH_TOKEN
+ * Env vars (eCall — preferred):
+ * - ECALL_API_URL, ECALL_API_USERNAME, ECALL_API_PASSWORD
+ *
+ * Env vars (Twilio — fallback):
+ * - TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN
+ *
+ * Shared:
  * - SMS_ALLOWED_NUMBERS (optional) — comma-separated E.164 whitelist.
  *   When set, only these numbers receive SMS. Empty/unset = send to all.
  *
@@ -31,7 +37,40 @@ function isE164(from: string): boolean {
   return /^\+[1-9]\d{7,14}$/.test(from);
 }
 
+/** Check if eCall env vars are configured. */
+function isEcallConfigured(): boolean {
+  return !!(
+    process.env.ECALL_API_URL &&
+    process.env.ECALL_API_USERNAME &&
+    process.env.ECALL_API_PASSWORD
+  );
+}
+
 export async function sendSms(
+  to: string,
+  body: string,
+  from: string,
+): Promise<SendSmsResult> {
+  // Whitelist guard: when SMS_ALLOWED_NUMBERS is set, only send to listed numbers.
+  const allowList = process.env.SMS_ALLOWED_NUMBERS;
+  if (allowList) {
+    const allowed = allowList.split(",").map((n) => n.trim());
+    if (!allowed.includes(to)) {
+      return { sent: false, reason: `not_in_allowlist: ${to}` };
+    }
+  }
+
+  // Route 1: eCall (Swiss gateway — preferred)
+  if (isEcallConfigured()) {
+    return sendSmsEcall(to, body, from);
+  }
+
+  // Route 2: Twilio (fallback)
+  return sendSmsTwilio(to, body, from);
+}
+
+/** Send SMS via Twilio REST API. */
+async function sendSmsTwilio(
   to: string,
   body: string,
   from: string,
@@ -45,15 +84,6 @@ export async function sendSms(
 
   if (!isE164(from) && !isValidAlphaSender(from)) {
     return { sent: false, reason: `invalid_sender: "${from}"` };
-  }
-
-  // Whitelist guard: when SMS_ALLOWED_NUMBERS is set, only send to listed numbers.
-  const allowList = process.env.SMS_ALLOWED_NUMBERS;
-  if (allowList) {
-    const allowed = allowList.split(",").map((n) => n.trim());
-    if (!allowed.includes(to)) {
-      return { sent: false, reason: `not_in_allowlist: ${to}` };
-    }
   }
 
   try {

--- a/src/web/src/lib/sms/sendSmsEcall.ts
+++ b/src/web/src/lib/sms/sendSmsEcall.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+import type { SendSmsResult } from "./sendSms";
+
+/**
+ * Send an SMS via eCall.ch REST API (Swiss SMS gateway).
+ * Routes through Swiss carriers → no spam filter issues.
+ *
+ * Env vars:
+ * - ECALL_API_URL (e.g. https://rest.ecall.ch/api/message)
+ * - ECALL_API_USERNAME
+ * - ECALL_API_PASSWORD
+ *
+ * Phone format: eCall expects international format with 00 prefix (e.g. 0041791234567).
+ * We accept E.164 (+41...) and convert automatically.
+ *
+ * Never throws — returns result with sent:false on any error.
+ */
+
+/** Convert E.164 (+41791234567) to eCall format (0041791234567). */
+function toEcallNumber(e164: string): string {
+  if (e164.startsWith("+")) {
+    return "00" + e164.slice(1);
+  }
+  return e164;
+}
+
+export async function sendSmsEcall(
+  to: string,
+  body: string,
+  from: string,
+): Promise<SendSmsResult> {
+  const apiUrl = process.env.ECALL_API_URL;
+  const username = process.env.ECALL_API_USERNAME;
+  const password = process.env.ECALL_API_PASSWORD;
+
+  if (!apiUrl || !username || !password) {
+    return { sent: false, reason: "ecall_missing_env" };
+  }
+
+  try {
+    const auth = Buffer.from(`${username}:${password}`).toString("base64");
+
+    const res = await fetch(apiUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        channel: "sms",
+        from,
+        to: toEcallNumber(to),
+        content: {
+          type: "Text",
+          text: body,
+        },
+      }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return { sent: false, reason: `ecall_${res.status}`, messageSid: text.slice(0, 300) };
+    }
+
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const messageId = (data.id ?? data.messageId ?? data.message_id ?? "") as string;
+    return { sent: true, messageSid: messageId || "ecall_ok" };
+  } catch {
+    return { sent: false, reason: "ecall_fetch_exception" };
+  }
+}

--- a/src/web/src/lib/tenants/getTenantSmsConfig.ts
+++ b/src/web/src/lib/tenants/getTenantSmsConfig.ts
@@ -34,9 +34,9 @@ export async function getTenantSmsConfig(
     const senderName = modules.sms_sender_name;
     if (typeof senderName !== "string" || senderName.length === 0) return null;
 
-    // fromNumber: will be populated once Swiss SMS provider (eCall) is configured.
-    // Twilio SIP trunk numbers are NOT SMS-capable — do not use them as sender.
-    // Until eCall is live, SMS sends via alphanumeric sender (spam risk accepted).
+    // eCall is now the primary SMS provider (Swiss gateway, no spam issues).
+    // fromNumber is no longer needed — eCall accepts alphanumeric senders natively.
+    // Kept for potential future per-tenant number routing.
     const fromNumber: string | null = null;
 
     return { senderName, fromNumber };


### PR DESCRIPTION
## Summary
- **New:** `sendSmsEcall.ts` — eCall.ch REST API client (Swiss gateway, Basic Auth, JSON)
- **Changed:** `sendSms.ts` — auto-routes to eCall when `ECALL_API_*` env vars are set, Twilio as fallback
- **Updated:** `getTenantSmsConfig.ts` comments, `env_vars.md` with eCall section

## Why
V5 blocker: Twilio routes SMS through international gateways → Swiss carriers flag as spam. eCall.ch routes through Swiss carriers natively → no spam.

## How it works
1. `sendSms()` checks if `ECALL_API_URL` + `ECALL_API_USERNAME` + `ECALL_API_PASSWORD` are set
2. If yes → routes to `sendSmsEcall()` (Swiss gateway)
3. If no → falls back to Twilio (existing behavior, zero regression)
4. `SMS_ALLOWED_NUMBERS` whitelist still applies (checked before provider routing)

## Env vars (already on Vercel)
- `ECALL_API_URL` = `https://rest.ecall.ch/api/message`
- `ECALL_API_USERNAME` = `flowsight_restapi`
- `ECALL_API_PASSWORD` = (set)

## Test plan
- [ ] CI green (lint + build)
- [ ] Testanruf Weinberger → SMS kommt an (nicht im Spam)
- [ ] Fallback: wenn eCall-Vars entfernt → Twilio greift wie bisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)