### PR TITLE
fix: STOPP deltas — tenant branding in Leitstand (D8, R4)

### DIFF
--- a/src/web/app/ops/(dashboard)/layout.tsx
+++ b/src/web/app/ops/(dashboard)/layout.tsx
@@ -9,19 +9,23 @@ import { OpsShell } from "@/src/components/ops/OpsShell";
  * Falls back to "Leitstand" for admin or when no tenant is scoped.
  * Never shows "FlowSight" (R4).
  */
+/**
+ * Tab title: "{short_name} Leitstand" — Identity Contract E2.
+ * Uses title.absolute to bypass root layout's " — FlowSight" template (R4).
+ */
 export async function generateMetadata(): Promise<Metadata> {
   try {
     const authClient = await getAuthClient();
     const {
       data: { user },
     } = await authClient.auth.getUser();
-    if (!user) return { title: "Leitstand" };
+    if (!user) return { title: { absolute: "Leitstand" } };
 
     const identity = await resolveTenantIdentity(user);
     const tabLabel = identity?.shortName ?? "Leitstand";
-    return { title: `${tabLabel} Leitstand` };
+    return { title: { absolute: `${tabLabel} Leitstand` } };
   } catch {
-    return { title: "Leitstand" };
+    return { title: { absolute: "Leitstand" } };
   }
 }
 
@@ -39,7 +43,11 @@ export default async function DashboardLayout({
   const identity = await resolveTenantIdentity(user);
 
   return (
-    <OpsShell userEmail={user.email ?? ""} tenantName={identity?.displayName ?? undefined}>
+    <OpsShell
+      userEmail={user.email ?? ""}
+      tenantName={identity?.displayName ?? undefined}
+      brandColor={identity?.primaryColor ?? undefined}
+    >
       {children}
     </OpsShell>
   );

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -63,10 +63,13 @@ const NAV_ITEMS: NavItem[] = [
 export function OpsShell({
   userEmail,
   tenantName,
+  brandColor,
   children,
 }: {
   userEmail: string;
   tenantName?: string;
+  /** Tenant brand color hex (e.g. "#004994"). Falls back to amber if not set. */
+  brandColor?: string;
   children: React.ReactNode;
 }) {
   // Identity Contract R4: No "FlowSight" visible to end users
@@ -78,22 +81,26 @@ export function OpsShell({
         .map((w) => w[0]?.toUpperCase() ?? "")
         .join("")
     : "LS";
+  const color = brandColor ?? "#d97706"; // fallback amber-600
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const pathname = usePathname();
 
   const sidebarContent = (
     <>
-      {/* Logo */}
+      {/* Logo — Identity Contract R4: Tenant branding, not FlowSight */}
       <div className="px-4 py-5 border-b border-gray-200">
         <Link href="/ops/cases" className="flex items-center gap-2">
-          <div className="w-8 h-8 rounded-lg bg-amber-500 flex items-center justify-center">
+          <div
+            className="w-8 h-8 rounded-lg flex items-center justify-center"
+            style={{ backgroundColor: color }}
+          >
             <span className="text-white font-bold text-sm">{initials}</span>
           </div>
           <span className="font-bold text-gray-900 truncate">{displayName}</span>
         </Link>
       </div>
 
-      {/* Navigation */}
+      {/* Navigation — active state uses tenant brand color */}
       <nav className="flex-1 px-3 py-4 space-y-1">
         {NAV_ITEMS.map((item) => {
           const isActive = pathname.startsWith(item.href);
@@ -104,9 +111,18 @@ export function OpsShell({
               onClick={() => setSidebarOpen(false)}
               className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
                 isActive
-                  ? "bg-amber-50 text-amber-700 border-l-2 border-amber-500 -ml-px"
+                  ? "border-l-2 -ml-px"
                   : "text-gray-700 hover:bg-gray-50 hover:text-gray-900"
               }`}
+              style={
+                isActive
+                  ? {
+                      backgroundColor: `${color}10`,
+                      color: color,
+                      borderColor: color,
+                    }
+                  : undefined
+              }
             >
               {item.icon}
               <span>{item.label}</span>
@@ -149,7 +165,10 @@ export function OpsShell({
           </svg>
         </button>
         <Link href="/ops/cases" className="flex items-center gap-2">
-          <div className="w-7 h-7 rounded-lg bg-amber-500 flex items-center justify-center">
+          <div
+            className="w-7 h-7 rounded-lg flex items-center justify-center"
+            style={{ backgroundColor: color }}
+          >
             <span className="text-white font-bold text-xs">{initials}</span>
           </div>
           <span className="font-semibold text-gray-900 text-sm truncate max-w-[160px]">{displayName}</span>

--- a/src/web/src/lib/tenants/resolveTenantIdentity.ts
+++ b/src/web/src/lib/tenants/resolveTenantIdentity.ts
@@ -67,11 +67,13 @@ export async function resolveTenantIdentity(
       }
     }
 
-    // Fallback: single-tenant MVP
+    // Fallback: pick first tenant (admin without tenant_id, or single-tenant MVP).
+    // Admin sees all cases via RLS anyway — this just provides branding context.
     const { data: tenants } = await supabase
       .from("tenants")
       .select("id, name, slug, case_id_prefix, modules")
-      .limit(2);
+      .order("created_at", { ascending: true })
+      .limit(1);
 
     if (tenants && tenants.length === 1) {
       const t = tenants[0];


### PR DESCRIPTION
## Summary
- **OpsShell**: `brandColor` prop replaces all hardcoded `bg-amber-500` (avatar, nav, mobile header)
- **resolveTenantIdentity**: admin without `tenant_id` falls back to first tenant (fixes null identity)
- **Tab title**: `title.absolute` prevents root layout's " — FlowSight" template suffix
- **DB**: `primary_color` set on Weinberger (#004994), Doerfler (#2b6cb0), Brunner (#0d7377)

## QA Sweep Deltas Fixed (6/6)
| Severity | ID | Issue |
|----------|-----|-------|
| STOPP | IC_SIDEBAR_INITIALS | "LS" → tenant initials |
| STOPP | IC_SIDEBAR_NAME | "Leitstand" → display_name |
| STOPP | IC_BRAND_COLOR | amber → tenant color |
| STOPP | IC_TAB_FLOWSIGHT | " — FlowSight" removed |
| SYSTEM | IC_NAV_COLOR | amber nav → tenant color |
| SYSTEM | IC_TAB_NAME | tab shows tenant short_name |

## Test plan
- [ ] Re-run `qa_sweep.mjs --tenant=weinberger-ag` → 0 STOPP expected
- [ ] Visual: sidebar shows "JW" in blue (#004994), not "LS" in amber
- [ ] Tab title: "Weinberger Leitstand" (no FlowSight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)