### PR TITLE
fix: website nav brand accent + case list polish

### DIFF
--- a/src/web/app/kunden/[slug]/page.tsx
+++ b/src/web/app/kunden/[slug]/page.tsx
@@ -90,8 +90,10 @@ export default async function CustomerPage({
 /* ── Navigation ──────────────────────────────────────────────────── */
 function Nav({ company: c, accent, wizardUrl }: { company: CustomerSite; accent: string; wizardUrl: string }) {
   return (
-    <nav className="sticky top-0 z-50 border-b border-gray-100 bg-white/95 backdrop-blur-sm">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+    <nav className="sticky top-0 z-50 bg-white/95 backdrop-blur-sm shadow-sm">
+      {/* Brand accent bar */}
+      <div className="h-1" style={{ backgroundColor: accent }} />
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-3">
         <a href={`/kunden/${c.slug}`} className="text-xl font-bold" style={{ color: accent }}>
           {c.companyName}
         </a>
@@ -100,22 +102,26 @@ function Nav({ company: c, accent, wizardUrl }: { company: CustomerSite; accent:
           {c.reviews && <a href="#bewertungen" className="text-sm text-gray-600 transition-colors hover:text-gray-900">Bewertungen</a>}
           {c.team.length > 1 && <a href="#team" className="text-sm text-gray-600 transition-colors hover:text-gray-900">Team</a>}
           <a href="#kontakt" className="text-sm text-gray-600 transition-colors hover:text-gray-900">Kontakt</a>
+          <a href={`tel:${c.contact.phoneRaw}`} className="text-sm font-semibold text-gray-700 hover:text-gray-900 transition-colors">
+            {c.contact.phone}
+          </a>
           {c.emergency?.enabled ? (
             <a href={`tel:${c.emergency.phoneRaw}`} className="rounded-lg bg-[#c41e3a] px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90">
               {c.emergency.label}
             </a>
           ) : (
-            <a href={`tel:${c.contact.phoneRaw}`} className="rounded-lg px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90" style={{ backgroundColor: accent }}>
-              Anrufen
+            <a href={wizardUrl} className="rounded-lg px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90" style={{ backgroundColor: accent }}>
+              Anliegen melden
             </a>
           )}
         </div>
         <div className="flex items-center gap-2 md:hidden">
-          <a href="#kontakt" className="text-sm text-gray-600">Kontakt</a>
           {c.emergency?.enabled ? (
             <a href={`tel:${c.emergency.phoneRaw}`} className="rounded-lg bg-[#c41e3a] px-4 py-2 text-sm font-bold text-white">Notfall</a>
           ) : (
-            <a href={`tel:${c.contact.phoneRaw}`} className="rounded-lg px-4 py-2 text-sm font-bold text-white" style={{ backgroundColor: accent }}>Anrufen</a>
+            <a href={`tel:${c.contact.phoneRaw}`} className="rounded-lg px-4 py-2 text-sm font-bold text-white" style={{ backgroundColor: accent }}>
+              {c.contact.phone}
+            </a>
           )}
         </div>
       </div>
@@ -195,13 +201,13 @@ function ServicesSection({
   const galleryMap = new Map(gallery.map((g) => [g.slug, g.images]));
 
   return (
-    <section id="leistungen" className="py-20">
+    <section id="leistungen" className="py-14">
       <div className="mx-auto max-w-6xl px-6">
         <div className="text-center">
           <h2 className="text-3xl font-bold sm:text-4xl">Unsere Leistungen</h2>
           <p className="mt-3 text-lg text-gray-600">Kompetenz aus einer Hand — von {companyName}</p>
         </div>
-        <div className="mt-14 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
           {services.map((s) => {
             const imgs = galleryMap.get(s.slug) ?? [];
             return (

--- a/src/web/src/components/ops/CaseListClient.tsx
+++ b/src/web/src/components/ops/CaseListClient.tsx
@@ -201,7 +201,7 @@ export function CaseListClient({
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Name, Adresse, Kategorie…"
-                className="rounded-lg border border-gray-300 bg-white pl-8 pr-3 py-2 text-xs text-gray-700 placeholder:text-gray-400 w-52 focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
+                className="rounded-lg border border-gray-300 bg-white pl-8 pr-3 py-2 text-xs text-gray-700 placeholder:text-gray-400 w-52 focus:outline-none focus:ring-2 focus:ring-slate-400/30 focus:border-slate-400"
               />
             </div>
             {search !== searchQuery && (
@@ -280,7 +280,7 @@ export function CaseListClient({
                     <td className="px-4 py-3">
                       <Link
                         href={`/ops/cases/${c.id}`}
-                        className="text-amber-600 hover:text-amber-700 font-medium hover:underline"
+                        className="text-slate-700 hover:text-slate-900 font-medium hover:underline"
                       >
                         {formatCaseId(c.seq_number, caseIdPrefix)}
                       </Link>
@@ -291,11 +291,13 @@ export function CaseListClient({
                     <td className="px-4 py-3 text-gray-600 max-w-[180px] truncate">
                       {formatAddress(c)}
                     </td>
-                    <td className="px-4 py-3 text-gray-700 max-w-[200px]">
-                      <span className="font-medium">{c.category}</span>
-                      {c.description && (
-                        <span className="text-gray-400"> — {truncate(c.description, 40)}</span>
-                      )}
+                    <td className="px-4 py-3 text-gray-700 max-w-[220px]">
+                      <div className="truncate">
+                        <span className="font-medium">{c.category}</span>
+                        {c.description && (
+                          <span className="text-gray-400"> — {truncate(c.description, 50)}</span>
+                        )}
+                      </div>
                     </td>
                     <td className="px-4 py-3 text-gray-500">
                       <span className="mr-1">{SOURCE_ICON[c.source] ?? ""}</span>
@@ -341,11 +343,11 @@ export function CaseListClient({
               <Link
                 key={c.id}
                 href={`/ops/cases/${c.id}`}
-                className="block bg-white rounded-xl border border-gray-200 p-4 hover:border-amber-300 transition-colors"
+                className="block bg-white rounded-xl border border-gray-200 p-4 hover:border-gray-300 hover:shadow-sm transition-colors"
               >
                 <div className="flex items-start justify-between mb-2">
                   <div>
-                    <span className="text-amber-600 font-medium text-sm">
+                    <span className="text-slate-700 font-medium text-sm">
                       {formatCaseId(c.seq_number, caseIdPrefix)}
                     </span>
                     {c.reporter_name && (


### PR DESCRIPTION
## Summary
- Website nav: brand-color accent bar, visible phone number, wizard CTA
- Services section: tighter spacing (less excessive whitespace)
- Case list: amber→slate links (brand identity via sidebar header now)
- Case list: description truncation fix for text overflow

Fixes QA Sweep findings: VIS_WEB_001, VIS_WEB_002, VIS_WEB_003, VIS_OPS_003, VIS_OPS_005

## Test plan
- [ ] Website `/kunden/weinberger-ag`: blue accent bar visible at top of nav
- [ ] Website nav: phone number visible as text on desktop
- [ ] Services section: less whitespace between heading and cards
- [ ] Leitstand case list: links are slate (not amber), description truncates cleanly
- [ ] Mobile case cards: neutral hover state

🤖 Generated with [Claude Code](https://claude.com/claude-code)