### PR TITLE
feat: Leitsystem high-end rebuild — 5-module grid, dark sidebar, JW prefix

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -6,7 +6,7 @@ import { ZentraleView } from "@/src/components/ops/ZentraleView";
 import type { ZentraleCase, TodayAppointment } from "@/src/components/ops/ZentraleView";
 
 // ---------------------------------------------------------------------------
-// Page (Server Component) — "Zentrale" (Daily Driver)
+// Page (Server Component) — Leitsystem
 // ---------------------------------------------------------------------------
 
 export default async function OpsCasesPage({
@@ -35,7 +35,7 @@ export default async function OpsCasesPage({
     if (t) filterTenantId = t.id;
   }
 
-  // ── Query 1: Active cases (up to 200) for Zentrale grouping ────────
+  // ── Query 1: Active cases (up to 200) for Leitsystem grouping ────
   let casesQuery = supabase
     .from("cases")
     .select(
@@ -82,17 +82,42 @@ export default async function OpsCasesPage({
     .gte("updated_at", sevenDaysAgo);
   if (filterTenantId) statsErledigtQuery = statsErledigtQuery.eq("tenant_id", filterTenantId);
 
+  // ── Query 5+6: Review stats (server-side, last 30 days) ──────────
+  const thirtyDaysAgo = new Date(new Date().getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  let reviewSentQuery = supabase
+    .from("cases")
+    .select("id", { count: "exact", head: true })
+    .eq("is_demo", showDemo)
+    .eq("status", "done")
+    .not("review_sent_at", "is", null)
+    .gte("updated_at", thirtyDaysAgo);
+  if (filterTenantId) reviewSentQuery = reviewSentQuery.eq("tenant_id", filterTenantId);
+
+  let reviewPendingQuery = supabase
+    .from("cases")
+    .select("id", { count: "exact", head: true })
+    .eq("is_demo", showDemo)
+    .eq("status", "done")
+    .is("review_sent_at", null)
+    .gte("updated_at", thirtyDaysAgo);
+  if (filterTenantId) reviewPendingQuery = reviewPendingQuery.eq("tenant_id", filterTenantId);
+
   // ── Execute all queries in parallel ────────────────────────────────
   const [
     { data: casesRaw },
     { data: appointmentsRaw },
     { count: neueCount },
     { count: erledigtCount },
+    { count: reviewSentCount },
+    { count: reviewPendingCount },
   ] = await Promise.all([
     casesQuery,
     appointmentsQuery,
     statsNeueQuery,
     statsErledigtQuery,
+    reviewSentQuery,
+    reviewPendingQuery,
   ]);
 
   const cases = (casesRaw ?? []) as ZentraleCase[];
@@ -127,6 +152,10 @@ export default async function OpsCasesPage({
       weekStats={{
         neue: neueCount ?? 0,
         erledigt: erledigtCount ?? 0,
+      }}
+      reviewStats={{
+        sent: reviewSentCount ?? 0,
+        pending: reviewPendingCount ?? 0,
       }}
     />
   );

--- a/src/web/app/ops/(dashboard)/faelle/page.tsx
+++ b/src/web/app/ops/(dashboard)/faelle/page.tsx
@@ -34,7 +34,22 @@ const SOURCE_OPTIONS = [
 ];
 
 // ---------------------------------------------------------------------------
-// Page (Server Component) — "Fälle" (Suche, Filter, Export, Tabelle)
+// Semantic view definitions — mirror Leitsystem modules 1:1
+// ---------------------------------------------------------------------------
+
+type SemanticView = "neu" | "wartet" | "heute" | "abschluss" | "wirkung" | "alle" | "";
+
+const QUICK_CHIPS: { label: string; view: SemanticView }[] = [
+  { label: "Offen", view: "" },
+  { label: "Neu", view: "neu" },
+  { label: "Wartet", view: "wartet" },
+  { label: "Heute", view: "heute" },
+  { label: "Abschluss", view: "abschluss" },
+  { label: "Alle", view: "alle" },
+];
+
+// ---------------------------------------------------------------------------
+// Page
 // ---------------------------------------------------------------------------
 
 export default async function FaellePage({
@@ -45,13 +60,11 @@ export default async function FaellePage({
   const params = await searchParams;
 
   // Filters from URL
+  const view = (params.view ?? "") as SemanticView;
   const filterStatus = params.status ?? "";
   const filterUrgency = params.urgency ?? "";
   const filterSource = params.source ?? "";
-  const filterCategory = params.category;
-  const filterAssigned = params.assigned;
   const filterTenantSlug = params.tenant;
-  const showAll = params.show === "all";
   const filterQuery = params.q ?? "";
   const showDemo = params.tab === "demo";
   const currentPage = Math.max(1, parseInt(params.page ?? "1", 10) || 1);
@@ -74,7 +87,7 @@ export default async function FaellePage({
     if (t) filterTenantId = t.id;
   }
 
-  // Filtered list query
+  // ── Build query ───────────────────────────────────────────────────
   let listQuery = supabase
     .from("cases")
     .select(
@@ -85,22 +98,34 @@ export default async function FaellePage({
     .order("created_at", { ascending: false });
   if (filterTenantId) listQuery = listQuery.eq("tenant_id", filterTenantId);
 
-  // Status filter logic
-  if (filterStatus === "in_progress") {
+  // ── Apply semantic view filter ────────────────────────────────────
+  if (view === "neu") {
+    listQuery = listQuery.eq("status", "new");
+  } else if (view === "wartet") {
+    // Contacted + no appointment yet = ball stuck with us
+    listQuery = listQuery.eq("status", "contacted").is("scheduled_at", null);
+  } else if (view === "heute") {
+    // Day-relevant: scheduled cases + cases with today's appointments
+    // Broad definition: anything with status=scheduled OR contacted with scheduled_at
+    listQuery = listQuery.in("status", ["scheduled", "contacted"]).not("scheduled_at", "is", null);
+  } else if (view === "abschluss") {
+    listQuery = listQuery.eq("status", "done").is("review_sent_at", null);
+  } else if (view === "wirkung") {
+    listQuery = listQuery.eq("status", "done").not("review_sent_at", "is", null);
+  } else if (view === "alle") {
+    listQuery = listQuery.neq("status", "archived");
+  } else if (filterStatus === "in_progress") {
+    // Legacy filter support
     listQuery = listQuery.in("status", ["contacted", "scheduled"]);
   } else if (filterStatus) {
     listQuery = listQuery.eq("status", filterStatus);
-  } else if (!showAll) {
-    listQuery = listQuery.not("status", "in", "(done,archived)");
   } else {
-    listQuery = listQuery.neq("status", "archived");
+    // Default: open cases (not done, not archived)
+    listQuery = listQuery.not("status", "in", "(done,archived)");
   }
 
   if (filterUrgency) listQuery = listQuery.eq("urgency", filterUrgency);
-  if (filterCategory) listQuery = listQuery.ilike("category", filterCategory);
   if (filterSource) listQuery = listQuery.eq("source", filterSource);
-  if (filterAssigned === "yes") listQuery = listQuery.not("assignee_text", "is", null);
-  if (filterAssigned === "no") listQuery = listQuery.is("assignee_text", null);
 
   // Text search
   if (filterQuery) {
@@ -142,84 +167,54 @@ export default async function FaellePage({
     }
   } catch { /* fallback to defaults */ }
 
-  // Build filter URL helper
+  // Chip URL builder
+  function chipHref(chipView: SemanticView): string {
+    const p = new URLSearchParams();
+    if (filterTenantSlug) p.set("tenant", filterTenantSlug);
+    if (showDemo) p.set("tab", "demo");
+    if (chipView) p.set("view", chipView);
+    if (filterQuery) p.set("q", filterQuery);
+    const qs = p.toString();
+    return `/ops/faelle${qs ? `?${qs}` : ""}`;
+  }
+
+  // Detail filter URL builder
   function filterHref(key: string, value: string): string {
     const p = new URLSearchParams();
     if (filterTenantSlug) p.set("tenant", filterTenantSlug);
     if (showDemo) p.set("tab", "demo");
-    if (key === "status") { if (value) p.set("status", value); }
-    else if (filterStatus) p.set("status", filterStatus);
+    if (view) p.set("view", view);
     if (key === "urgency") { if (value) p.set("urgency", value); }
     else if (filterUrgency) p.set("urgency", filterUrgency);
     if (key === "source") { if (value) p.set("source", value); }
     else if (filterSource) p.set("source", filterSource);
-    if (key === "show") { if (value) p.set("show", value); }
-    else if (showAll) p.set("show", "all");
     if (filterQuery) p.set("q", filterQuery);
     const qs = p.toString();
     return `/ops/faelle${qs ? `?${qs}` : ""}`;
   }
 
-  const hasActiveFilters = !!(filterStatus || filterUrgency || filterSource || filterAssigned);
-
-  // Quickfilter chip helper
-  function quickHref(overrides: Record<string, string>): string {
-    const p = new URLSearchParams();
-    if (filterTenantSlug) p.set("tenant", filterTenantSlug);
-    if (showDemo) p.set("tab", "demo");
-    for (const [k, v] of Object.entries(overrides)) {
-      if (v) p.set(k, v);
-    }
-    if (filterQuery) p.set("q", filterQuery);
-    const qs = p.toString();
-    return `/ops/faelle${qs ? `?${qs}` : ""}`;
-  }
-
-  const QUICK_FILTERS = [
-    { label: "Neu", href: quickHref({ status: "new" }), active: filterStatus === "new" },
-    { label: "Bei uns", href: quickHref({ status: "in_progress" }), active: filterStatus === "in_progress" },
-    { label: "Abschluss", href: quickHref({ status: "done", show: "all" }), active: filterStatus === "done" },
-    { label: "Kritisch", href: quickHref({ urgency: "notfall" }), active: filterUrgency === "notfall" && !filterStatus },
-    { label: "Unzugewiesen", href: quickHref({ assigned: "no" }), active: filterAssigned === "no" && !filterStatus },
-  ];
+  const hasDetailFilters = !!(filterUrgency || filterSource);
 
   return (
     <>
-      {/* Quickfilter chips — semantic betriebsnahe Schnellzugriffe */}
+      {/* Quickfilter chips — mirror Leitsystem modules 1:1 */}
       <div className="flex flex-wrap items-center gap-2 mb-3">
-        <Link
-          href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}${showDemo ? "&tab=demo" : ""}` : `/ops/faelle${showDemo ? "?tab=demo" : ""}`}
-          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-            !hasActiveFilters && !showAll
-              ? "bg-slate-800 text-white"
-              : "bg-white text-gray-600 border border-gray-200 hover:border-gray-300"
-          }`}
-        >
-          Offen
-        </Link>
-        {QUICK_FILTERS.map((qf) => (
-          <Link
-            key={qf.label}
-            href={qf.href}
-            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-              qf.active
-                ? "bg-slate-800 text-white"
-                : "bg-white text-gray-600 border border-gray-200 hover:border-gray-300"
-            }`}
-          >
-            {qf.label}
-          </Link>
-        ))}
-        <Link
-          href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}&show=all${showDemo ? "&tab=demo" : ""}` : `/ops/faelle?show=all${showDemo ? "&tab=demo" : ""}`}
-          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-            showAll && !filterStatus && !filterUrgency && !filterAssigned
-              ? "bg-slate-800 text-white"
-              : "bg-white text-gray-600 border border-gray-200 hover:border-gray-300"
-          }`}
-        >
-          Alle
-        </Link>
+        {QUICK_CHIPS.map((chip) => {
+          const isActive = view === chip.view && !filterStatus;
+          return (
+            <Link
+              key={chip.label}
+              href={chipHref(chip.view)}
+              className={`px-3.5 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                isActive
+                  ? "bg-gray-900 text-white"
+                  : "bg-white text-gray-600 border border-gray-200 hover:border-gray-300"
+              }`}
+            >
+              {chip.label}
+            </Link>
+          );
+        })}
       </div>
 
       {/* Secondary filters */}
@@ -231,17 +226,17 @@ export default async function FaellePage({
               href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}` : "/ops/faelle"}
               className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                 !showDemo
-                  ? "bg-slate-700 text-white"
+                  ? "bg-gray-800 text-white"
                   : "bg-white text-gray-600 hover:bg-gray-50"
               }`}
             >
-              Ihre Fälle
+              Ihre F\u00e4lle
             </Link>
             <Link
               href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}&tab=demo` : "/ops/faelle?tab=demo"}
               className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                 showDemo
-                  ? "bg-slate-700 text-white"
+                  ? "bg-gray-800 text-white"
                   : "bg-white text-gray-600 hover:bg-gray-50"
               }`}
             >
@@ -252,17 +247,16 @@ export default async function FaellePage({
           <span className="border-l border-gray-200 h-6 inline-block" />
 
           {/* Detail filters */}
-          <FilterSelect options={STATUS_OPTIONS} value={filterStatus} paramKey="status" filterHref={filterHref} />
           <FilterSelect options={URGENCY_OPTIONS} value={filterUrgency} paramKey="urgency" filterHref={filterHref} />
           <FilterSelect options={SOURCE_OPTIONS} value={filterSource} paramKey="source" filterHref={filterHref} />
 
           {/* Reset */}
-          {hasActiveFilters && (
+          {hasDetailFilters && (
             <Link
-              href={filterTenantSlug ? `/ops/faelle?tenant=${filterTenantSlug}` : "/ops/faelle"}
+              href={chipHref(view)}
               className="text-xs text-gray-400 hover:text-gray-600 transition-colors ml-1"
             >
-              Zurücksetzen
+              Zur\u00fccksetzen
             </Link>
           )}
         </div>
@@ -283,7 +277,7 @@ export default async function FaellePage({
 }
 
 // ---------------------------------------------------------------------------
-// Filter dropdown (renders as styled links to preserve SSR)
+// Filter dropdown
 // ---------------------------------------------------------------------------
 
 function FilterSelect({
@@ -305,7 +299,7 @@ function FilterSelect({
       <button
         className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
           isActive
-            ? "border-slate-600 bg-slate-700 text-white"
+            ? "border-gray-700 bg-gray-800 text-white"
             : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
         }`}
       >
@@ -322,7 +316,7 @@ function FilterSelect({
               href={filterHref(paramKey, opt.value)}
               className={`block px-3 py-1.5 text-xs transition-colors ${
                 opt.value === value
-                  ? "bg-slate-50 text-slate-900 font-medium"
+                  ? "bg-gray-50 text-gray-900 font-medium"
                   : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
               }`}
             >

--- a/src/web/app/ops/(dashboard)/layout.tsx
+++ b/src/web/app/ops/(dashboard)/layout.tsx
@@ -1,18 +1,11 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
-import { getServiceClient } from "@/src/lib/supabase/server";
 import { resolveTenantIdentity } from "@/src/lib/tenants/resolveTenantIdentity";
-import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 import { OpsShell } from "@/src/components/ops/OpsShell";
 
 /**
- * Dynamic tab title: "{short_name} Leitstand" per Identity Contract E2.
- * Falls back to "Leitstand" for admin or when no tenant is scoped.
- * Never shows "FlowSight" (R4).
- */
-/**
- * Tab title: "{short_name} Leitstand" — Identity Contract E2.
+ * Tab title: "{short_name} Leitsystem" — Identity Contract E2.
  * Uses title.absolute to bypass root layout's " — FlowSight" template (R4).
  */
 export async function generateMetadata(): Promise<Metadata> {
@@ -21,13 +14,13 @@ export async function generateMetadata(): Promise<Metadata> {
     const {
       data: { user },
     } = await authClient.auth.getUser();
-    if (!user) return { title: { absolute: "Leitstand" } };
+    if (!user) return { title: { absolute: "Leitsystem" } };
 
     const identity = await resolveTenantIdentity(user);
-    const tabLabel = identity?.shortName ?? "Leitstand";
-    return { title: { absolute: `${tabLabel} Leitstand` } };
+    const tabLabel = identity?.shortName ?? "Leitsystem";
+    return { title: { absolute: `${tabLabel} Leitsystem` } };
   } catch {
-    return { title: { absolute: "Leitstand" } };
+    return { title: { absolute: "Leitsystem" } };
   }
 }
 
@@ -44,27 +37,11 @@ export default async function DashboardLayout({
 
   const identity = await resolveTenantIdentity(user);
 
-  // Lightweight staff count for progressive nav (leitstand.md §2)
-  let staffCount = 0;
-  try {
-    const scope = await resolveTenantScope();
-    if (scope?.tenantId) {
-      const supabase = getServiceClient();
-      const { count } = await supabase
-        .from("staff")
-        .select("id", { count: "exact", head: true })
-        .eq("tenant_id", scope.tenantId)
-        .eq("is_active", true);
-      staffCount = count ?? 0;
-    }
-  } catch { /* fallback to 0 */ }
-
   return (
     <OpsShell
       userEmail={user.email ?? ""}
       tenantName={identity?.displayName ?? undefined}
       brandColor={identity?.primaryColor ?? undefined}
-      staffCount={staffCount}
     >
       {children}
     </OpsShell>

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -4,20 +4,23 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+// ---------------------------------------------------------------------------
+// Navigation — 3 items only, mirroring the Leitsystem architecture
+// ---------------------------------------------------------------------------
+
 interface NavItem {
   label: string;
   href: string;
   icon: React.ReactNode;
 }
 
-// Primary nav: Daily Driver
-const PRIMARY_NAV: NavItem[] = [
+const NAV_ITEMS: NavItem[] = [
   {
-    label: "Zentrale",
+    label: "Leitsystem",
     href: "/ops/cases",
     icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+      <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />
       </svg>
     ),
   },
@@ -25,72 +28,41 @@ const PRIMARY_NAV: NavItem[] = [
     label: "F\u00e4lle",
     href: "/ops/faelle",
     icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+      </svg>
+    ),
+  },
+  {
+    label: "Einstellungen",
+    href: "/ops/settings",
+    icon: (
+      <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
       </svg>
     ),
   },
 ];
 
-// Secondary nav items: Betrieb
-const SECONDARY_NAV_UEBERBLICK: NavItem = {
-  label: "\u00dcberblick",
-  href: "/ops/metrics",
-  icon: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
-    </svg>
-  ),
-};
-
-const SECONDARY_NAV_EINSATZPLAN: NavItem = {
-  label: "Einsatzplan",
-  href: "/ops/schedule",
-  icon: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
-    </svg>
-  ),
-};
-
-const SECONDARY_NAV_TEAM: NavItem = {
-  label: "Team",
-  href: "/ops/staff",
-  icon: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
-    </svg>
-  ),
-};
-
-const SECONDARY_NAV_EINSTELLUNGEN: NavItem = {
-  label: "Einstellungen",
-  href: "/ops/settings",
-  icon: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
-      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-    </svg>
-  ),
-};
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 export function OpsShell({
   userEmail,
   tenantName,
   brandColor,
-  staffCount = 0,
   children,
 }: {
   userEmail: string;
   tenantName?: string;
-  /** Tenant brand color hex (e.g. "#004994"). Falls back to amber if not set. */
+  /** Tenant brand color hex (e.g. "#004994"). Falls back to neutral slate if not set. */
   brandColor?: string;
-  /** Number of staff members — controls progressive nav */
-  staffCount?: number;
   children: React.ReactNode;
 }) {
   // Identity Contract R4: No "FlowSight" visible to end users
-  const displayName = tenantName ?? "Leitstand";
+  const displayName = tenantName ?? "Leitsystem";
   const initials = tenantName
     ? tenantName
         .split(/\s+/)
@@ -98,113 +70,107 @@ export function OpsShell({
         .map((w) => w[0]?.toUpperCase() ?? "")
         .join("")
     : "LS";
-  const color = brandColor ?? "#64748b"; // slate-500 — neutral "no brand set" signal
+  const color = brandColor ?? "#64748b";
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const pathname = usePathname();
 
-  // Active state check: exact match for /ops/cases (not /ops/cases/xxx), prefix for others
   function isNavActive(href: string): boolean {
     if (href === "/ops/cases") {
-      return pathname === "/ops/cases" || pathname === "/ops/cases/";
+      // Active for Leitsystem main AND case detail views
+      return pathname === "/ops/cases" || pathname === "/ops/cases/" || pathname.startsWith("/ops/cases/");
     }
     return pathname.startsWith(href);
   }
 
-  function renderNavLink(item: NavItem, size: "primary" | "secondary") {
-    const isActive = isNavActive(item.href);
-    const isPrimary = size === "primary";
-    return (
-      <Link
-        key={item.label}
-        href={item.href}
-        onClick={() => setSidebarOpen(false)}
-        className={`flex items-center gap-3 px-3 ${isPrimary ? "py-2.5" : "py-2"} rounded-lg ${isPrimary ? "text-sm" : "text-xs"} font-medium transition-colors ${
-          isActive
-            ? "border-l-2 -ml-px"
-            : isPrimary
-              ? "text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-              : "text-gray-500 hover:bg-gray-50 hover:text-gray-700"
-        }`}
-        style={
-          isActive
-            ? {
-                backgroundColor: `${color}10`,
-                color: color,
-                borderColor: color,
-              }
-            : undefined
-        }
-      >
-        {item.icon}
-        <span>{item.label}</span>
+  // ── Brand Header ────────────────────────────────────────────────────
+  const brandHeader = (
+    <div
+      className="px-5 py-6"
+      style={{
+        backgroundColor: color,
+        backgroundImage: `linear-gradient(to bottom, ${color}, ${color}ee)`,
+      }}
+    >
+      <Link href="/ops/cases" className="flex items-center gap-3">
+        <div
+          className="w-11 h-11 rounded-xl flex items-center justify-center border border-white/20 flex-shrink-0"
+          style={{ backgroundColor: "rgba(255,255,255,0.12)" }}
+        >
+          <span className="text-white font-bold text-lg tracking-tight">{initials}</span>
+        </div>
+        <div className="min-w-0">
+          <span className="block text-[15px] font-semibold text-white leading-tight">
+            {displayName}
+          </span>
+          <span className="block text-[11px] text-white/50 mt-0.5">Leitsystem</span>
+        </div>
       </Link>
-    );
-  }
+    </div>
+  );
 
+  // ── Nav Links ───────────────────────────────────────────────────────
+  const navLinks = (
+    <nav className="flex-1 px-3 py-5">
+      <div className="space-y-1">
+        {NAV_ITEMS.map((item) => {
+          const active = isNavActive(item.href);
+          return (
+            <Link
+              key={item.label}
+              href={item.href}
+              onClick={() => setSidebarOpen(false)}
+              className={`flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-colors ${
+                active
+                  ? "text-white bg-white/[0.08]"
+                  : "text-gray-400 hover:text-gray-200 hover:bg-white/[0.04]"
+              }`}
+              style={
+                active
+                  ? { borderLeft: `3px solid ${color}`, paddingLeft: "9px" }
+                  : undefined
+              }
+            >
+              {item.icon}
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+
+  // ── Footer ──────────────────────────────────────────────────────────
+  const footer = (
+    <div className="px-4 py-4 border-t border-gray-800">
+      <p className="text-[11px] text-gray-500 truncate mb-2">{userEmail}</p>
+      <form action="/api/ops/logout" method="POST">
+        <button
+          type="submit"
+          className="text-[11px] text-gray-600 hover:text-gray-400 transition-colors"
+        >
+          Abmelden
+        </button>
+      </form>
+    </div>
+  );
+
+  // ── Sidebar Content ─────────────────────────────────────────────────
   const sidebarContent = (
     <>
-      {/* Logo — Identity Contract R4: Tenant branding, Full Brand Header */}
-      <div
-        className="px-4 py-5"
-        style={{ backgroundColor: color }}
-      >
-        <Link href="/ops/cases" className="flex items-center gap-2">
-          <div
-            className="w-8 h-8 rounded-lg flex items-center justify-center border-2 border-white/30"
-            style={{ backgroundColor: "rgba(255,255,255,0.15)" }}
-          >
-            <span className="text-white font-bold text-sm">{initials}</span>
-          </div>
-          <span className="font-bold text-white truncate">{displayName}</span>
-        </Link>
-      </div>
-
-      {/* Navigation */}
-      <nav className="flex-1 px-3 py-4">
-        {/* Primary nav: Zentrale + Fälle */}
-        <div className="space-y-1">
-          {PRIMARY_NAV.map((item) => renderNavLink(item, "primary"))}
-        </div>
-
-        {/* Separator + Secondary nav: Betrieb */}
-        <div className="mt-5 pt-4 border-t border-gray-200">
-          <p className="px-3 mb-2 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Betrieb</p>
-          <div className="space-y-0.5">
-            {/* Überblick — always visible */}
-            {renderNavLink(SECONDARY_NAV_UEBERBLICK, "secondary")}
-            {/* Einsatzplan — only when staffCount > 0 */}
-            {staffCount > 0 && renderNavLink(SECONDARY_NAV_EINSATZPLAN, "secondary")}
-            {/* Team — only when staffCount > 0 */}
-            {staffCount > 0 && renderNavLink(SECONDARY_NAV_TEAM, "secondary")}
-            {/* Einstellungen — always visible */}
-            {renderNavLink(SECONDARY_NAV_EINSTELLUNGEN, "secondary")}
-          </div>
-        </div>
-      </nav>
-
-      {/* User info + logout */}
-      <div className="px-4 py-4 border-t border-gray-200">
-        <p className="text-xs text-gray-500 truncate mb-2">{userEmail}</p>
-        <form action="/api/ops/logout" method="POST">
-          <button
-            type="submit"
-            className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
-          >
-            Abmelden
-          </button>
-        </form>
-      </div>
+      {brandHeader}
+      {navLinks}
+      {footer}
     </>
   );
 
   return (
-    <div className="min-h-screen bg-slate-100">
+    <div className="min-h-screen bg-gray-100">
       {/* Desktop sidebar */}
-      <aside className="hidden md:flex md:flex-col md:fixed md:inset-y-0 md:w-56 bg-slate-50 border-r border-slate-200">
+      <aside className="hidden md:flex md:flex-col md:fixed md:inset-y-0 md:w-56 bg-gray-950 border-r border-gray-800/50">
         {sidebarContent}
       </aside>
 
-      {/* Mobile header — Full Brand Header */}
+      {/* Mobile header */}
       <div
         className="md:hidden sticky top-0 z-30 px-4 py-3 flex items-center justify-between"
         style={{ backgroundColor: color }}
@@ -220,28 +186,28 @@ export function OpsShell({
         </button>
         <Link href="/ops/cases" className="flex items-center gap-2">
           <div
-            className="w-7 h-7 rounded-lg flex items-center justify-center border border-white/30"
-            style={{ backgroundColor: "rgba(255,255,255,0.15)" }}
+            className="w-8 h-8 rounded-lg flex items-center justify-center border border-white/20"
+            style={{ backgroundColor: "rgba(255,255,255,0.12)" }}
           >
-            <span className="text-white font-bold text-xs">{initials}</span>
+            <span className="text-white font-bold text-sm">{initials}</span>
           </div>
           <span className="font-semibold text-white text-sm truncate max-w-[160px]">{displayName}</span>
         </Link>
-        <div className="w-9" /> {/* Spacer for centering */}
+        <div className="w-9" />
       </div>
 
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
         <div className="md:hidden fixed inset-0 z-40">
           <div
-            className="absolute inset-0 bg-black/30"
+            className="absolute inset-0 bg-black/40"
             onClick={() => setSidebarOpen(false)}
           />
-          <aside className="relative w-64 max-w-[80%] h-full bg-white flex flex-col shadow-xl">
+          <aside className="relative w-64 max-w-[80%] h-full bg-gray-950 flex flex-col shadow-2xl">
             <button
               onClick={() => setSidebarOpen(false)}
               aria-label="Men\u00fc schliessen"
-              className="absolute top-3 right-3 z-10 flex h-8 w-8 items-center justify-center rounded-lg text-white/70 hover:text-white hover:bg-white/10"
+              className="absolute top-4 right-3 z-10 flex h-8 w-8 items-center justify-center rounded-lg text-white/50 hover:text-white hover:bg-white/10"
             >
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />

--- a/src/web/src/components/ops/ZentraleView.tsx
+++ b/src/web/src/components/ops/ZentraleView.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { formatCaseId } from "@/src/lib/cases/formatCaseId";
 import { CreateCaseModal } from "./CreateCaseModal";
 
 // ---------------------------------------------------------------------------
@@ -53,6 +52,11 @@ export interface WeekStats {
   erledigt: number;
 }
 
+export interface ReviewStats {
+  sent: number;
+  pending: number;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -86,37 +90,33 @@ function computeNextStep(c: ZentraleCase): string {
 }
 
 // ---------------------------------------------------------------------------
-// Grouping — Cases → Leitzentrale zones
+// Grouping — Cases → Leitsystem modules
 // ---------------------------------------------------------------------------
 
-interface Lage {
-  kritisch: number;
+interface LeitsystemGroups {
+  // Counts for Betriebspuls
   aktive: number;
-  beiUns: number;
-  abschlussOffen: number;
-}
-
-interface ZentraleGroups {
-  lage: Lage;
+  kritisch: number;
+  // Module data
   notfallCases: ZentraleCase[];
   eingaenge: ZentraleCase[];
   wartet: ZentraleCase[];
-  beiUnsActive: ZentraleCase[];
-  todayAppointments: TodayAppointment[];
+  scheduled: ZentraleCase[];
   abschluss: ZentraleCase[];
+  // Derived signals
+  unassignedWartet: number;
+  oldestWartetDays: number;
+  oldestAbschlussDays: number;
 }
 
-function groupForZentrale(
-  cases: ZentraleCase[],
-  rawAppointments: TodayAppointment[],
-): ZentraleGroups {
-  let kritisch = 0;
+function groupForLeitsystem(cases: ZentraleCase[]): LeitsystemGroups {
   let aktive = 0;
+  let kritisch = 0;
 
   const notfallCases: ZentraleCase[] = [];
   const eingaenge: ZentraleCase[] = [];
   const wartet: ZentraleCase[] = [];
-  const beiUnsActive: ZentraleCase[] = [];
+  const scheduled: ZentraleCase[] = [];
   const abschluss: ZentraleCase[] = [];
 
   for (const c of cases) {
@@ -128,40 +128,36 @@ function groupForZentrale(
       if (c.urgency === "notfall") kritisch++;
     }
 
-    // Notfall-Banner (active emergencies)
+    // Notfall overlay
     if (c.urgency === "notfall" && isActive) {
       notfallCases.push(c);
     }
 
-    // Eingänge: new cases
+    // Neu (Eingänge)
     if (c.status === "new") {
       eingaenge.push(c);
       continue;
     }
 
-    // Wartet auf uns: contacted, no appointment yet — ball stuck with us
+    // Wartet auf uns: contacted, no appointment
     if (c.status === "contacted" && !c.scheduled_at) {
       wartet.push(c);
       continue;
     }
 
-    // Bei uns active: contacted WITH appointment + scheduled
-    if (c.status === "contacted" && c.scheduled_at) {
-      beiUnsActive.push(c);
-      continue;
-    }
-    if (c.status === "scheduled") {
-      beiUnsActive.push(c);
+    // Scheduled / with appointment (for Heute)
+    if ((c.status === "contacted" && c.scheduled_at) || c.status === "scheduled") {
+      scheduled.push(c);
       continue;
     }
 
-    // Abschluss: done, no review, last 7 days
-    if (c.status === "done" && !c.review_sent_at && daysAgo(c.updated_at) <= 7) {
+    // Abschluss: done, no review sent, last 14 days
+    if (c.status === "done" && !c.review_sent_at && daysAgo(c.updated_at) <= 14) {
       abschluss.push(c);
     }
   }
 
-  // Sort: eingänge = notfall first, then dringend, then newest
+  // Sort eingänge by urgency then newest
   const urgencyRank: Record<string, number> = { notfall: 0, dringend: 1, normal: 2 };
   eingaenge.sort((a, b) => {
     const ra = urgencyRank[a.urgency] ?? 9;
@@ -170,78 +166,68 @@ function groupForZentrale(
     return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
   });
 
-  // Sort: wartet = oldest first (most stuck)
+  // Sort wartet by oldest first
   wartet.sort(
-    (a, b) =>
-      new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime(),
+    (a, b) => new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime(),
   );
 
-  // Sort: beiUnsActive = scheduled with date first, then by update
-  beiUnsActive.sort((a, b) => {
-    const aS = a.status === "scheduled" && a.scheduled_at;
-    const bS = b.status === "scheduled" && b.scheduled_at;
-    if (aS && !bS) return -1;
-    if (!aS && bS) return 1;
-    if (aS && bS)
-      return (
-        new Date(a.scheduled_at!).getTime() -
-        new Date(b.scheduled_at!).getTime()
-      );
-    return (
-      new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-    );
-  });
-
-  // Sort: notfall = newest first
+  // Sort notfall by newest
   notfallCases.sort(
-    (a, b) =>
-      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
   );
 
-  // Sort: abschluss = oldest first (most overdue for review)
+  // Sort abschluss by oldest first
   abschluss.sort(
-    (a, b) =>
-      new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime(),
-  );
-
-  // Appointments: only scheduled/confirmed
-  const todayAppointments = rawAppointments.filter(
-    (a) => a.status === "scheduled" || a.status === "confirmed",
+    (a, b) => new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime(),
   );
 
   return {
-    lage: {
-      kritisch,
-      aktive,
-      beiUns: wartet.length + beiUnsActive.length,
-      abschlussOffen: abschluss.length,
-    },
+    aktive,
+    kritisch,
     notfallCases,
     eingaenge,
     wartet,
-    beiUnsActive,
-    todayAppointments,
+    scheduled,
     abschluss,
+    unassignedWartet: wartet.filter((c) => !c.assignee_text).length,
+    oldestWartetDays: wartet.length > 0 ? daysAgo(wartet[0].updated_at) : 0,
+    oldestAbschlussDays: abschluss.length > 0 ? daysAgo(abschluss[0].updated_at) : 0,
   };
 }
 
 // ---------------------------------------------------------------------------
-// Constants
+// Betriebspuls — system health signal
 // ---------------------------------------------------------------------------
 
-const URGENCY_BORDER: Record<string, string> = {
-  notfall: "border-l-red-500",
-  dringend: "border-l-amber-400",
-  normal: "border-l-gray-200",
-};
-
-const MAX_EINGAENGE = 5;
-const MAX_WARTET = 4;
-const MAX_BEI_UNS = 6;
-const MAX_ABSCHLUSS = 5;
+function derivePulsSignal(g: LeitsystemGroups): {
+  color: string;
+  dotClass: string;
+  text: string;
+} {
+  if (g.kritisch > 0) {
+    return {
+      color: "text-red-700",
+      dotClass: "bg-red-500 animate-pulse",
+      text: `${g.kritisch} kritisch`,
+    };
+  }
+  const stuckCount = g.wartet.filter((c) => isStuck48h(c.updated_at)).length;
+  if (stuckCount > 0 || g.unassignedWartet > 3) {
+    return {
+      color: "text-amber-700",
+      dotClass: "bg-amber-500",
+      text: `${g.wartet.length} wartend`,
+    };
+  }
+  return {
+    color: "text-emerald-700",
+    dotClass: "bg-emerald-500",
+    text: "Ruhig",
+  };
+}
 
 // ---------------------------------------------------------------------------
-// Component — Leitzentrale
+// Component — Leitsystem
 // ---------------------------------------------------------------------------
 
 export function ZentraleView({
@@ -249,367 +235,223 @@ export function ZentraleView({
   todayAppointments,
   caseIdPrefix = "FS",
   weekStats,
+  reviewStats,
 }: {
   cases: ZentraleCase[];
   todayAppointments: TodayAppointment[];
   caseIdPrefix?: string;
   weekStats: WeekStats;
+  reviewStats: ReviewStats;
 }) {
   const [modalOpen, setModalOpen] = useState(false);
-  const g = groupForZentrale(cases, todayAppointments);
+  const g = groupForLeitsystem(cases);
+  const puls = derivePulsSignal(g);
+
+  // Heute: appointments + scheduled cases
+  const todayFiltered = todayAppointments.filter(
+    (a) => a.status === "scheduled" || a.status === "confirmed",
+  );
+  const heuteCount = todayFiltered.length + g.scheduled.length;
+
+  // Eingänge urgency split
+  const dringendCount = g.eingaenge.filter((c) => c.urgency === "dringend" || c.urgency === "notfall").length;
+  const normalCount = g.eingaenge.length - dringendCount;
 
   return (
-    <div className="space-y-6">
-      {/* ────────────────────────────────────────────────────────────────
-          EBENE A — Priorität / Lage
-         ──────────────────────────────────────────────────────────────── */}
-
-      {/* Notfall-Banner — only when critical cases exist */}
+    <div className="space-y-5">
+      {/* ═══════════════════════════════════════════════════════════════
+          NOTFALL EVENT OVERLAY — conditional, focused, calm-but-clear
+         ═══════════════════════════════════════════════════════════════ */}
       {g.notfallCases.length > 0 && (
-        <div className="bg-red-50 border border-red-200 rounded-xl px-5 py-4">
-          <div className="flex items-center gap-2 mb-2.5">
-            <span className="w-2.5 h-2.5 rounded-full bg-red-500 animate-pulse flex-shrink-0" />
-            <span className="text-sm font-semibold text-red-800">
-              {g.notfallCases.length === 1
-                ? "Notfall"
-                : `${g.notfallCases.length} Notfälle`}
-            </span>
+        <Link
+          href="/ops/faelle?view=neu&urgency=notfall"
+          className="block bg-red-50/80 border border-red-200/60 rounded-2xl px-5 py-4 hover:bg-red-50 transition-colors group"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2.5">
+              <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse flex-shrink-0" />
+              <span className="text-sm font-semibold text-red-800">
+                {g.notfallCases.length === 1
+                  ? "Notfall"
+                  : `${g.notfallCases.length} Notf\u00e4lle`}
+              </span>
+              <span className="text-sm text-red-600/70">
+                {g.notfallCases[0].category}
+                {g.notfallCases[0].city && ` \u2014 ${g.notfallCases[0].city}`}
+              </span>
+            </div>
+            <svg className="w-4 h-4 text-red-400 group-hover:text-red-600 transition-colors flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+            </svg>
           </div>
-          <div className="space-y-1">
-            {g.notfallCases.slice(0, 3).map((c) => (
-              <Link
-                key={c.id}
-                href={`/ops/cases/${c.id}`}
-                className="flex items-center justify-between text-sm hover:bg-red-100/50 rounded-lg px-2.5 py-1.5 -mx-2.5 transition-colors"
-              >
-                <span className="text-red-800 font-medium">
-                  {c.category}
-                  <span className="text-red-600/60 font-normal ml-2">
-                    {c.plz} {c.city}
-                  </span>
-                </span>
-                <span className="text-xs text-red-500/80 font-medium flex-shrink-0 ml-3">
-                  {formatCaseId(c.seq_number, caseIdPrefix)}
-                </span>
-              </Link>
-            ))}
-            {g.notfallCases.length > 3 && (
-              <Link
-                href="/ops/faelle?urgency=notfall"
-                className="block text-xs text-red-500 hover:text-red-700 px-2.5 pt-1 transition-colors"
-              >
-                +{g.notfallCases.length - 3} weitere
-              </Link>
-            )}
-          </div>
-        </div>
+          {g.notfallCases.length > 1 && (
+            <p className="text-xs text-red-500/60 mt-1.5 pl-[18px]">
+              +{g.notfallCases.length - 1} weitere
+            </p>
+          )}
+        </Link>
       )}
 
-      {/* Lagezeile — Instrument strip */}
-      <div className="bg-white border border-gray-200 rounded-xl px-5 py-2.5 flex items-center justify-between">
-        <div className="flex items-center gap-3 text-sm">
-          {/* Status signal */}
-          {g.lage.kritisch > 0 ? (
-            <span className="inline-flex items-center gap-1.5 font-semibold text-red-700">
-              <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
-              {g.lage.kritisch} kritisch
+      {/* ═══════════════════════════════════════════════════════════════
+          BETRIEBSPULS — system status in one calm line
+         ═══════════════════════════════════════════════════════════════ */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm flex-wrap">
+          {/* Signal */}
+          <span className={`inline-flex items-center gap-1.5 font-medium ${puls.color}`}>
+            <span className={`w-2 h-2 rounded-full ${puls.dotClass}`} />
+            {puls.text}
+          </span>
+
+          <span className="text-gray-300 select-none">\u00b7</span>
+
+          {/* Pipeline flow — mirrors the modules below */}
+          <span className="text-gray-500">
+            {g.aktive} aktiv
+          </span>
+          {g.wartet.length > 0 && (
+            <span className="text-gray-400">
+              \u00b7 {g.wartet.length} warten auf euch
             </span>
-          ) : (
-            <span className="inline-flex items-center gap-1.5 font-medium text-emerald-700">
-              <span className="w-2 h-2 rounded-full bg-emerald-500" />
-              Alles ruhig
+          )}
+          {heuteCount > 0 && (
+            <span className="text-gray-400">
+              \u00b7 {heuteCount} heute
             </span>
           )}
 
-          {/* Counters — mirror the modules below */}
-          <span className="text-gray-300 select-none">|</span>
-          <span className="text-gray-500">
-            {g.lage.aktive} aktiv
+          <span className="text-gray-300 select-none">\u00b7</span>
+
+          {/* Week summary */}
+          <span className="text-gray-400 text-xs">
+            {weekStats.neue} neu, {weekStats.erledigt} erledigt diese Woche
           </span>
-          {g.lage.beiUns > 0 && (
-            <span className="text-gray-400">
-              {g.lage.beiUns} bei uns
-            </span>
-          )}
-          {g.lage.abschlussOffen > 0 && (
-            <span className="text-gray-400">
-              {g.lage.abschlussOffen} abschluss
-            </span>
-          )}
-          {g.todayAppointments.length > 0 && (
-            <span className="text-gray-400">
-              {g.todayAppointments.length} heute
-            </span>
-          )}
         </div>
 
         <button
           onClick={() => setModalOpen(true)}
-          className="rounded-lg bg-slate-800 px-3 py-1.5 text-xs font-medium text-white hover:bg-slate-700 transition-colors flex-shrink-0"
+          className="rounded-xl bg-gray-900 px-4 py-2 text-xs font-medium text-white hover:bg-gray-800 transition-colors flex-shrink-0 ml-3"
         >
           + Neuer Fall
         </button>
       </div>
 
-      {/* ────────────────────────────────────────────────────────────────
-          EBENE B — Hauptarbeitsfläche
-         ──────────────────────────────────────────────────────────────── */}
+      {/* ═══════════════════════════════════════════════════════════════
+          MODULE GRID — 5 high-end cards
+         ═══════════════════════════════════════════════════════════════ */}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {/* ── Links: Neu eingegangen ──────────────────────────────── */}
-        <section>
-          <SectionHeader
-            label="Neu eingegangen"
-            count={g.eingaenge.length}
-          />
+      {/* Row 1: Neu + Wartet auf uns */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* ── NEU ──────────────────────────────────────────────────── */}
+        <ModuleCard
+          href="/ops/faelle?view=neu"
+          label="Neu"
+          accentColor="border-l-blue-500"
+          count={g.eingaenge.length}
+          context={
+            g.eingaenge.length === 0
+              ? "Alles gesichtet"
+              : dringendCount > 0
+                ? `${dringendCount} dringend \u00b7 ${normalCount} normal`
+                : `${normalCount} neue Eing\u00e4nge`
+          }
+          subSignal={
+            g.eingaenge.length > 0 && daysAgo(g.eingaenge[g.eingaenge.length - 1].created_at) > 1
+              ? `\u00c4ltester vor ${daysAgo(g.eingaenge[g.eingaenge.length - 1].created_at)} Tagen`
+              : undefined
+          }
+          emptyText="Keine neuen Eing\u00e4nge"
+        />
 
-          {g.eingaenge.length === 0 ? (
-            <EmptyState text="Keine neuen Eingänge" />
-          ) : (
-            <div className="space-y-2.5">
-              {g.eingaenge.slice(0, MAX_EINGAENGE).map((c) => (
-                <Link
-                  key={c.id}
-                  href={`/ops/cases/${c.id}`}
-                  className={`block bg-white border border-gray-200 border-l-[3px] ${URGENCY_BORDER[c.urgency] ?? "border-l-gray-200"} rounded-xl p-4 transition-all hover:shadow-md hover:-translate-y-px`}
-                >
-                  <div className="flex items-start justify-between gap-2 mb-1">
-                    <span className="text-sm font-semibold text-gray-900">
-                      {c.category}
-                    </span>
-                    <span className="text-xs text-gray-400 font-medium flex-shrink-0">
-                      {formatCaseId(c.seq_number, caseIdPrefix)}
-                    </span>
-                  </div>
-                  {c.description && (
-                    <p className="text-sm text-gray-500 line-clamp-1 mb-1.5">
-                      {c.description}
-                    </p>
-                  )}
-                  <div className="flex items-center gap-2 text-xs text-gray-400">
-                    <span>
-                      {c.plz} {c.city}
-                    </span>
-                    {c.reporter_name && (
-                      <>
-                        <span className="text-gray-300">&middot;</span>
-                        <span>{c.reporter_name}</span>
-                      </>
-                    )}
-                  </div>
-                </Link>
-              ))}
-              {g.eingaenge.length > MAX_EINGAENGE && (
-                <Link
-                  href="/ops/faelle?status=new"
-                  className="block text-xs text-gray-400 hover:text-gray-600 transition-colors px-1 pt-1"
-                >
-                  → Alle {g.eingaenge.length} Eingänge
-                </Link>
-              )}
-            </div>
-          )}
-        </section>
-
-        {/* ── Rechts: Bei uns ─────────────────────────────────────── */}
-        <section>
-          <SectionHeader
-            label="Bei uns"
-            count={g.wartet.length + g.beiUnsActive.length}
-          />
-
-          {g.wartet.length === 0 &&
-          g.beiUnsActive.length === 0 &&
-          g.todayAppointments.length === 0 ? (
-            <EmptyState text="Alles versorgt" />
-          ) : (
-            <div className="space-y-3">
-              {/* Wartet auf uns — amber sub-zone, only when stuck cases */}
-              {g.wartet.length > 0 && (
-                <div className="border border-amber-200 bg-amber-50/50 rounded-xl overflow-hidden">
-                  <div className="px-3.5 pt-2.5 pb-1.5">
-                    <h3 className="text-xs font-semibold text-amber-700 uppercase tracking-wide">
-                      Wartet auf uns
-                      <span className="ml-1.5 text-amber-500/70 normal-case tracking-normal font-medium">
-                        ({g.wartet.length})
-                      </span>
-                    </h3>
-                  </div>
-                  <div className="divide-y divide-amber-100">
-                    {g.wartet.slice(0, MAX_WARTET).map((c) => {
-                      const d = daysAgo(c.updated_at);
-                      const signal = !c.assignee_text
-                        ? "unzugewiesen"
-                        : d > 0
-                          ? `kein Termin, ${d}d`
-                          : "kein Termin";
-                      return (
-                        <Link
-                          key={c.id}
-                          href={`/ops/cases/${c.id}`}
-                          className="flex items-center justify-between px-3.5 py-2 text-sm hover:bg-amber-100/40 transition-colors"
-                        >
-                          <span className="text-gray-800 truncate">
-                            {c.reporter_name ?? c.category}
-                            <span className="text-gray-400 ml-1.5 text-xs font-normal">
-                              {c.category !== (c.reporter_name ?? c.category) ? c.category : ""}
-                            </span>
-                          </span>
-                          <span className="text-xs text-amber-600/80 flex-shrink-0 ml-2 font-medium">
-                            {signal}
-                          </span>
-                        </Link>
-                      );
-                    })}
-                  </div>
-                  {g.wartet.length > MAX_WARTET && (
-                    <Link
-                      href="/ops/faelle?status=contacted"
-                      className="block px-3.5 py-2 text-xs text-amber-600/70 hover:text-amber-700 transition-colors border-t border-amber-100"
-                    >
-                      → Alle in Fälle
-                    </Link>
-                  )}
-                </div>
-              )}
-
-              {/* Heute — only when appointments exist */}
-              {g.todayAppointments.length > 0 && (
-                <div className="bg-gray-50 border border-gray-200 rounded-xl overflow-hidden">
-                  <div className="px-3.5 pt-2.5 pb-1.5">
-                    <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                      Heute
-                      <span className="ml-1.5 text-gray-400 normal-case tracking-normal font-medium">
-                        ({g.todayAppointments.length})
-                      </span>
-                    </h3>
-                  </div>
-                  <div className="divide-y divide-gray-100">
-                    {g.todayAppointments.map((a) => (
-                      <Link
-                        key={a.id}
-                        href={
-                          a.case_info ? `/ops/cases/${a.case_info.id}` : "#"
-                        }
-                        className="flex items-center gap-2.5 px-3.5 py-2 text-sm hover:bg-gray-100/60 transition-colors"
-                      >
-                        <span className="font-semibold text-gray-900 flex-shrink-0 tabular-nums">
-                          {formatTime(a.scheduled_at)}
-                        </span>
-                        {a.staff?.display_name && (
-                          <span className="text-gray-600 truncate">
-                            {a.staff.display_name}
-                          </span>
-                        )}
-                        {a.case_info && (
-                          <span className="text-gray-400 truncate text-xs">
-                            {a.case_info.category} · {a.case_info.plz}{" "}
-                            {a.case_info.city}
-                          </span>
-                        )}
-                      </Link>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Active cases — contacted with appointment + scheduled */}
-              {g.beiUnsActive.length > 0 && (
-                <div className="bg-white border border-gray-200 rounded-xl divide-y divide-gray-100 overflow-hidden">
-                  {g.beiUnsActive.slice(0, MAX_BEI_UNS).map((c) => {
-                    const step = computeNextStep(c);
-                    const d = daysAgo(c.updated_at);
-                    const stuck = isStuck48h(c.updated_at);
-                    return (
-                      <Link
-                        key={c.id}
-                        href={`/ops/cases/${c.id}`}
-                        className="flex items-center justify-between px-3.5 py-2.5 text-sm hover:bg-gray-50 transition-colors"
-                      >
-                        <div className="truncate mr-2">
-                          <span className="text-gray-800 font-medium">
-                            {c.reporter_name ?? c.category}
-                          </span>
-                          {c.reporter_name && c.category && (
-                            <span className="text-gray-400 ml-1.5 text-xs">
-                              {c.category}
-                            </span>
-                          )}
-                        </div>
-                        <span
-                          className={`text-xs flex-shrink-0 ${stuck ? "text-amber-600 font-medium" : "text-gray-400"}`}
-                        >
-                          {step}
-                          {d > 2 && ` · ${d}d`}
-                        </span>
-                      </Link>
-                    );
-                  })}
-                  {g.beiUnsActive.length > MAX_BEI_UNS && (
-                    <Link
-                      href="/ops/faelle?status=in_progress"
-                      className="block px-3.5 py-2 text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                    >
-                      +{g.beiUnsActive.length - MAX_BEI_UNS} weitere
-                    </Link>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-        </section>
+        {/* ── WARTET AUF UNS ──────────────────────────────────────── */}
+        <ModuleCard
+          href="/ops/faelle?view=wartet"
+          label="Wartet auf euch"
+          accentColor="border-l-amber-500"
+          count={g.wartet.length}
+          tinted={g.oldestWartetDays > 2 || g.wartet.length > 3}
+          tintClass="bg-amber-50/40"
+          context={
+            g.wartet.length === 0
+              ? "Alles versorgt"
+              : g.oldestWartetDays > 0
+                ? `\u00c4ltester seit ${g.oldestWartetDays} Tagen`
+                : "Alle von heute"
+          }
+          subSignal={
+            g.unassignedWartet > 0
+              ? `${g.unassignedWartet} unzugewiesen`
+              : undefined
+          }
+          emptyText="Alles versorgt"
+        />
       </div>
 
-      {/* ────────────────────────────────────────────────────────────────
-          EBENE C — Schluss / Wirkung
-         ──────────────────────────────────────────────────────────────── */}
+      {/* Row 2: Heute (full width) */}
+      <ModuleCard
+        href="/ops/faelle?view=heute"
+        label="Heute"
+        accentColor="border-l-blue-600"
+        count={heuteCount}
+        context={
+          heuteCount === 0
+            ? "Keine Termine oder Eins\u00e4tze geplant"
+            : todayFiltered.length > 0
+              ? todayFiltered
+                  .slice(0, 3)
+                  .map((a) => formatTime(a.scheduled_at))
+                  .join(" \u00b7 ") +
+                (todayFiltered.length > 3 ? ` +${todayFiltered.length - 3}` : "") +
+                (g.scheduled.length > 0 ? ` \u00b7 ${g.scheduled.length} geplant` : "")
+              : `${g.scheduled.length} F\u00e4lle mit Termin`
+        }
+        subSignal={
+          heuteCount === 0
+            ? "Ruhiger Tag"
+            : undefined
+        }
+        emptyText="Keine Termine heute"
+        fullWidth
+      />
 
-      {/* Abschluss — compact, full width, collapse when empty */}
-      {g.abschluss.length > 0 && (
-        <section>
-          <SectionHeader label="Abschluss" count={g.abschluss.length} />
-          <div className="bg-white border border-gray-200 rounded-xl divide-y divide-gray-100 overflow-hidden">
-            {g.abschluss.slice(0, MAX_ABSCHLUSS).map((c) => {
-              const d = daysAgo(c.updated_at);
-              return (
-                <Link
-                  key={c.id}
-                  href={`/ops/cases/${c.id}`}
-                  className="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors"
-                >
-                  <span className="text-gray-700 font-medium truncate">
-                    {c.reporter_name ?? c.category}
-                  </span>
-                  <span className="text-xs text-gray-400 flex-shrink-0 ml-3">
-                    Review offen{d > 0 ? ` · ${d}d` : ""}
-                  </span>
-                </Link>
-              );
-            })}
-            {g.abschluss.length > MAX_ABSCHLUSS && (
-              <Link
-                href="/ops/faelle?status=done"
-                className="block px-4 py-2 text-xs text-gray-400 hover:text-gray-600 transition-colors"
-              >
-                +{g.abschluss.length - MAX_ABSCHLUSS} weitere
-              </Link>
-            )}
-          </div>
-        </section>
-      )}
+      {/* Row 3: Abschluss + Wirkung */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* ── ABSCHLUSS ───────────────────────────────────────────── */}
+        <ModuleCard
+          href="/ops/faelle?view=abschluss"
+          label="Abschluss"
+          accentColor="border-l-emerald-500"
+          count={g.abschluss.length}
+          context={
+            g.abschluss.length === 0
+              ? "Alles nachgefasst"
+              : `${g.abschluss.length} ohne Bewertungsanfrage`
+          }
+          subSignal={
+            g.oldestAbschlussDays > 3
+              ? `\u00c4ltester seit ${g.oldestAbschlussDays} Tagen`
+              : undefined
+          }
+          emptyText="Alles nachgefasst"
+        />
 
-      {/* Betriebsleiste — ambient footer with Wirkung */}
-      <div className="text-center pt-3 pb-1">
-        <p className="text-xs text-gray-400">
-          {weekStats.neue} neue · {weekStats.erledigt} erledigt
-          <span className="text-gray-300 ml-0.5">(7d)</span>
-          {g.abschluss.length > 0 && (
-            <>
-              <span className="text-gray-300 mx-1.5">·</span>
-              {g.abschluss.length} Review offen
-            </>
-          )}
-        </p>
+        {/* ── WIRKUNG ─────────────────────────────────────────────── */}
+        <ModuleCard
+          href="/ops/faelle?view=wirkung"
+          label="Wirkung"
+          accentColor="border-l-emerald-600"
+          count={reviewStats.sent}
+          countSuffix={reviewStats.sent === 1 ? " Bewertungsanfrage" : " Bewertungsanfragen"}
+          context={
+            reviewStats.sent === 0 && reviewStats.pending === 0
+              ? "Noch keine Bewertungsanfragen"
+              : reviewStats.pending > 0
+                ? `${reviewStats.pending} F\u00e4lle bereit f\u00fcr Anfrage`
+                : "Alle angefragten F\u00e4lle versorgt"
+          }
+          subSignal="Letzte 30 Tage"
+          emptyText="Noch keine Bewertungsanfragen"
+        />
       </div>
 
       <CreateCaseModal open={modalOpen} onClose={() => setModalOpen(false)} />
@@ -618,27 +460,81 @@ export function ZentraleView({
 }
 
 // ---------------------------------------------------------------------------
-// Sub-components
+// ModuleCard — shared anatomy for all 5 Leitsystem modules
 // ---------------------------------------------------------------------------
 
-function SectionHeader({ label, count }: { label: string; count: number }) {
-  return (
-    <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3 px-1">
-      {label}
-      {count > 0 && (
-        <span className="ml-1.5 text-gray-400 normal-case tracking-normal font-medium">
-          ({count})
-        </span>
-      )}
-    </h2>
-  );
-}
+function ModuleCard({
+  href,
+  label,
+  accentColor,
+  count,
+  countSuffix,
+  context,
+  subSignal,
+  emptyText,
+  tinted,
+  tintClass,
+  fullWidth,
+}: {
+  href: string;
+  label: string;
+  accentColor: string;
+  count: number;
+  countSuffix?: string;
+  context: string;
+  subSignal?: string;
+  emptyText: string;
+  tinted?: boolean;
+  tintClass?: string;
+  fullWidth?: boolean;
+}) {
+  const isEmpty = count === 0;
 
-function EmptyState({ text }: { text: string }) {
   return (
-    <div className="bg-white border border-gray-200 rounded-xl px-4 py-8 text-center">
-      <p className="text-sm text-gray-400">{text}</p>
-    </div>
+    <Link
+      href={href}
+      className={`block border border-gray-200 rounded-2xl border-l-[4px] ${accentColor} px-6 py-5 transition-all hover:border-gray-300 hover:shadow-sm group ${
+        tinted && !isEmpty ? tintClass ?? "" : "bg-white"
+      } ${isEmpty ? "bg-white" : "bg-white"}`}
+    >
+      {/* Module identity */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">
+          {label}
+        </span>
+        <svg className="w-3.5 h-3.5 text-gray-300 group-hover:text-gray-500 transition-colors" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+        </svg>
+      </div>
+
+      {/* Primary metric */}
+      <div className="mb-1.5">
+        {countSuffix ? (
+          <span className="text-gray-900">
+            <span className="text-2xl font-bold">{count}</span>
+            <span className="text-sm font-medium text-gray-500 ml-1">{countSuffix}</span>
+          </span>
+        ) : (
+          <span className={`text-2xl font-bold ${isEmpty ? "text-gray-300" : "text-gray-900"}`}>
+            {count}
+          </span>
+        )}
+      </div>
+
+      {/* Context line */}
+      <p className={`text-sm ${isEmpty ? "text-gray-400" : "text-gray-600"}`}>
+        {isEmpty ? emptyText : context}
+      </p>
+
+      {/* Sub-signal */}
+      {subSignal && !isEmpty && (
+        <p className="text-xs text-gray-400 mt-1">{subSignal}</p>
+      )}
+      {/* Wirkung: show sub-signal even when empty for time-scope clarity */}
+      {subSignal && isEmpty && label === "Wirkung" && (
+        <p className="text-xs text-gray-400 mt-1">{subSignal}</p>
+      )}
+    </Link>
   );
 }
 

--- a/supabase/migrations/20260316000000_weinberger_prefix_jw.sql
+++ b/supabase/migrations/20260316000000_weinberger_prefix_jw.sql
@@ -1,0 +1,3 @@
+-- Change Weinberger AG case_id_prefix from WB to JW
+-- Aligns with sidebar initials (Jul. Weinberger → JW) for visual consistency
+UPDATE tenants SET case_id_prefix = 'JW' WHERE slug = 'weinberger-ag';


### PR DESCRIPTION
## Summary
- **Leitsystem**: 5-module card grid (Neu, Wartet, Heute, Abschluss, Wirkung) replacing list-based Zentrale
- **Sidebar**: Dark theme (gray-950), premium brand header, 3 nav items only (Leitsystem, Fälle, Einstellungen)
- **Fälle**: Semantic `view=` filters mirroring Leitsystem modules 1:1 (neu/wartet/heute/abschluss/wirkung)
- **JW prefix**: Weinberger AG case_id_prefix changed from WB to JW (DB migration applied)
- **Wirkung**: Server-side review stats (30d scoped, honest data)
- **Betriebspuls**: System health line replacing separate Überblick nav item

## Files changed
- `OpsShell.tsx` — Dark sidebar, 3 nav, premium brand header
- `ZentraleView.tsx` — 5-module card grid with ModuleCard component
- `cases/page.tsx` — Added review stats queries
- `faelle/page.tsx` — Semantic view= filters, mirrored quickfilter chips
- `layout.tsx` — Removed staffCount, title → "Leitsystem"
- `20260316000000_weinberger_prefix_jw.sql` — JW prefix migration

## Test plan
- [ ] Login → see dark sidebar with "JW" / "Jul. Weinberger AG" / "Leitsystem" sublabel
- [ ] Leitsystem: 5 module cards (Neu, Wartet, Heute, Abschluss, Wirkung)
- [ ] Each card: click → filtered Fälle with correct view= parameter
- [ ] Fälle quickfilter chips: Offen, Neu, Wartet, Heute, Abschluss, Alle
- [ ] All case IDs show JW-XXXX
- [ ] Settings: JW prefix displayed correctly
- [ ] Mobile: dark sidebar overlay, brand header
- [ ] `/ops/metrics` still accessible via direct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)