### PR TITLE
fix: auto-unpin phone versions + SMS shows reporter name

### DIFF
--- a/retell/agent_ids.json
+++ b/retell/agent_ids.json
@@ -4,14 +4,14 @@
     "de_flow_id": "conversation_flow_e2c3a7cec528",
     "intl_agent_id": "agent_01fad4217f8b0697f0c26c69d5",
     "intl_flow_id": "conversation_flow_3c7d423226a9",
-    "last_synced": "2026-03-14T06:07:06.336Z"
+    "last_synced": "2026-03-14T08:03:13.639Z"
   },
   "doerfler": {
     "de_agent_id": "agent_d7dfe45ab444e1370e836c3e0f",
     "de_flow_id": "conversation_flow_8170ad3c2ca9",
     "intl_agent_id": "agent_fb4b956eec31db9c591880fdeb",
     "intl_flow_id": "conversation_flow_608d542979bb",
-    "last_synced": "2026-03-14T06:07:09.122Z"
+    "last_synced": "2026-03-14T08:03:10.704Z"
   },
   "flowsight_sales": {
     "de_agent_id": "agent_6515d8d1f23072ce61db806901",
@@ -25,13 +25,13 @@
     "de_flow_id": "conversation_flow_4254de993a58",
     "intl_agent_id": "agent_0976aabe2c12ab0ca4d48933a5",
     "intl_flow_id": "conversation_flow_ac5b3603b478",
-    "last_synced": "2026-03-14T06:07:03.329Z"
+    "last_synced": "2026-03-14T08:03:00.428Z"
   },
   "walter-leuthold": {
     "de_agent_id": "agent_de6242e8d8a98244e18e762ea8",
     "de_flow_id": "conversation_flow_fff73f294502",
     "intl_agent_id": "agent_ae0185d3494461f8bb2c7e8369",
     "intl_flow_id": "conversation_flow_f50db5e3f3c8",
-    "last_synced": "2026-03-14T06:07:12.095Z"
+    "last_synced": "2026-03-14T08:03:16.932Z"
   }
 }

--- a/scripts/_ops/retell_sync.mjs
+++ b/scripts/_ops/retell_sync.mjs
@@ -110,6 +110,15 @@ async function retellPost(urlPath, body) {
   return data;
 }
 
+async function retellGet(urlPath) {
+  const res = await fetch(`${RETELL_BASE}${urlPath}`, { headers: hdrs });
+  const data = await res.json().catch(() => null);
+  if (!res.ok) {
+    throw new Error(`GET ${urlPath} → ${res.status}: ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
 async function retellPatch(urlPath, body) {
   const res = await fetch(`${RETELL_BASE}${urlPath}`, {
     method: "PATCH",
@@ -323,6 +332,31 @@ try {
 
   await retellPost(`/publish-agent/${intlAgentId}`, {});
   console.log(`  ✓ INTL agent published`);
+  console.log("");
+
+  // ── Step 4b: Unpin phone number versions ──────────────────────────
+  // Phone numbers can be pinned to a specific agent version. After publish,
+  // reassign to ensure calls use the latest published version.
+  console.log("━━━ Step 4b: Unpin phone number versions ━━━\n");
+
+  async function unpinPhoneNumbers(agentId) {
+    try {
+      const phones = await retellGet("/list-phone-numbers");
+      for (const p of phones) {
+        if (p.inbound_agent_id === agentId && p.inbound_agent_version != null) {
+          await retellPatch(`/update-phone-number/${encodeURIComponent(p.phone_number)}`, {
+            inbound_agent_id: agentId,
+          });
+          console.log(`  ✓ ${p.phone_number} unpinned (was v${p.inbound_agent_version})`);
+        }
+      }
+    } catch (e) {
+      console.log(`  ⚠ Could not unpin phone numbers: ${e.message}`);
+    }
+  }
+
+  await unpinPhoneNumbers(deAgentId);
+  await unpinPhoneNumbers(intlAgentId);
   console.log("");
 
   // ── Step 5: Save IDs ────────────────────────────────────────────────

--- a/src/web/app/api/cases/route.ts
+++ b/src/web/app/api/cases/route.ts
@@ -328,6 +328,7 @@ export async function POST(request: NextRequest) {
           category: data.category,
           street: data.street,
           houseNumber: data.house_number,
+          reporterName: data.reporter_name,
         });
         if (smsResult.sent) {
           await supabase.from("case_events").insert({

--- a/src/web/app/api/retell/webhook/route.ts
+++ b/src/web/app/api/retell/webhook/route.ts
@@ -568,6 +568,7 @@ export async function POST(req: Request) {
           category: category!,
           street: street ?? undefined,
           houseNumber: houseNumber ?? undefined,
+          reporterName: reporterName ?? undefined,
         });
         smsSent = smsResult.sent;
         smsSid = smsResult.messageSid;

--- a/src/web/src/lib/sms/postCallSms.ts
+++ b/src/web/src/lib/sms/postCallSms.ts
@@ -13,10 +13,12 @@ export interface PostCallSmsPayload {
   category: string;
   street?: string;
   houseNumber?: string;
+  reporterName?: string;
 }
 
 /**
  * Build and send the post-call confirmation SMS with correction link.
+ * Shows captured data so the reporter can verify — reduces callbacks.
  * Never throws — returns SendSmsResult.
  */
 export async function sendPostCallSms(
@@ -32,24 +34,29 @@ export async function sendPostCallSms(
 
   const hasStreet = p.street && p.street.length > 0;
 
-  const addressBlock = hasStreet
-    ? `Erfasste Adresse:\n${p.street}${p.houseNumber ? ` ${p.houseNumber}` : ""}, ${p.plz} ${p.city}`
-    : `Erfasster Ort: ${p.plz} ${p.city}`;
+  const addressLine = hasStreet
+    ? `${p.street}${p.houseNumber ? ` ${p.houseNumber}` : ""}, ${p.plz} ${p.city}`
+    : `${p.plz} ${p.city}`;
 
-  const correctionCta = hasStreet
-    ? `Stimmt alles? Haben Sie Fotos vom Schaden?`
-    : `Bitte ergänzen Sie Ihre Adresse. Fotos vom Schaden helfen uns:`;
-
-  const body = [
+  const lines: string[] = [
     `${p.smsSenderName}: Ihre Meldung (${p.category}) wurde aufgenommen.`,
     ``,
-    addressBlock,
-    ``,
-    correctionCta,
-    correctionUrl,
-    ``,
-    `Ihr Service-Team meldet sich schnellstmöglich.`,
-  ].join("\n");
+  ];
 
-  return sendSms(p.callerPhone, body, p.smsSenderName);
+  if (p.reporterName) {
+    lines.push(`Name: ${p.reporterName}`);
+  }
+  lines.push(`Adresse: ${addressLine}`);
+  lines.push(``);
+
+  if (!hasStreet || !p.reporterName) {
+    lines.push(`Bitte prüfen und ggf. ergänzen:`);
+  } else {
+    lines.push(`Stimmt alles? Fotos helfen uns:`);
+  }
+  lines.push(correctionUrl);
+  lines.push(``);
+  lines.push(`Ihr Service-Team meldet sich schnellstmöglich.`);
+
+  return sendSms(p.callerPhone, lines.join("\n"), p.smsSenderName);
 }


### PR DESCRIPTION
## Summary
- **Root cause fix for ALL voice agent failures (V2/V3/V6):** Retell phone numbers had `inbound_agent_version` pinned to v1 — publish had zero effect. `retell_sync.mjs` Step 4b now auto-unpins after every publish.
- **SMS quality:** `postCallSms` now shows reporter name + captured address for verification, with contextual CTA (verify vs. complete missing data).
- Both voice webhook and cases API route updated to pass `reporterName`.

## Test plan
- [ ] Founder: Testanruf Weinberger → V2 (kein "Jul"), V3 (kein Ort-Echo), V6 (Namensfrage)
- [ ] Founder: SMS kommt an mit Name + Adresse + korrektem Link
- [ ] retell_sync.mjs: bei nächstem Sync prüfen dass Step 4b loggt "unpinned"

🤖 Generated with [Claude Code](https://claude.com/claude-code)