### PR TITLE
refactor: eCall-only SMS — remove Twilio SMS, 2-tier sender

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -25,7 +25,7 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 |-------|--------|----------|
 | **Wizard** (Website Intake) | LIVE ✅ | /kunden/[slug]/meldung — "Was ist Ihr Anliegen?", Top-3 dynamic + fixed row (Allgemein/Angebot/Kontakt), photo upload in Step 3, branded per customer |
 | **Voice** (Telefon Intake) | LIVE ✅ | Dual-Agent DE/INTL, PLZ→City auto-lookup (24 Orte), Language Gate, SMS+Photo mention, reporter_name, deterministic closing, Notfall-Empathie, FAQ-safe edge logic |
-| **SMS Channel** | LIVE ✅ | Post-call SMS with short correction link `/v/[id]?t=<16hex>` (~85 chars) + photo upload. Twilio alphanumeric sender. HMAC-secured. |
+| **SMS Channel** | LIVE ✅ | Post-call SMS with short correction link `/v/[id]?t=<16hex>` (~85 chars) + photo upload. eCall.ch Swiss gateway (2-tier sender: alphanumeric → FlowSight-Servicenummer). HMAC-secured. |
 | **Ops Dashboard** | LIVE ✅ | /ops — Case Detail (UX v2), Case List (search, pagination, KPI click-to-filter), CSV-Export, Timeline |
 | **Email Notifications** | LIVE ✅ | HTML Ops-Notification + Melder-Bestätigung + Review-Anfrage + Demo + Sales Lead |
 | **Peoplefone Front Door** | LIVE ✅ | Brand-Nr → Twilio → SIP → Retell |
@@ -85,6 +85,7 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 - **S2.2 Tier-1 Website QA (13.03.):** PR #177. Walter Leuthold History-Section enabled (2. Milestone). Widmer Spenglerei-Icon `roof`. Widmer Opening Hours Sa/So. Dörfler Blitzschutz-Bild Encoding-Fix.
 - **S2.4 Voice Agent Gold-QA (13.03.):** PR #178. Placeholder Agent-IDs ersetzt (Brunner + Weinberger DE↔INTL Transfer). Alle 8 Agents synced + published.
 - **BLOCKER:** Keine. Go-Live möglich.
+- **SMS-Architektur (14.03.):** eCall.ch = einziger SMS-Provider (CH). Twilio = nur Voice/SIP. 2-Tier Sender: alphanumerisch (Tenant) → ECALL_SENDER_NUMBER (FlowSight-Servicenummer). Twilio-SMS-Pfad entfernt.
 - **S2.5 SMS-Config (13.03.):** Verified. Brunner (BrunnerHT) + Weinberger (Weinberger) korrekt. Andere 4 Tenants wizard-only → kein SMS nötig.
 - **S2 KOMPLETT** (CC-seitig). Alle 6 Blocks done (S2.1–S2.6).
 - **S3 Journey Verification (13.03.):** PR #181. Trial E2E Tag 0–14 verifiziert (Voice/Wizard/Review/SMS/Dashboard). Trial Expiry Hard Gate (Middleware → /ops/expired). Morning Report follow_up_due Auto-Expire (3d). Milestone-Retry-Bug = FALSE POSITIVE (Code korrekt). **S3 VERDICT: PASS.**

--- a/docs/architecture/env_vars.md
+++ b/docs/architecture/env_vars.md
@@ -33,10 +33,10 @@ Diese Datei ist eine Liste aller benötigten Env Vars + Herkunft. Keine Werte ei
 - RETELL_API_KEY -> Retell Dashboard (optional)
 - RETELL_AGENT_ID -> optional
 
-## Twilio (Carrier)
+## Twilio (Voice/SIP only — kein SMS)
 - TWILIO_ACCOUNT_SID -> Twilio Console
 - TWILIO_AUTH_TOKEN -> Twilio Console
-- TWILIO_PHONE_NUMBER -> gekaufte CH Nummer (E.164)
+- TWILIO_PHONE_NUMBER -> gekaufte CH Nummer (E.164) — nur SIP/Voice-Routing
 - TWILIO_SIP_TRUNK_NAME -> SIP Trunk Name für Retell-Routing
 
 ## Peoplefone (Brand-Nummer, optional)
@@ -45,11 +45,11 @@ Diese Datei ist eine Liste aller benötigten Env Vars + Herkunft. Keine Werte ei
 - Portal-Zugang: my.peoplefone.ch (Credentials in Bitwarden)
 - Siehe: docs/runbooks/peoplefone_front_door.md
 
-## eCall.ch (Swiss SMS Gateway — Primary)
+## eCall.ch (Einziger SMS-Provider für CH)
 - ECALL_API_URL -> https://rest.ecall.ch/api/message (eCall REST endpoint)
 - ECALL_API_USERNAME -> eCall Portal → REST API User
 - ECALL_API_PASSWORD -> eCall Portal → REST API Passwort
-- ECALL_SENDER_NUMBER -> Fallback-Nummer (E.164) wenn alphanumerischer Sender nicht freigeschaltet. Langfristig: Sender im eCall-Portal freischalten ("Weinberger", "Doerfler" etc.).
+- ECALL_SENDER_NUMBER -> FlowSight-Servicenummer (E.164). Globaler Fallback wenn alphanumerischer Sender (Tier 1) vom eCall-Portal rejected wird. KEINE Founder-Privatnummer. Dedizierte CH-Nummer beschaffen (eCall oder Peoplefone).
 
 ## SMS (Post-Call Verification)
 - SMS_HMAC_SECRET -> selbst generiert (Bitwarden), für HMAC-SHA256 Token in Korrektur-Links

--- a/docs/architecture/zielarchitektur.md
+++ b/docs/architecture/zielarchitektur.md
@@ -489,9 +489,11 @@ TenantContext ist nicht "ein Feature" — es ist eine **Architekturachse**, die 
 
 #### SMS
 - **Rolle:** Brücke zwischen Voice und Korrektur. Einziger Post-Call-Kontakt zum Melder.
+- **Provider:** eCall.ch (Schweizer SMS-Gateway). Twilio = nur Voice/SIP, kein SMS.
+- **Sender-Logik (2-Tier):** (1) Alphanumerischer Sender pro Tenant (z.B. "Weinberger") — muss im eCall-Portal freigeschaltet sein. (2) Fallback: ECALL_SENDER_NUMBER (FlowSight-Servicenummer, global).
 - **Qualitätsanspruch:** Muss von Firmenname kommen (alphanumeric sender). Muss Korrekturlink enthalten. Muss unter 160 Chars (~85 Chars aktuell). Muss auf Handy funktionieren.
-- **Typische Risiken:** SMS an Twilio-owned Number (gefixt PR #126). DEMO_SIP_CALLER_ID nicht gesetzt → SMS ins Nirgendwo. SMS-Provider-Limits.
-- **Zielzustand:** Melder erhält SMS innerhalb 10s nach Anruf. Korrekturlink funktioniert. Foto-Upload möglich.
+- **Typische Risiken:** Alphanumerischer Sender nicht im eCall-Portal freigeschaltet → 400 → Fallback auf Servicenummer. eCall-Env-Vars nicht gesetzt → SMS-Versand komplett blockiert.
+- **Zielzustand:** Melder erhält SMS innerhalb 10s nach Anruf. Korrekturlink funktioniert. Foto-Upload möglich. Absender = Firmenname (nach eCall-Freischaltung).
 
 #### Ops Dashboard
 - **Rolle:** "Mein System" — der Ort, an dem der Handwerker seine Fälle sieht und bearbeitet.
@@ -546,40 +548,75 @@ TenantContext ist nicht "ein Feature" — es ist eine **Architekturachse**, die 
 
 ---
 
-## 12. SMS-/Kontaktzielrouting
+## 12. SMS-Architektur (eCall.ch)
 
-### Das Problem als Architekturthema
+### Architekturentscheidung (14.03.2026)
 
-SMS-Routing ist kein Bug — es ist eine **Architekturentscheidung**, die sich durch alle Demo-Modi zieht. Die Frage "Wer bekommt die SMS?" muss pro Modus klar beantwortet sein.
+**eCall.ch = einziger SMS-Provider für Schweiz. Twilio = nur Voice/SIP, kein SMS.**
 
-### Routing-Matrix
+Grund: Twilio-SMS via internationale Carrier verursachen Spam-Friktion bei Schweizer Empfängern. eCall.ch routet direkt über Schweizer Carrier → keine Spam-Filter-Probleme. Ein Twilio-SMS-Fallback wäre ein Fallback der nicht funktioniert und false confidence gibt.
 
-| Auslöser | Modus | Anrufer-Nummer | SMS-Ziel | Logik |
-|----------|-------|----------------|----------|-------|
-| Voice-Call | **Production** | Echter Melder (+41...) | Anrufer-Nummer | Standard |
-| Voice-Call | **Internal Test** | Founder von SIP (+41445053019 / +41445520919) | DEMO_SIP_CALLER_ID (Founder-Handy) | Twilio-owned Detection |
-| Voice-Call | **Prospect Demo** | Prospect von SIP oder eigenem Handy | ??? (D11 — offen) | Muss geklärt werden |
-| Review-SMS | **Production** | — | case.contact_phone | Standard |
-| Review-SMS | **Prospect Demo** | — | Demo-Case → Prospect-Handy? | Muss geklärt werden |
-
-### Empfohlene Routing-Logik
+### Provider-Architektur
 
 ```
-WENN anrufer_nummer ∈ TWILIO_OWNED_NUMBERS:
-  → sms_ziel = tenant.modules.demo_sms_target ?? DEMO_SIP_CALLER_ID
-SONST:
-  → sms_ziel = anrufer_nummer (Standard)
+┌──────────────────────────────────────────────────┐
+│  SMS (eCall.ch)          │  Voice/SIP (Twilio)    │
+│                          │                        │
+│  sendSms()               │  Retell → Twilio SIP   │
+│    → sendSmsEcall()      │    → Peoplefone         │
+│                          │                        │
+│  Env: ECALL_API_*        │  Env: TWILIO_*          │
+│  Env: ECALL_SENDER_NUMBER│                        │
+└──────────────────────────────────────────────────┘
 ```
 
-**Vorteile:**
-- Tenant-spezifisch: Jeder Demo-Tenant kann ein anderes SMS-Ziel haben
-- Fallback auf globale Env-Var (Founder-Handy)
-- Production unberührt (echte Nummern → echte Melder)
+### Sender-Logik (2-Tier)
 
-**Entscheidungsbedarf (D11):**
-- Soll der Prospect beim Demo-Anruf die SMS auf SEIN Handy bekommen? (= überzeugender, aber erfordert Prospect-Nummer im System)
-- Oder soll die SMS an Founder gehen, der sie dem Prospect zeigt? (= sicherer, aber weniger Wow)
-- **Empfehlung:** Prospect soll SMS selbst erhalten. Demo-Tenant bekommt `demo_sms_target` = Prospect-Handynummer (Founder setzt vor Demo-Call).
+```
+Tier 1: tenant.modules.sms_sender_name
+        "Weinberger", "Doerfler" etc. (alphanumerisch)
+        Muss pro Tenant im eCall-Portal freigeschaltet sein
+        → Empfänger sieht: "Weinberger"
+
+        ↓ 400 rejected (nicht freigeschaltet)?
+
+Tier 2: ECALL_SENDER_NUMBER
+        FlowSight-Servicenummer (global, dedizierte CH-Nummer)
+        KEINE Founder-Privatnummer
+        → Empfänger sieht: +41 7x xxx xx xx + Text "Weinberger: Ihre Meldung..."
+```
+
+### SMS-Empfänger-Routing (unverändert)
+
+| Auslöser | Modus | SMS-Empfänger | Logik |
+|----------|-------|---------------|-------|
+| Voice-Call | **Production** | Anrufer-Nummer (Melder) | Standard |
+| Voice-Call | **Internal Test** | DEMO_SIP_CALLER_ID (Founder-Handy) | Twilio-owned Detection |
+| Voice-Call | **Prospect Demo** | demo_sms_target (Prospect-Handy) | Tenant-spezifisch |
+| Review-SMS | **Production** | case.contact_phone | Standard |
+
+### Richtung
+
+**One-Way.** Kein Reply-Handling. Korrekturen/Interaktion laufen über Korrekturlink → Wizard → Leitstand.
+
+### Code-Pfade
+
+```
+postCallSms.ts  →  sendSms()  →  sendSmsEcall()  →  eCall REST API
+                    ↑ Whitelist                        ↑ 2-Tier Sender
+                    SMS_ALLOWED_NUMBERS                 Tier 1 → Tier 2
+```
+
+### Produktionsreife-Checkliste
+
+- [x] eCall REST API Client (`sendSmsEcall.ts`)
+- [x] 2-Tier Sender-Fallback (alpha → Servicenummer)
+- [x] Twilio-SMS-Pfad entfernt
+- [ ] FlowSight-Servicenummer beschaffen (bei eCall oder dedizierte CH-Nummer)
+- [ ] ECALL_SENDER_NUMBER auf Vercel setzen (Servicenummer)
+- [ ] Alpha-Sender pro Tenant im eCall-Portal freischalten
+- [ ] SMS_ALLOWED_NUMBERS Whitelist entfernen (nach Go-Live-Entscheid)
+- [ ] Delivery-Status-Monitoring (eCall Status-Webhooks → Morning Report)
 
 ---
 

--- a/docs/ticketlist.md
+++ b/docs/ticketlist.md
@@ -11,8 +11,8 @@
 
 - **Produkt:** 17 Module LIVE (Website, Voice, Wizard, Ops, Reviews, Review Surface, Morning Report, Entitlements, Email, Peoplefone, Sales Agent, Demo Booking, Demo-Strang, SMS Channel, CoreBot, Customer Links Page, BigBen Pub)
 - **Kunden:** 7 Websites live (Doerfler, Brunner HT, Walter Leuthold, Orlandini, Widmer, **Weinberger AG**, BigBen Pub)
-- **BLOCKER:** 2 (S3: eCall SMS kommt nicht an + V2/V3 Voice-Fixes nicht live auf Retell)
-- **Phase:** Renovation Code DONE. **Founder E2E-Verification 14.03. deckt 22 Gaps auf.** Naechster Schritt: STOPP-Blocker fixen, dann Leitstand-Redesign R2.
+- **BLOCKER:** 1 (S3: eCall SMS — Code ready, wartet auf Founder-Action: FlowSight-Servicenummer + ECALL_SENDER_NUMBER)
+- **Phase:** Voice V2/V3/V6 DONE (PR #198). SMS-Architektur vereinfacht: eCall-only, 2-Tier Sender, Twilio-SMS entfernt (PR #199). Naechster Schritt: Founder setzt Servicenummer, dann E2E-Verify, dann Leitstand-Redesign R2.
 - **Redesign-Docs:** `docs/redesign/` — plan.md + 6 Zielbilder + 4 IST-Audits + identity_contract.md
 - **Gold Contact:** `docs/gtm/gold_contact.md` — Nordstern (unveraendert)
 - **CI/CD:** GitHub Actions (lint + build + Telegram notify + lifecycle-tick + morning-report). Branch Protection: PR required.
@@ -35,9 +35,9 @@
 |---|-------|------|-----------|--------|
 | S1 | **Weinberger SMS kommt nicht an** | Voice→Webhook→SMS | `+41435051101` fehlte in TWILIO_OWNED_NUMBERS → SMS ging an Twilio-Nr statt Founder-Handy | **DONE** (PR #189) |
 | S2 | **SMS_ALLOWED_NUMBERS Whitelist pruefen** | Vercel Env | `+41764458942` ist in Whitelist → kein Blocker | **PASS** |
-| S3 | **eCall SMS kommt nicht an** | eCall-Integration deployed (PR #197), Env Vars gesetzt, aber SMS kommt weder normal noch als Spam an | Debuggen: eCall-Response pruefen, Nummernformat, API-Testcall | **OFFEN** |
+| S3 | **eCall SMS kommt nicht an** | eCall-Integration deployed (PR #197+#199), 2-Tier Sender (alpha→Servicenr), Twilio-SMS entfernt. **Blocker:** ECALL_SENDER_NUMBER (FlowSight-Servicenr) noch nicht gesetzt + Alpha-Sender nicht im eCall-Portal freigeschaltet. | Founder: Servicenummer beschaffen → ECALL_SENDER_NUMBER setzen → E2E-Test | **OFFEN (Founder-Action)** |
 
-**Status:** S1+S2 DONE. **S3 = aktiver Blocker.** eCall-Code deployed, Env Vars auf Vercel, aber SMS kommt nicht an. Muss debuggt werden.
+**Status:** S1+S2 DONE. **S3 = Founder-Action.** Code ist produktionsreif (2-Tier, eCall-only). Wartet auf: (1) FlowSight-Servicenummer beschaffen, (2) ECALL_SENDER_NUMBER auf Vercel setzen, (3) E2E-Verify.
 
 ---
 
@@ -48,11 +48,11 @@
 | # | Titel | Root Cause | Schwere | Status |
 |---|-------|-----------|---------|--------|
 | V1 | **Voice auf Juniper umstellen (alle Agents)** | Agent-JSONs verwenden falsche voice_id | hoch | **DONE** (PR #193) |
-| V2 | **"Jul" aus Greeting entfernen** | Agent sagt weiterhin "Jul Weinberger AG" statt nur "Weinberger AG". Prompt/Greeting nicht korrekt auf Retell publiziert? | hoch | **REOPENED** — Testanruf 14.03. bestaetigt: "Jul" wird gesprochen |
-| V3 | **Ortsnamen NICHT wiederholen** | Agent wiederholt weiterhin "Thalwil, richtig?" — Prompt-Aenderung nicht auf Retell live? | mittel | **REOPENED** — Testanruf 14.03. bestaetigt |
+| V2 | **"Jul" aus Greeting entfernen** | Global gefixt: agent_name, greeting, global_prompt, FIRMEN-WISSEN — alle "Jul." entfernt. Alle 8 Agents republished. | hoch | **DONE** (PR #198) — Founder-Verify ausstehend |
+| V3 | **Ortsnamen NICHT wiederholen** | NIEMALS-Regel mit VERBOTEN-Beispielen auf allen 4 DE-Agents. Republished. | mittel | **DONE** (PR #198) — Founder-Verify ausstehend |
 | V4 | **Dringlichkeits-Echo korrigieren** | Agent-Prompt mappt nicht 1:1 | mittel | **DONE** (PR #193) |
-| V5 | **SMS kommt nicht an (eCall)** | eCall-Integration deployed (PR #197), SMS kommt trotzdem nicht an | hoch | **OFFEN** — identisch mit S3 |
-| V6 | **Namens-Frage falsch formuliert** | Agent sagt "Und wie ist Ihr Name bitte? Damit unser Techniker weiss bei wem er klingeln muss." — Soll stattdessen sagen: "Und koennten Sie mir als letztes sagen, wo unser Techniker klingeln darf?" | mittel | **OFFEN** |
+| V5 | **SMS kommt nicht an (eCall)** | Identisch mit S3. Code produktionsreif. Wartet auf Founder-Action (Servicenummer + ECALL_SENDER_NUMBER) | hoch | **OFFEN** — blockiert durch S3 |
+| V6 | **Namens-Frage falsch formuliert** | Global gefixt auf allen 4 DE-Agents: "Und koennten Sie mir als letztes sagen, wo unser Techniker klingeln darf?" Republished. | mittel | **DONE** (PR #198) — Founder-Verify ausstehend |
 
 ---
 
@@ -163,13 +163,16 @@ Alle GTM Building Blocks (G1-G12, S1-S9) = DONE. Details → `docs/gtm/gtm_track
 
 ## Completed (Archiv — kondensiert)
 
-### eCall SMS Integration (14.03.)
+### SMS-Architektur Vereinfachung (14.03.)
 
 | Deliverable | Evidence |
 |-------------|----------|
 | sendSmsEcall.ts — eCall.ch REST API Client (Swiss Gateway) | PR #197 |
-| sendSms.ts — Auto-Routing: eCall (preferred) → Twilio (fallback) | PR #197 |
-| Env Vars dokumentiert (ECALL_API_URL, USERNAME, PASSWORD) | PR #197 |
+| Twilio-SMS-Pfad komplett entfernt — eCall = einziger SMS-Provider (CH) | PR #199 |
+| 2-Tier Sender: alphanumerisch (Tenant) → ECALL_SENDER_NUMBER (FlowSight-Servicenr) | PR #199 |
+| Tote `fromNumber`-Logik entfernt (getTenantSmsConfig, postCallSms, API routes) | PR #199 |
+| Docs aligned: zielarchitektur.md §12, STATUS.md, env_vars.md, ticketlist.md | PR #199 |
+| Voice V2/V3/V6 global gefixt + alle 8 Agents republished | PR #198 |
 
 ### Renovation Gold Contact (13.03.)
 

--- a/src/web/app/api/cases/route.ts
+++ b/src/web/app/api/cases/route.ts
@@ -323,7 +323,6 @@ export async function POST(request: NextRequest) {
           createdAt: row.created_at,
           callerPhone: data.contact_phone,
           smsSenderName: smsConfig.senderName,
-          smsFromNumber: smsConfig.fromNumber ?? undefined,
           plz: data.plz,
           city: data.city,
           category: data.category,

--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -156,7 +156,6 @@ export async function POST(
     channel = "sms";
     const smsConfig = await getTenantSmsConfig(row.tenant_id);
     const senderName = smsConfig?.senderName ?? "FlowSight";
-    const fromNumber = smsConfig?.fromNumber;
     const smsBody = [
       `${senderName}: Wie war unser Service?`,
       ``,
@@ -165,7 +164,7 @@ export async function POST(
       ``,
       `Vielen Dank für Ihr Vertrauen — Ihr Service-Team`,
     ].join("\n");
-    const smsResult = await sendSms(row.contact_phone, smsBody, fromNumber ?? senderName);
+    const smsResult = await sendSms(row.contact_phone, smsBody, senderName);
     sent = smsResult.sent;
   }
 

--- a/src/web/app/api/retell/webhook/route.ts
+++ b/src/web/app/api/retell/webhook/route.ts
@@ -563,7 +563,6 @@ export async function POST(req: Request) {
           createdAt: row.created_at,
           callerPhone: smsTarget,
           smsSenderName: smsConfig.senderName,
-          smsFromNumber: smsConfig.fromNumber ?? undefined,
           plz: plz!,
           city: city!,
           category: category!,

--- a/src/web/src/lib/sms/postCallSms.ts
+++ b/src/web/src/lib/sms/postCallSms.ts
@@ -8,8 +8,6 @@ export interface PostCallSmsPayload {
   createdAt: string;
   callerPhone: string;
   smsSenderName: string;
-  /** Twilio phone number (E.164) to send from. Falls back to smsSenderName (alphanumeric) if not set. */
-  smsFromNumber?: string;
   plz: string;
   city: string;
   category: string;
@@ -53,5 +51,5 @@ export async function sendPostCallSms(
     `Ihr Service-Team meldet sich schnellstmöglich.`,
   ].join("\n");
 
-  return sendSms(p.callerPhone, body, p.smsFromNumber ?? p.smsSenderName);
+  return sendSms(p.callerPhone, body, p.smsSenderName);
 }

--- a/src/web/src/lib/sms/sendSms.ts
+++ b/src/web/src/lib/sms/sendSms.ts
@@ -3,15 +3,12 @@ import "server-only";
 import { sendSmsEcall } from "./sendSmsEcall";
 
 /**
- * Send an SMS — routes to the best available provider:
- *   1. eCall.ch (Swiss gateway, no spam) — if ECALL_API_* env vars are set
- *   2. Twilio (international) — fallback
+ * Send an SMS via eCall.ch — sole SMS provider for CH.
+ * Twilio is used for Voice/SIP only, not SMS.
  *
- * Env vars (eCall — preferred):
+ * Env vars (eCall):
  * - ECALL_API_URL, ECALL_API_USERNAME, ECALL_API_PASSWORD
- *
- * Env vars (Twilio — fallback):
- * - TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN
+ * - ECALL_SENDER_NUMBER (optional) — fallback if alphanumeric sender is rejected
  *
  * Shared:
  * - SMS_ALLOWED_NUMBERS (optional) — comma-separated E.164 whitelist.
@@ -25,25 +22,6 @@ export interface SendSmsResult {
   sent: boolean;
   messageSid?: string;
   reason?: string;
-}
-
-/** Twilio alphanumeric sender: 3-11 chars, [A-Za-z0-9 ], min 1 letter. */
-function isValidAlphaSender(from: string): boolean {
-  return /^[A-Za-z0-9 ]{3,11}$/.test(from) && /[A-Za-z]/.test(from);
-}
-
-/** E.164 phone number: +{country}{number}, 8-15 digits total. */
-function isE164(from: string): boolean {
-  return /^\+[1-9]\d{7,14}$/.test(from);
-}
-
-/** Check if eCall env vars are configured. */
-function isEcallConfigured(): boolean {
-  return !!(
-    process.env.ECALL_API_URL &&
-    process.env.ECALL_API_USERNAME &&
-    process.env.ECALL_API_PASSWORD
-  );
 }
 
 export async function sendSms(
@@ -60,53 +38,5 @@ export async function sendSms(
     }
   }
 
-  // Route 1: eCall (Swiss gateway — preferred)
-  if (isEcallConfigured()) {
-    return sendSmsEcall(to, body, from);
-  }
-
-  // Route 2: Twilio (fallback)
-  return sendSmsTwilio(to, body, from);
-}
-
-/** Send SMS via Twilio REST API. */
-async function sendSmsTwilio(
-  to: string,
-  body: string,
-  from: string,
-): Promise<SendSmsResult> {
-  const accountSid = process.env.TWILIO_ACCOUNT_SID;
-  const authToken = process.env.TWILIO_AUTH_TOKEN;
-
-  if (!accountSid || !authToken) {
-    return { sent: false, reason: "missing_env" };
-  }
-
-  if (!isE164(from) && !isValidAlphaSender(from)) {
-    return { sent: false, reason: `invalid_sender: "${from}"` };
-  }
-
-  try {
-    const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
-    const auth = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
-
-    const res = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: `Basic ${auth}`,
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: new URLSearchParams({ From: from, To: to, Body: body }),
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      return { sent: false, reason: `twilio_${res.status}`, messageSid: text.slice(0, 200) };
-    }
-
-    const data = (await res.json()) as { sid?: string };
-    return { sent: true, messageSid: data.sid };
-  } catch {
-    return { sent: false, reason: "fetch_exception" };
-  }
+  return sendSmsEcall(to, body, from);
 }

--- a/src/web/src/lib/sms/sendSmsEcall.ts
+++ b/src/web/src/lib/sms/sendSmsEcall.ts
@@ -15,7 +15,7 @@ import type { SendSmsResult } from "./sendSms";
  * Sender logic:
  * - First tries the alphanumeric sender (e.g. "Weinberger")
  * - If rejected (400 invalid sender): retries with ECALL_SENDER_NUMBER
- * - Alphanumeric senders must be pre-approved in eCall portal
+ * - Alphanumeric senders need pre-approval in the eCall portal
  *
  * Phone format: eCall expects international format with 00 prefix (e.g. 0041791234567).
  * We accept E.164 (+41...) and convert automatically.

--- a/src/web/src/lib/tenants/getTenantSmsConfig.ts
+++ b/src/web/src/lib/tenants/getTenantSmsConfig.ts
@@ -2,17 +2,16 @@ import "server-only";
 
 import { getServiceClient } from "@/src/lib/supabase/server";
 
-export interface TenantSmsConfig {
-  senderName: string;
-  /** Tenant's Twilio phone number (E.164). Used as SMS sender to avoid spam filters. */
-  fromNumber: string | null;
-}
-
 /**
- * Read SMS config from the tenant's `modules` JSONB + first active phone number.
+ * Returns the alphanumeric sender name for eCall SMS.
+ * Fallback to ECALL_SENDER_NUMBER is handled by sendSmsEcall.ts.
  * Returns null if sms is not enabled or sms_sender_name is missing.
  * Never throws.
  */
+export interface TenantSmsConfig {
+  senderName: string;
+}
+
 export async function getTenantSmsConfig(
   tenantId: string,
 ): Promise<TenantSmsConfig | null> {
@@ -34,12 +33,7 @@ export async function getTenantSmsConfig(
     const senderName = modules.sms_sender_name;
     if (typeof senderName !== "string" || senderName.length === 0) return null;
 
-    // eCall is now the primary SMS provider (Swiss gateway, no spam issues).
-    // fromNumber is no longer needed — eCall accepts alphanumeric senders natively.
-    // Kept for potential future per-tenant number routing.
-    const fromNumber: string | null = null;
-
-    return { senderName, fromNumber };
+    return { senderName };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- **eCall.ch = einziger SMS-Provider (CH).** Twilio-SMS-Pfad komplett entfernt.
- **2-Tier Sender:** alphanumerisch (Tenant, z.B. "Weinberger") → ECALL_SENDER_NUMBER (FlowSight-Servicenummer)
- **Tote Logik entfernt:** `fromNumber`, `smsFromNumber`, `sendSmsTwilio()`, Twilio-Validation-Helper
- **Docs aligned:** zielarchitektur.md §12 komplett umgeschrieben, STATUS.md, env_vars.md, ticketlist.md

## Architekturentscheidung
Twilio verursacht Spam-Friktion bei Schweizer Empfängern. Ein Twilio-SMS-Fallback ist ein Fallback der nicht funktioniert → entfernt. eCall routet über Schweizer Carrier = keine Spam-Filter.

## Code-Änderungen
- `sendSms.ts`: Nur noch eCall-Aufruf + Whitelist-Guard (43 Zeilen statt 113)
- `sendSmsEcall.ts`: Kommentar-Korrektur (eCall braucht Portal-Freischaltung für Alpha-Sender)
- `getTenantSmsConfig.ts`: `fromNumber` entfernt, nur noch `senderName`
- `postCallSms.ts`: `smsFromNumber` entfernt
- 3 API routes: `fromNumber`-Referenzen entfernt

## Test plan
- [x] `npm run build` passes clean
- [ ] Founder: ECALL_SENDER_NUMBER setzen (FlowSight-Servicenummer)
- [ ] E2E: Testanruf → SMS muss ankommen

🤖 Generated with [Claude Code](https://claude.com/claude-code)