### PR TITLE
feat: Leitsystem-Schärfung — Tenant-Wahrheit, Überblick, Quickfilter

### DIFF
--- a/src/web/app/api/ops/metrics/route.ts
+++ b/src/web/app/api/ops/metrics/route.ts
@@ -47,11 +47,14 @@ export async function GET() {
   return NextResponse.json({
     totalCases: cases.length,
     openCases: openCases.length,
+    newThisWeek: cases.filter((c) => new Date(c.created_at).getTime() > weekAgo).length,
+    newThisMonth: cases.filter((c) => new Date(c.created_at).getTime() > monthAgo).length,
     resolvedThisWeek: doneCases.filter((c) => new Date(c.updated_at).getTime() > weekAgo).length,
     resolvedThisMonth: doneCases.filter((c) => new Date(c.updated_at).getTime() > monthAgo).length,
     avgResolutionHours,
     notfallCount: cases.filter((c) => c.urgency === "notfall").length,
     voiceCases: cases.filter((c) => c.source === "voice").length,
     wizardCases: cases.filter((c) => c.source === "wizard").length,
+    manualCases: cases.filter((c) => c.source === "manual").length,
   });
 }

--- a/src/web/app/api/ops/settings/route.ts
+++ b/src/web/app/api/ops/settings/route.ts
@@ -41,7 +41,7 @@ export async function GET() {
     tenant_id: data.id,
     tenant_name: data.name,
     tenant_slug: data.slug,
-    case_id_prefix: data.case_id_prefix ?? "FS",
+    case_id_prefix: data.case_id_prefix,
     settings: {
       google_review_url: (modules.google_review_url as string) ?? "",
       default_appointment_duration_min: (modules.default_appointment_duration_min as number) ?? 60,

--- a/src/web/app/ops/(dashboard)/faelle/page.tsx
+++ b/src/web/app/ops/(dashboard)/faelle/page.tsx
@@ -100,6 +100,7 @@ export default async function FaellePage({
   if (filterCategory) listQuery = listQuery.ilike("category", filterCategory);
   if (filterSource) listQuery = listQuery.eq("source", filterSource);
   if (filterAssigned === "yes") listQuery = listQuery.not("assignee_text", "is", null);
+  if (filterAssigned === "no") listQuery = listQuery.is("assignee_text", null);
 
   // Text search
   if (filterQuery) {
@@ -159,11 +160,69 @@ export default async function FaellePage({
     return `/ops/faelle${qs ? `?${qs}` : ""}`;
   }
 
-  const hasActiveFilters = !!(filterStatus || filterUrgency || filterSource);
+  const hasActiveFilters = !!(filterStatus || filterUrgency || filterSource || filterAssigned);
+
+  // Quickfilter chip helper
+  function quickHref(overrides: Record<string, string>): string {
+    const p = new URLSearchParams();
+    if (filterTenantSlug) p.set("tenant", filterTenantSlug);
+    if (showDemo) p.set("tab", "demo");
+    for (const [k, v] of Object.entries(overrides)) {
+      if (v) p.set(k, v);
+    }
+    if (filterQuery) p.set("q", filterQuery);
+    const qs = p.toString();
+    return `/ops/faelle${qs ? `?${qs}` : ""}`;
+  }
+
+  const QUICK_FILTERS = [
+    { label: "Neu", href: quickHref({ status: "new" }), active: filterStatus === "new" },
+    { label: "Bei uns", href: quickHref({ status: "in_progress" }), active: filterStatus === "in_progress" },
+    { label: "Abschluss", href: quickHref({ status: "done", show: "all" }), active: filterStatus === "done" },
+    { label: "Kritisch", href: quickHref({ urgency: "notfall" }), active: filterUrgency === "notfall" && !filterStatus },
+    { label: "Unzugewiesen", href: quickHref({ assigned: "no" }), active: filterAssigned === "no" && !filterStatus },
+  ];
 
   return (
     <>
-      {/* Filters row */}
+      {/* Quickfilter chips — semantic betriebsnahe Schnellzugriffe */}
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        <Link
+          href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}${showDemo ? "&tab=demo" : ""}` : `/ops/faelle${showDemo ? "?tab=demo" : ""}`}
+          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+            !hasActiveFilters && !showAll
+              ? "bg-slate-800 text-white"
+              : "bg-white text-gray-600 border border-gray-200 hover:border-gray-300"
+          }`}
+        >
+          Offen
+        </Link>
+        {QUICK_FILTERS.map((qf) => (
+          <Link
+            key={qf.label}
+            href={qf.href}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              qf.active
+                ? "bg-slate-800 text-white"
+                : "bg-white text-gray-600 border border-gray-200 hover:border-gray-300"
+            }`}
+          >
+            {qf.label}
+          </Link>
+        ))}
+        <Link
+          href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}&show=all${showDemo ? "&tab=demo" : ""}` : `/ops/faelle?show=all${showDemo ? "&tab=demo" : ""}`}
+          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+            showAll && !filterStatus && !filterUrgency && !filterAssigned
+              ? "bg-slate-800 text-white"
+              : "bg-white text-gray-600 border border-gray-200 hover:border-gray-300"
+          }`}
+        >
+          Alle
+        </Link>
+      </div>
+
+      {/* Secondary filters */}
       <div className="bg-white border border-gray-200 rounded-xl p-3 mb-5">
         <div className="flex flex-wrap items-center gap-3">
           {/* Demo/Real tab toggle */}
@@ -176,7 +235,7 @@ export default async function FaellePage({
                   : "bg-white text-gray-600 hover:bg-gray-50"
               }`}
             >
-              Ihre F\u00e4lle
+              Ihre Fälle
             </Link>
             <Link
               href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}&tab=demo` : "/ops/faelle?tab=demo"}
@@ -192,33 +251,7 @@ export default async function FaellePage({
 
           <span className="border-l border-gray-200 h-6 inline-block" />
 
-          {/* View toggle */}
-          <div className="flex rounded-lg border border-gray-200 overflow-hidden">
-            <Link
-              href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}${showDemo ? "&tab=demo" : ""}` : `/ops/faelle${showDemo ? "?tab=demo" : ""}`}
-              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                !showAll && !filterStatus
-                  ? "bg-slate-700 text-white"
-                  : "bg-white text-gray-600 hover:bg-gray-50"
-              }`}
-            >
-              Offen
-            </Link>
-            <Link
-              href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}&show=all${showDemo ? "&tab=demo" : ""}` : `/ops/faelle?show=all${showDemo ? "&tab=demo" : ""}`}
-              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                showAll && !filterStatus
-                  ? "bg-slate-700 text-white"
-                  : "bg-white text-gray-600 hover:bg-gray-50"
-              }`}
-            >
-              Alle
-            </Link>
-          </div>
-
-          <span className="border-l border-gray-200 h-6 inline-block" />
-
-          {/* Filter dropdowns */}
+          {/* Detail filters */}
           <FilterSelect options={STATUS_OPTIONS} value={filterStatus} paramKey="status" filterHref={filterHref} />
           <FilterSelect options={URGENCY_OPTIONS} value={filterUrgency} paramKey="urgency" filterHref={filterHref} />
           <FilterSelect options={SOURCE_OPTIONS} value={filterSource} paramKey="source" filterHref={filterHref} />
@@ -229,7 +262,7 @@ export default async function FaellePage({
               href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}` : "/ops/faelle"}
               className="text-xs text-gray-400 hover:text-gray-600 transition-colors ml-1"
             >
-              Filter zur\u00fccksetzen
+              Zurücksetzen
             </Link>
           )}
         </div>

--- a/src/web/app/ops/(dashboard)/settings/page.tsx
+++ b/src/web/app/ops/(dashboard)/settings/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useState } from "react";
 
 interface Settings {
@@ -77,32 +76,46 @@ export default function SettingsPage() {
   }
 
   if (loading) {
-    return <p className="text-sm text-gray-400 py-8 text-center">Laden…</p>;
+    return <p className="text-sm text-gray-400 py-12 text-center">Laden…</p>;
   }
 
   return (
     <div>
-      <div className="mb-6">
+      <div className="mb-8">
         <h2 className="text-lg font-bold text-gray-900">Einstellungen</h2>
-        <p className="text-sm text-gray-500">
-          Konfiguration für {data?.tenant_name ?? "Ihren Betrieb"}
-        </p>
+        {data?.tenant_name && (
+          <p className="text-sm text-gray-500">{data.tenant_name}</p>
+        )}
       </div>
 
-      {/* Quick links */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-8">
-        <NavCard href="/ops/staff" label="Mitarbeiter" sub="Verwalten" color="amber" />
-        <NavCard href="/ops/metrics" label="Kennzahlen" sub="Trends" color="emerald" />
-        <NavCard href="/ops/schedule" label="Einsatzplan" sub="Termine" color="blue" />
+      {/* Betriebsinformationen — prominent, read-only */}
+      <div className="bg-white border border-gray-200 rounded-xl p-5 mb-6">
+        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
+          Betrieb
+        </h3>
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <p className="text-gray-400 text-xs mb-0.5">Betriebsname</p>
+            <p className="text-gray-900 font-medium">
+              {data?.tenant_name ?? "—"}
+            </p>
+          </div>
+          <div>
+            <p className="text-gray-400 text-xs mb-0.5">Fall-Präfix</p>
+            <p className="text-gray-900 font-medium">
+              {data?.case_id_prefix ?? "—"}
+            </p>
+          </div>
+        </div>
       </div>
 
-      {/* Settings sections */}
-      <div className="space-y-6">
-        {/* Google Review Link */}
-        <Section title="Google-Bewertungen" description="Link zu Ihrem Google-Bewertungsprofil. Wird in Review-Anfragen verwendet.">
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">
-            Google Review URL
-          </label>
+      {/* Editable settings */}
+      <div className="space-y-5">
+        {/* Google Review */}
+        <Section
+          title="Google-Bewertungen"
+          description="Link zu Ihrem Google-Bewertungsprofil. Wird in Review-Anfragen verwendet."
+        >
           <input
             type="url"
             value={googleReviewUrl}
@@ -111,14 +124,18 @@ export default function SettingsPage() {
             className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400"
           />
           <p className="mt-1.5 text-xs text-gray-400">
-            Tipp: Suchen Sie Ihren Betrieb auf Google Maps → &quot;Rezension schreiben&quot; → Link kopieren
+            Suchen Sie Ihren Betrieb auf Google Maps &rarr; &quot;Rezension
+            schreiben&quot; &rarr; Link kopieren
           </p>
         </Section>
 
-        {/* Termin-Defaults */}
-        <Section title="Termine" description="Standard-Einstellungen für neue Termine.">
+        {/* Termine */}
+        <Section
+          title="Termine"
+          description="Standard-Einstellungen für neue Termine."
+        >
           <label className="block text-sm font-medium text-gray-700 mb-1.5">
-            Standard-Termindauer (Minuten)
+            Standard-Termindauer
           </label>
           <select
             value={appointmentDuration}
@@ -136,7 +153,7 @@ export default function SettingsPage() {
 
           <div className="mt-4">
             <label className="block text-sm font-medium text-gray-700 mb-1.5">
-              Kalender-E-Mail (für ICS-Einladungen)
+              Kalender-E-Mail
             </label>
             <input
               type="email"
@@ -146,40 +163,29 @@ export default function SettingsPage() {
               className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400"
             />
             <p className="mt-1.5 text-xs text-gray-400">
-              Optional — Termine werden als ICS-Einladung an diese Adresse gesendet
+              Termine werden als ICS-Einladung an diese Adresse gesendet
             </p>
           </div>
         </Section>
 
-        {/* Benachrichtigungen */}
-        <Section title="Melder-Benachrichtigungen" description="Automatische Bestätigungen an den Melder nach Fallerfassung.">
+        {/* Bestätigungen */}
+        <Section
+          title="Bestätigungen an Meldende"
+          description="Automatische Rückmeldung nach Fallerfassung."
+        >
           <div className="space-y-3">
             <Toggle
               checked={notifyEmail}
               onChange={setNotifyEmail}
               label="E-Mail-Bestätigung"
-              description="Melder erhält eine E-Mail mit Fallnummer und Zusammenfassung"
+              description="Meldende erhalten eine E-Mail mit Fallnummer und Zusammenfassung"
             />
             <Toggle
               checked={notifySms}
               onChange={setNotifySms}
               label="SMS-Bestätigung"
-              description="Melder erhält eine SMS-Bestätigung nach der Meldung"
+              description="Meldende erhalten eine SMS-Bestätigung nach der Meldung"
             />
-          </div>
-        </Section>
-
-        {/* Betriebsinfo (read-only) */}
-        <Section title="Betriebsinformationen" description="Diese Werte werden zentral verwaltet.">
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <p className="text-gray-400 text-xs mb-0.5">Betriebsname</p>
-              <p className="text-gray-900 font-medium">{data?.tenant_name ?? "—"}</p>
-            </div>
-            <div>
-              <p className="text-gray-400 text-xs mb-0.5">Fall-Präfix</p>
-              <p className="text-gray-900 font-medium">{data?.case_id_prefix ?? "FS"}</p>
-            </div>
           </div>
         </Section>
       </div>
@@ -191,22 +197,32 @@ export default function SettingsPage() {
           disabled={saving}
           className="rounded-lg bg-slate-800 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:opacity-50"
         >
-          {saving ? "Speichern…" : "Einstellungen speichern"}
+          {saving ? "Speichern…" : "Speichern"}
         </button>
         {saved && (
-          <span className="text-sm text-emerald-600 font-medium">Gespeichert</span>
+          <span className="text-sm text-emerald-600 font-medium">
+            Gespeichert
+          </span>
         )}
-        {error && (
-          <span className="text-sm text-red-600">{error}</span>
-        )}
+        {error && <span className="text-sm text-red-600">{error}</span>}
       </div>
     </div>
   );
 }
 
-// -- Sub-components --
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
 
-function Section({ title, description, children }: { title: string; description: string; children: React.ReactNode }) {
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="bg-white border border-gray-200 rounded-xl p-5">
       <h3 className="text-sm font-semibold text-gray-900 mb-0.5">{title}</h3>
@@ -216,7 +232,17 @@ function Section({ title, description, children }: { title: string; description:
   );
 }
 
-function Toggle({ checked, onChange, label, description }: { checked: boolean; onChange: (v: boolean) => void; label: string; description: string }) {
+function Toggle({
+  checked,
+  onChange,
+  label,
+  description,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+  description: string;
+}) {
   return (
     <label className="flex items-start gap-3 cursor-pointer">
       <div className="pt-0.5">
@@ -241,21 +267,5 @@ function Toggle({ checked, onChange, label, description }: { checked: boolean; o
         <p className="text-xs text-gray-400">{description}</p>
       </div>
     </label>
-  );
-}
-
-function NavCard({ href, label, sub, color }: { href: string; label: string; sub: string; color: string }) {
-  const bgMap: Record<string, string> = { amber: "bg-amber-50 group-hover:bg-amber-100", emerald: "bg-emerald-50 group-hover:bg-emerald-100", blue: "bg-blue-50 group-hover:bg-blue-100" };
-  const textMap: Record<string, string> = { amber: "text-amber-600", emerald: "text-emerald-600", blue: "text-blue-600" };
-  return (
-    <Link href={href} className="bg-white border border-gray-200 rounded-xl p-4 hover:border-gray-300 transition-colors group flex items-center gap-3">
-      <div className={`w-9 h-9 rounded-lg ${bgMap[color]} flex items-center justify-center transition-colors`}>
-        <span className={`text-sm font-bold ${textMap[color]}`}>{label[0]}</span>
-      </div>
-      <div>
-        <p className="text-sm font-semibold text-gray-900">{label}</p>
-        <p className="text-xs text-gray-500">{sub}</p>
-      </div>
-    </Link>
   );
 }

--- a/src/web/src/components/ops/MetricsView.tsx
+++ b/src/web/src/components/ops/MetricsView.tsx
@@ -5,81 +5,181 @@ import { useEffect, useState } from "react";
 interface MetricsData {
   totalCases: number;
   openCases: number;
+  newThisWeek: number;
+  newThisMonth: number;
   resolvedThisWeek: number;
   resolvedThisMonth: number;
   avgResolutionHours: number | null;
   notfallCount: number;
   voiceCases: number;
   wizardCases: number;
+  manualCases: number;
 }
 
-function MetricCard({
-  label,
-  value,
-  sublabel,
-  color = "text-gray-900",
-}: {
-  label: string;
-  value: string | number;
-  sublabel?: string;
-  color?: string;
-}) {
-  return (
-    <div className="bg-white border border-gray-200 rounded-xl px-4 py-3">
-      <p className="text-xs font-medium text-gray-500 mb-1">{label}</p>
-      <p className={`text-2xl font-bold ${color}`}>{value}</p>
-      {sublabel && <p className="text-xs text-gray-400 mt-0.5">{sublabel}</p>}
-    </div>
-  );
-}
+// ---------------------------------------------------------------------------
+// Überblick — Betriebsbrief, nicht KPI-Wand
+// ---------------------------------------------------------------------------
 
 export function MetricsView() {
   const [data, setData] = useState<MetricsData | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchMetrics();
+    fetch("/api/ops/metrics")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((d) => setData(d))
+      .catch(() => {})
+      .finally(() => setLoading(false));
   }, []);
 
-  async function fetchMetrics() {
-    setLoading(true);
-    try {
-      const res = await fetch("/api/ops/metrics");
-      if (res.ok) {
-        setData(await res.json());
-      }
-    } catch { /* ignore */ }
-    setLoading(false);
-  }
-
   if (loading) {
-    return <p className="text-sm text-gray-400 py-8 text-center">Laden…</p>;
+    return <p className="text-sm text-gray-400 py-12 text-center">Laden…</p>;
   }
 
   if (!data) {
-    return <p className="text-sm text-red-500 py-8 text-center">Fehler beim Laden der Kennzahlen.</p>;
+    return (
+      <p className="text-sm text-gray-400 py-12 text-center">
+        Daten konnten nicht geladen werden.
+      </p>
+    );
   }
+
+  const totalSources = data.voiceCases + data.wizardCases + data.manualCases;
 
   return (
     <div>
-      <div className="mb-4">
-        <h2 className="text-lg font-bold text-gray-900">Kennzahlen</h2>
-        <p className="text-sm text-gray-500">Trends und Übersicht — nur für Inhaber sichtbar</p>
+      <div className="mb-8">
+        <h2 className="text-lg font-bold text-gray-900">Überblick</h2>
+        <p className="text-sm text-gray-500">
+          Ihr Betrieb auf einen Blick
+        </p>
       </div>
 
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <MetricCard label="Total Fälle" value={data.totalCases} color="text-slate-900" />
-        <MetricCard label="Offen" value={data.openCases} color="text-blue-700" />
-        <MetricCard label="Erledigt (Woche)" value={data.resolvedThisWeek} color="text-emerald-700" sublabel="letzte 7 Tage" />
-        <MetricCard label="Erledigt (Monat)" value={data.resolvedThisMonth} color="text-emerald-700" sublabel="letzte 30 Tage" />
-        <MetricCard
-          label="Ø Bearbeitungszeit"
-          value={data.avgResolutionHours !== null ? `${data.avgResolutionHours}h` : "—"}
-          sublabel="Erstellung → Erledigt"
-        />
-        <MetricCard label="Notfälle" value={data.notfallCount} color="text-red-700" sublabel="gesamt" />
-        <MetricCard label="Anrufe" value={data.voiceCases} sublabel="via Voice Agent" />
-        <MetricCard label="Website" value={data.wizardCases} sublabel="via Meldungsformular" />
+      {/* Leistung — Woche vs. Monat */}
+      <div className="bg-white border border-gray-200 rounded-xl p-6 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
+          <div>
+            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-4">
+              Letzte 7 Tage
+            </h3>
+            <div className="space-y-2.5">
+              <Stat value={data.newThisWeek} label="neue Fälle" />
+              <Stat value={data.resolvedThisWeek} label="erledigt" />
+              {data.avgResolutionHours !== null && (
+                <Stat
+                  value={`Ø ${data.avgResolutionHours}h`}
+                  label="bis Abschluss"
+                />
+              )}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-4">
+              Letzte 30 Tage
+            </h3>
+            <div className="space-y-2.5">
+              <Stat value={data.newThisMonth} label="neue Fälle" />
+              <Stat value={data.resolvedThisMonth} label="erledigt" />
+              {data.notfallCount > 0 && (
+                <Stat
+                  value={data.notfallCount}
+                  label="Notfälle"
+                  accent="text-red-700"
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Aktuell + Eingangsquellen */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div className="bg-white border border-gray-200 rounded-xl p-5">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-4">
+            Aktuell
+          </h3>
+          <div className="space-y-2.5">
+            <Stat value={data.openCases} label="offene Fälle" />
+            <Stat value={data.totalCases} label="insgesamt" />
+          </div>
+        </div>
+
+        <div className="bg-white border border-gray-200 rounded-xl p-5">
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-4">
+            Eingangsquellen
+          </h3>
+          <div className="space-y-2">
+            <SourceRow
+              label="Anrufe"
+              count={data.voiceCases}
+              total={totalSources}
+            />
+            <SourceRow
+              label="Formulare"
+              count={data.wizardCases}
+              total={totalSources}
+            />
+            {data.manualCases > 0 && (
+              <SourceRow
+                label="Manuell"
+                count={data.manualCases}
+                total={totalSources}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function Stat({
+  value,
+  label,
+  accent,
+}: {
+  value: string | number;
+  label: string;
+  accent?: string;
+}) {
+  return (
+    <p className="text-sm text-gray-600">
+      <span className={`font-semibold ${accent ?? "text-gray-900"}`}>
+        {value}
+      </span>{" "}
+      {label}
+    </p>
+  );
+}
+
+function SourceRow({
+  label,
+  count,
+  total,
+}: {
+  label: string;
+  count: number;
+  total: number;
+}) {
+  const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-gray-600">{label}</span>
+      <div className="flex items-center gap-2">
+        <div className="w-16 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-gray-400 rounded-full"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <span className="text-gray-900 font-semibold tabular-nums w-6 text-right">
+          {count}
+        </span>
       </div>
     </div>
   );

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -98,7 +98,7 @@ export function OpsShell({
         .map((w) => w[0]?.toUpperCase() ?? "")
         .join("")
     : "LS";
-  const color = brandColor ?? "#d97706"; // fallback amber-600
+  const color = brandColor ?? "#64748b"; // slate-500 — neutral "no brand set" signal
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const pathname = usePathname();
 

--- a/src/web/src/components/ops/ZentraleView.tsx
+++ b/src/web/src/components/ops/ZentraleView.tsx
@@ -598,11 +598,17 @@ export function ZentraleView({
         </section>
       )}
 
-      {/* Betriebsleiste — ambient footer */}
-      <div className="text-center pt-2 pb-1">
+      {/* Betriebsleiste — ambient footer with Wirkung */}
+      <div className="text-center pt-3 pb-1">
         <p className="text-xs text-gray-400">
           {weekStats.neue} neue · {weekStats.erledigt} erledigt
-          <span className="text-gray-300 ml-1">(7d)</span>
+          <span className="text-gray-300 ml-0.5">(7d)</span>
+          {g.abschluss.length > 0 && (
+            <>
+              <span className="text-gray-300 mx-1.5">·</span>
+              {g.abschluss.length} Review offen
+            </>
+          )}
         </p>
       </div>
 

--- a/src/web/src/lib/tenants/resolveTenantIdentity.ts
+++ b/src/web/src/lib/tenants/resolveTenantIdentity.ts
@@ -20,10 +20,10 @@ export interface TenantIdentity {
 }
 
 const FALLBACK: Omit<TenantIdentity, "tenantId"> = {
-  displayName: "FlowSight",
-  shortName: "FlowSight",
+  displayName: "Leitstand",
+  shortName: "Leitstand",
   caseIdPrefix: "FS",
-  primaryColor: "#d4a853",
+  primaryColor: "#64748b", // slate-500 — neutral "no brand set" signal
 };
 
 /**


### PR DESCRIPTION
## Summary
- **Tenant-Wahrheit repariert**: Einheitlicher Fallback slate-500 (neutral) statt doppeltes Gold. FALLBACK sagt jetzt "Leitstand" statt "FlowSight". Settings API gibt DB-Wert direkt zurück.
- **Überblick komplett neu**: 8 gleich starke KPI-Cards ersetzt durch ruhigen Betriebsbrief (Woche/Monat/Aktuell/Eingangsquellen). Keine Dashboard-Wand mehr.
- **Settings geschärft**: NavCards raus, Betriebsinfo prominent oben, betriebsnähere Sprache
- **Fälle Quickfilter**: Semantische Chip-Reihe (Offen/Neu/Bei uns/Abschluss/Kritisch/Unzugewiesen/Alle) + assigned=no Filter
- **Zentrale Betriebsleiste**: Review-Count ergänzt

## Architektur-Entscheidungen
- **Fallback-Farbe `#64748b` (slate-500)**: Neutral-professionell, signalisiert "keine Betriebsfarbe gesetzt" statt falsches Gold. EIN Fallback statt zwei verschiedene.
- **Überblick = Betriebsbrief**: Textbasiert, nicht kartenbasiert. Liest sich wie Lagebericht, nicht wie Dashboard.
- **Quickfilter = Chips**: Spiegeln die Leitzentrale-Module (Neu/Bei uns/Abschluss) → konsistente Semantik.

## Test plan
- [ ] Überblick → Zeigt Woche/Monat/Aktuell/Quellen als ruhigen Betriebsbrief
- [ ] Settings → Keine NavCards, Betriebsinfo oben, "Bestätigungen an Meldende"
- [ ] Fälle → Quickfilter-Chips funktionieren (Offen/Neu/Bei uns/Abschluss/Kritisch/Unzugewiesen/Alle)
- [ ] Weinberger → Navy-Sidebar (#004994), Fall-Präfix "WB", keine "FS" oder "Default" Reste
- [ ] Tenant ohne Farbe → Slate-Sidebar (nicht Gold)
- [ ] Zentrale Betriebsleiste → Zeigt "X Review offen" wenn Abschluss-Fälle existieren

🤖 Generated with [Claude Code](https://claude.com/claude-code)