### PR TITLE
fix: SMS direct sender — always ECALL_SENDER_NUMBER

### DIFF
--- a/docs/architecture/env_vars.md
+++ b/docs/architecture/env_vars.md
@@ -49,7 +49,7 @@ Diese Datei ist eine Liste aller benötigten Env Vars + Herkunft. Keine Werte ei
 - ECALL_API_URL -> https://rest.ecall.ch/api/message (eCall REST endpoint)
 - ECALL_API_USERNAME -> eCall Portal → REST API User
 - ECALL_API_PASSWORD -> eCall Portal → REST API Passwort
-- ECALL_SENDER_NUMBER -> FlowSight-Servicenummer (E.164). Globaler Fallback wenn alphanumerischer Sender (Tier 1) vom eCall-Portal rejected wird. KEINE Founder-Privatnummer. Dedizierte CH-Nummer beschaffen (eCall oder Peoplefone).
+- ECALL_SENDER_NUMBER -> FlowSight-Servicenummer (E.164, +41766012739). IMMER als SMS-Absender verwendet. Firmenname steht im SMS-Text. KEINE Founder-Privatnummer.
 
 ## SMS (Post-Call Verification)
 - SMS_HMAC_SECRET -> selbst generiert (Bitwarden), für HMAC-SHA256 Token in Korrektur-Links

--- a/docs/architecture/zielarchitektur.md
+++ b/docs/architecture/zielarchitektur.md
@@ -570,21 +570,19 @@ Grund: Twilio-SMS via internationale Carrier verursachen Spam-Friktion bei Schwe
 └──────────────────────────────────────────────────┘
 ```
 
-### Sender-Logik (2-Tier)
+### Sender-Logik (1-Tier, direkt)
 
 ```
-Tier 1: tenant.modules.sms_sender_name
-        "Weinberger", "Doerfler" etc. (alphanumerisch)
-        Muss pro Tenant im eCall-Portal freigeschaltet sein
-        → Empfänger sieht: "Weinberger"
-
-        ↓ 400 rejected (nicht freigeschaltet)?
-
-Tier 2: ECALL_SENDER_NUMBER
-        FlowSight-Servicenummer (global, dedizierte CH-Nummer)
-        KEINE Founder-Privatnummer
-        → Empfänger sieht: +41 7x xxx xx xx + Text "Weinberger: Ihre Meldung..."
+ECALL_SENDER_NUMBER = +41766012739 (FlowSight-Servicenummer)
+→ Immer als Absender verwendet (keine alphanumerische Sender-Registrierung nötig)
+→ Empfänger sieht: +41766012739 + Text "Weinberger: Ihre Meldung..."
+→ Firmenname steht im SMS-Text, nicht im Absender-Feld
+→ Skaliert: Ein Sender für alle Tenants, kein Setup pro Betrieb
 ```
+
+Bewusste Entscheidung (14.03.): Alphanumerische Sender (z.B. "Weinberger" als Absendername)
+erfordern pro Tenant eine Freischaltung im eCall-Portal. Bei 50+ Betrieben = operativer Overhead.
+Stattdessen: Eine Nummer für alle, Firmenname im Text. Upgrade auf Alpha-Sender optional pro Tenant.
 
 ### SMS-Empfänger-Routing (unverändert)
 
@@ -610,13 +608,13 @@ postCallSms.ts  →  sendSms()  →  sendSmsEcall()  →  eCall REST API
 ### Produktionsreife-Checkliste
 
 - [x] eCall REST API Client (`sendSmsEcall.ts`)
-- [x] 2-Tier Sender-Fallback (alpha → Servicenummer)
 - [x] Twilio-SMS-Pfad entfernt
-- [ ] FlowSight-Servicenummer beschaffen (bei eCall oder dedizierte CH-Nummer)
-- [ ] ECALL_SENDER_NUMBER auf Vercel setzen (Servicenummer)
-- [ ] Alpha-Sender pro Tenant im eCall-Portal freischalten
+- [x] FlowSight-Servicenummer beschafft: +41766012739 (eCall)
+- [x] ECALL_SENDER_NUMBER auf Vercel gesetzt
+- [x] Direkt-Sender: ECALL_SENDER_NUMBER immer als Absender (kein Alpha-Fallback-Tanz)
 - [ ] SMS_ALLOWED_NUMBERS Whitelist entfernen (nach Go-Live-Entscheid)
 - [ ] Delivery-Status-Monitoring (eCall Status-Webhooks → Morning Report)
+- [ ] Optional: Alpha-Sender pro Tenant im eCall-Portal (UX-Upgrade, kein Blocker)
 
 ---
 

--- a/scripts/_ops/test_ecall.mjs
+++ b/scripts/_ops/test_ecall.mjs
@@ -18,16 +18,29 @@ if (!url || !user || !pass) {
 
 const auth = Buffer.from(`${user}:${pass}`).toString("base64");
 
-const targetNumber = process.argv[2] || "0041764458942";
-console.log("\nSending test SMS to:", targetNumber);
+const rawTarget = process.argv[2] || "+41764458942";
+const senderArg = process.argv[3] || undefined; // optional: --from <sender>
+const fromIdx = process.argv.indexOf("--from");
+const senderOverride = fromIdx >= 0 ? process.argv[fromIdx + 1] : undefined;
+
+// Convert E.164 to eCall format (0041...)
+function toEcall(num) { return num.startsWith("+") ? "00" + num.slice(1) : num; }
+
+const targetNumber = toEcall(rawTarget);
+const fallbackNumber = process.env.ECALL_SENDER_NUMBER;
+const sender = senderOverride || fallbackNumber || "FlowSight";
+
+console.log("\nSending test SMS to:", targetNumber, "(raw:", rawTarget, ")");
+console.log("Sender:", sender);
+if (fallbackNumber) console.log("ECALL_SENDER_NUMBER:", fallbackNumber);
 
 const payload = {
   channel: "sms",
-  from: "FlowSight",
+  from: sender,
   to: targetNumber,
   content: {
     type: "Text",
-    text: "eCall Test — FlowSight SMS Integration Check 14.03.2026",
+    text: `eCall Test — FlowSight SMS via sender "${sender}" — ${new Date().toISOString()}`,
   },
 };
 

--- a/src/web/src/lib/sms/sendSmsEcall.ts
+++ b/src/web/src/lib/sms/sendSmsEcall.ts
@@ -10,12 +10,11 @@ import type { SendSmsResult } from "./sendSms";
  * - ECALL_API_URL (e.g. https://rest.ecall.ch/api/message)
  * - ECALL_API_USERNAME
  * - ECALL_API_PASSWORD
- * - ECALL_SENDER_NUMBER (optional) — fallback E.164 number if alphanumeric sender is rejected
+ * - ECALL_SENDER_NUMBER (required) — FlowSight service number (E.164), always used as sender
  *
- * Sender logic:
- * - First tries the alphanumeric sender (e.g. "Weinberger")
- * - If rejected (400 invalid sender): retries with ECALL_SENDER_NUMBER
- * - Alphanumeric senders need pre-approval in the eCall portal
+ * Sender: Always ECALL_SENDER_NUMBER (dedicated FlowSight CH number).
+ * The tenant/brand name is embedded in the SMS body text, not the sender field.
+ * This avoids alphanumeric sender approval per tenant in eCall portal.
  *
  * Phone format: eCall expects international format with 00 prefix (e.g. 0041791234567).
  * We accept E.164 (+41...) and convert automatically.
@@ -31,78 +30,52 @@ function toEcallNumber(e164: string): string {
   return e164;
 }
 
-async function callEcallApi(
-  apiUrl: string,
-  auth: string,
-  to: string,
-  body: string,
-  from: string,
-): Promise<{ ok: boolean; status: number; text: string; messageId?: string }> {
-  const res = await fetch(apiUrl, {
-    method: "POST",
-    headers: {
-      Authorization: `Basic ${auth}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      channel: "sms",
-      from,
-      to: toEcallNumber(to),
-      content: {
-        type: "Text",
-        text: body,
-      },
-    }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    return { ok: false, status: res.status, text };
-  }
-
-  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-  const messageId = (data.id ?? data.messageId ?? data.message_id ?? "") as string;
-  return { ok: true, status: res.status, text: "", messageId };
-}
-
 export async function sendSmsEcall(
   to: string,
   body: string,
-  from: string,
+  _from: string,
 ): Promise<SendSmsResult> {
   const apiUrl = process.env.ECALL_API_URL;
   const username = process.env.ECALL_API_USERNAME;
   const password = process.env.ECALL_API_PASSWORD;
+  const senderNumber = process.env.ECALL_SENDER_NUMBER;
 
   if (!apiUrl || !username || !password) {
     return { sent: false, reason: "ecall_missing_env" };
   }
 
+  if (!senderNumber) {
+    return { sent: false, reason: "ecall_missing_sender_number" };
+  }
+
   try {
     const auth = Buffer.from(`${username}:${password}`).toString("base64");
 
-    // Try with requested sender (alphanumeric or number)
-    const result = await callEcallApi(apiUrl, auth, to, body, from);
+    const res = await fetch(apiUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        channel: "sms",
+        from: toEcallNumber(senderNumber),
+        to: toEcallNumber(to),
+        content: {
+          type: "Text",
+          text: body,
+        },
+      }),
+    });
 
-    if (result.ok) {
-      return { sent: true, messageSid: result.messageId || "ecall_ok" };
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return { sent: false, reason: `ecall_${res.status}`, messageSid: text.slice(0, 300) };
     }
 
-    // If alphanumeric sender was rejected (400), retry with fallback number
-    const fallbackNumber = process.env.ECALL_SENDER_NUMBER;
-    if (result.status === 400 && fallbackNumber && from !== fallbackNumber) {
-      const fallbackResult = await callEcallApi(
-        apiUrl, auth, to, body, toEcallNumber(fallbackNumber),
-      );
-
-      if (fallbackResult.ok) {
-        return { sent: true, messageSid: fallbackResult.messageId || "ecall_ok_fallback" };
-      }
-
-      return { sent: false, reason: `ecall_fallback_${fallbackResult.status}`, messageSid: fallbackResult.text.slice(0, 300) };
-    }
-
-    return { sent: false, reason: `ecall_${result.status}`, messageSid: result.text.slice(0, 300) };
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const messageId = (data.id ?? data.messageId ?? data.message_id ?? "") as string;
+    return { sent: true, messageSid: messageId || "ecall_ok" };
   } catch {
     return { sent: false, reason: "ecall_fetch_exception" };
   }


### PR DESCRIPTION
## Summary
- **ECALL_SENDER_NUMBER wird immer als SMS-Absender verwendet**
- Kein alphanumerischer Sender-Versuch mehr (scheiterte immer mit 400)
- Eliminiert doppelten API-Call pro SMS (Latenz halbiert)
- Firmenname steht im SMS-Body: "Weinberger: Ihre Meldung..."
- Skaliert: Ein Sender für alle Tenants, kein Portal-Setup pro Betrieb

## Verified
- eCall Test-SMS mit +41766012739 als Sender: **kommt an**
- eCall Test-SMS mit alphanumerischem Sender: **kommt NICHT an**

## Test plan
- [x] `npm run build` passes
- [ ] Founder: Testanruf Weinberger → SMS muss ankommen von +41766012739

🤖 Generated with [Claude Code](https://claude.com/claude-code)