### PR TITLE
feat: custom appointment picker with von-bis range

### DIFF
--- a/src/web/app/api/ops/cases/[id]/route.ts
+++ b/src/web/app/api/ops/cases/[id]/route.ts
@@ -28,6 +28,7 @@ const FIELD_LABELS: Record<string, string> = {
   house_number: "Hausnummer",
   assignee_text: "Zuständig",
   scheduled_at: "Termin",
+  scheduled_end_at: "Termin-Ende",
   internal_notes: "Notizen",
   contact_email: "E-Mail",
   contact_phone: "Telefon",
@@ -45,6 +46,7 @@ const OPS_UPDATABLE_FIELDS = [
   "description",
   "assignee_text",
   "scheduled_at",
+  "scheduled_end_at",
   "internal_notes",
   "contact_email",
   "contact_phone",
@@ -191,7 +193,7 @@ export async function PATCH(
       .update(update)
       .eq("id", id)
       .select(
-        "id, status, urgency, category, plz, city, description, assignee_text, scheduled_at, internal_notes, contact_email, contact_phone, street, house_number, reporter_name, updated_at"
+        "id, status, urgency, category, plz, city, description, assignee_text, scheduled_at, scheduled_end_at, internal_notes, contact_email, contact_phone, street, house_number, reporter_name, updated_at"
       )
       .single();
 

--- a/src/web/app/api/ops/cases/[id]/send-invite/route.ts
+++ b/src/web/app/api/ops/cases/[id]/send-invite/route.ts
@@ -53,6 +53,29 @@ function buildIcs(opts: {
 }
 
 // ---------------------------------------------------------------------------
+// Termin range formatting
+// ---------------------------------------------------------------------------
+
+const dateFmt: Intl.DateTimeFormatOptions = {
+  weekday: "short", day: "2-digit", month: "2-digit",
+  timeZone: "Europe/Zurich",
+};
+const timeFmt: Intl.DateTimeFormatOptions = {
+  hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich",
+};
+
+function formatTerminRange(start: Date, end: Date): string {
+  const sameDay =
+    start.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", timeZone: "Europe/Zurich" }) ===
+    end.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", timeZone: "Europe/Zurich" });
+
+  if (sameDay) {
+    return `${start.toLocaleDateString("de-CH", dateFmt)}, ${start.toLocaleTimeString("de-CH", timeFmt)}–${end.toLocaleTimeString("de-CH", timeFmt)}`;
+  }
+  return `${start.toLocaleDateString("de-CH", dateFmt)} ${start.toLocaleTimeString("de-CH", timeFmt)} – ${end.toLocaleDateString("de-CH", dateFmt)} ${end.toLocaleTimeString("de-CH", timeFmt)}`;
+}
+
+// ---------------------------------------------------------------------------
 // POST /api/ops/cases/[id]/send-invite
 // ---------------------------------------------------------------------------
 
@@ -97,7 +120,7 @@ export async function POST(
   const supabase = getServiceClient();
   const { data: row, error: dbError } = await supabase
     .from("cases")
-    .select("id, seq_number, scheduled_at, category, city")
+    .select("id, seq_number, scheduled_at, scheduled_end_at, category, city")
     .eq("id", id)
     .single();
 
@@ -147,7 +170,9 @@ export async function POST(
     ? `FS-${String(row.seq_number).padStart(4, "0")}`
     : id.slice(0, 8);
   const dtStart = new Date(row.scheduled_at);
-  const dtEnd = new Date(dtStart.getTime() + 60 * 60 * 1000); // +60 min
+  const dtEnd = row.scheduled_end_at
+    ? new Date(row.scheduled_end_at)
+    : new Date(dtStart.getTime() + 60 * 60 * 1000);
 
   const fromEnvValue = process.env.MAIL_FROM;
   const from = fromEnvValue ?? "noreply@send.flowsight.ch";
@@ -185,7 +210,7 @@ export async function POST(
         `FlowSight Termin`,
         `──────────────────────`,
         `Fall:    ${caseLabel}`,
-        `Termin:  ${dtStart.toLocaleDateString("de-CH", { timeZone: "Europe/Zurich", day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}`,
+        `Termin:  ${formatTerminRange(dtStart, dtEnd)}`,
         ``,
         `Fall öffnen: ${opsLink}`,
         `(Login erforderlich)`,

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -5,6 +5,7 @@ import type { CaseDetail } from "./page";
 import { deriveReviewStatus } from "@/src/lib/reviews/deriveReviewStatus";
 import type { CaseEvent } from "@/src/components/ops/CaseTimeline";
 import { AttachmentsSection } from "./AttachmentsSection";
+import { AppointmentPicker } from "@/src/components/ops/AppointmentPicker";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -38,8 +39,6 @@ const URGENCIES = [
 
 const URGENCY_LABELS: Record<string, string> = Object.fromEntries(URGENCIES.map(u => [u.value, u.label]));
 
-const QUICK_TIMES = ["08:00", "11:00", "15:00"] as const;
-
 const NEXT_STEP: Record<string, string> = {
   new: "Sichten und einordnen",
   scheduled: "Einsatz durchführen",
@@ -51,21 +50,6 @@ const NEXT_STEP: Record<string, string> = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function toDatetimeLocal(iso: string): string {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return "";
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-function quickDateTime(dayOffset: number, time: string): string {
-  const d = new Date();
-  d.setDate(d.getDate() + dayOffset);
-  const [h, m] = time.split(":").map(Number);
-  d.setHours(h, m, 0, 0);
-  return toDatetimeLocal(d.toISOString());
-}
-
 function formatEventDate(iso: string): string {
   return new Date(iso).toLocaleDateString("de-CH", {
     day: "2-digit",
@@ -76,15 +60,29 @@ function formatEventDate(iso: string): string {
   });
 }
 
-function formatTermin(iso: string): string {
-  return new Date(iso).toLocaleDateString("de-CH", {
-    weekday: "short",
-    day: "2-digit",
-    month: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZone: "Europe/Zurich",
-  });
+function formatTerminRange(startIso: string, endIso: string | null): string {
+  const s = new Date(startIso);
+  const dayFmt: Intl.DateTimeFormatOptions = {
+    weekday: "short", day: "2-digit", month: "2-digit", timeZone: "Europe/Zurich",
+  };
+  const timeFmt: Intl.DateTimeFormatOptions = {
+    hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich",
+  };
+
+  if (!endIso) {
+    // Legacy single-point
+    return `${s.toLocaleDateString("de-CH", dayFmt)}, ${s.toLocaleTimeString("de-CH", timeFmt)}`;
+  }
+
+  const e = new Date(endIso);
+  const sameDay =
+    s.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", timeZone: "Europe/Zurich" }) ===
+    e.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", timeZone: "Europe/Zurich" });
+
+  if (sameDay) {
+    return `${s.toLocaleDateString("de-CH", dayFmt)} · ${s.toLocaleTimeString("de-CH", timeFmt)}–${e.toLocaleTimeString("de-CH", timeFmt)}`;
+  }
+  return `${s.toLocaleDateString("de-CH", dayFmt)} ${s.toLocaleTimeString("de-CH", timeFmt)} – ${e.toLocaleDateString("de-CH", dayFmt)} ${e.toLocaleTimeString("de-CH", timeFmt)}`;
 }
 
 function googleMapsUrl(street: string | null, houseNumber: string | null, plz: string, city: string): string {
@@ -151,16 +149,17 @@ export function CaseDetailForm({
   const [city, setCity] = useState(initialData.city);
   const [description, setDescription] = useState(initialData.description);
   const [assigneeText, setAssigneeText] = useState(initialData.assignee_text ?? "");
-  const [scheduledAt, setScheduledAt] = useState(
-    initialData.scheduled_at ? toDatetimeLocal(initialData.scheduled_at) : "",
-  );
+  const [scheduledAt, setScheduledAt] = useState(initialData.scheduled_at ?? "");
+  const [scheduledEndAt, setScheduledEndAt] = useState(initialData.scheduled_end_at ?? "");
   const [internalNotes, setInternalNotes] = useState(initialData.internal_notes ?? "");
   const [reporterName, setReporterName] = useState(initialData.reporter_name ?? "");
   const [contactPhone, setContactPhone] = useState(initialData.contact_phone ?? "");
   const [contactEmail, setContactEmail] = useState(initialData.contact_email ?? "");
   const [street, setStreet] = useState(initialData.street ?? "");
   const [houseNumber, setHouseNumber] = useState(initialData.house_number ?? "");
-  const [quickDay, setQuickDay] = useState<0 | 1>(0);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [showTerminWarning, setShowTerminWarning] = useState(false);
+  const [terminSentForCurrent, setTerminSentForCurrent] = useState(false);
 
   const [baseline, setBaseline] = useState({
     status: initialData.status,
@@ -170,7 +169,8 @@ export function CaseDetailForm({
     city: initialData.city,
     description: initialData.description,
     assignee_text: initialData.assignee_text ?? "",
-    scheduled_at: initialData.scheduled_at ? toDatetimeLocal(initialData.scheduled_at) : "",
+    scheduled_at: initialData.scheduled_at ?? "",
+    scheduled_end_at: initialData.scheduled_end_at ?? "",
     internal_notes: initialData.internal_notes ?? "",
     reporter_name: initialData.reporter_name ?? "",
     contact_phone: initialData.contact_phone ?? "",
@@ -203,7 +203,8 @@ export function CaseDetailForm({
   // ── Per-section dirty checks ─────────────────────────────────────────
   const steuerungDirty =
     status !== baseline.status || urgency !== baseline.urgency ||
-    assigneeText !== baseline.assignee_text || scheduledAt !== baseline.scheduled_at;
+    assigneeText !== baseline.assignee_text || scheduledAt !== baseline.scheduled_at ||
+    scheduledEndAt !== baseline.scheduled_end_at;
 
   const kontaktDirty =
     street !== baseline.street || houseNumber !== baseline.house_number ||
@@ -248,8 +249,7 @@ export function CaseDetailForm({
         for (const [k, v] of Object.entries(fields)) {
           const key = k as keyof typeof next;
           if (key in next) {
-            (next as Record<string, unknown>)[key] = key === "scheduled_at" && v
-              ? toDatetimeLocal(v as string) : v ?? "";
+            (next as Record<string, unknown>)[key] = v ?? "";
           }
         }
         return next;
@@ -269,7 +269,8 @@ export function CaseDetailForm({
     return saveFields({
       status, urgency,
       assignee_text: assigneeText || null,
-      scheduled_at: scheduledAt ? new Date(scheduledAt).toISOString() : null,
+      scheduled_at: scheduledAt || null,
+      scheduled_end_at: scheduledEndAt || null,
     });
   }
 
@@ -300,6 +301,8 @@ export function CaseDetailForm({
     setUrgency(baseline.urgency);
     setAssigneeText(baseline.assignee_text);
     setScheduledAt(baseline.scheduled_at);
+    setScheduledEndAt(baseline.scheduled_end_at);
+    setPickerOpen(false);
     setStreet(baseline.street);
     setHouseNumber(baseline.house_number);
     setPlz(baseline.plz);
@@ -328,6 +331,7 @@ export function CaseDetailForm({
       const res = await fetch(`/api/ops/cases/${initialData.id}/send-invite`, { method: "POST" });
       if (!res.ok) throw new Error("Fehler");
       setInviteState("sent");
+      setTerminSentForCurrent(true);
       setTimeout(() => setInviteState("idle"), 3000);
     } catch {
       setInviteState("error");
@@ -448,36 +452,84 @@ export function CaseDetailForm({
               </div>
               <div>
                 <label className={lbl}>Termin</label>
-                <input type="datetime-local" value={scheduledAt} onChange={e => setScheduledAt(e.target.value)} className={inp} />
+                <button
+                  type="button"
+                  onClick={() => setPickerOpen(p => !p)}
+                  className={`${inp} text-left`}
+                >
+                  {scheduledAt
+                    ? formatTerminRange(scheduledAt, scheduledEndAt || null)
+                    : <span className="text-gray-400">Termin wählen</span>}
+                </button>
               </div>
             </div>
 
-            {/* Termin quick-pick */}
-            <div className="flex items-center gap-2 flex-wrap mb-3">
-              <div className="flex rounded-lg border border-gray-200 overflow-hidden">
-                {([0, 1] as const).map(d => (
-                  <button key={d} type="button" onClick={() => setQuickDay(d)}
-                    className={`px-2.5 py-1.5 text-xs font-medium transition-colors ${quickDay === d ? "bg-gray-800 text-white" : "bg-white text-gray-500 hover:bg-gray-50"}`}
-                  >{d === 0 ? "Heute" : "Morgen"}</button>
-                ))}
-              </div>
-              <div className="flex gap-1">
-                {QUICK_TIMES.map(time => (
-                  <button key={time} type="button" onClick={() => setScheduledAt(quickDateTime(quickDay, time))}
-                    className="rounded border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-600 hover:border-gray-400 transition-colors"
-                  >{time}</button>
-                ))}
-              </div>
-            </div>
-            {scheduledAt && (
-              <div className="mt-2 pt-2 border-t border-gray-200/60 mb-3">
+            {/* Appointment Picker (inline) */}
+            {pickerOpen && (
+              <AppointmentPicker
+                initialStart={scheduledAt || null}
+                initialEnd={scheduledEndAt || null}
+                brandColor={brandColor}
+                onConfirm={(startIso, endIso) => {
+                  setScheduledAt(startIso);
+                  setScheduledEndAt(endIso);
+                  setPickerOpen(false);
+                  setTerminSentForCurrent(false);
+                }}
+                onCancel={() => setPickerOpen(false)}
+              />
+            )}
+
+            {/* Send invite button — after picker closes, if termin is set */}
+            {scheduledAt && !pickerOpen && (
+              <div className="flex items-center justify-end mt-2 pt-2 border-t border-gray-200/60 mb-3">
                 <button onClick={handleSendInvite} disabled={inviteState === "sending"}
                   className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-40 transition-colors"
-                >{inviteState === "sending" ? "Sende…" : inviteState === "sent" ? "Gesendet ✓" : "Termin senden"}</button>
+                >{inviteState === "sending" ? "Sende…" : inviteState === "sent" ? "Gesendet ✓" : "Termin senden →"}</button>
               </div>
             )}
 
-            <EditActions onSave={saveSteuerung} onCancel={cancelEdit} saving={saveState === "saving"} dirty={steuerungDirty} error={saveState === "error" ? errorMsg : ""} />
+            {/* Warning banner: Termin changed but not sent */}
+            {showTerminWarning && (
+              <div className="flex items-center justify-between gap-3 mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                <p className="text-sm text-amber-800">
+                  Termin eingetragen, aber noch nicht an den Kunden gesendet.
+                </p>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      setShowTerminWarning(false);
+                      await handleSendInvite();
+                    }}
+                    className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 transition-colors"
+                  >Jetzt senden</button>
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      setShowTerminWarning(false);
+                      await saveSteuerung();
+                    }}
+                    className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+                  >Nur speichern</button>
+                </div>
+              </div>
+            )}
+
+            <EditActions
+              onSave={() => {
+                const terminChanged = scheduledAt !== baseline.scheduled_at || scheduledEndAt !== baseline.scheduled_end_at;
+                if (terminChanged && !terminSentForCurrent) {
+                  setShowTerminWarning(true);
+                } else {
+                  saveSteuerung();
+                }
+              }}
+              onCancel={() => { setShowTerminWarning(false); cancelEdit(); }}
+              saving={saveState === "saving"}
+              dirty={steuerungDirty}
+              error={saveState === "error" ? errorMsg : ""}
+            />
           </div>
         ) : (
           <div className="bg-gray-50 -mx-5 -my-4 px-5 py-5 rounded-t-2xl border-b border-gray-200/60">
@@ -502,7 +554,7 @@ export function CaseDetailForm({
               </KV>
               <KV label="Termin">
                 {scheduledAt
-                  ? <span className="text-[15px] font-semibold text-gray-900">{formatTermin(new Date(scheduledAt).toISOString())}</span>
+                  ? <span className="text-[15px] font-semibold text-gray-900">{formatTerminRange(scheduledAt, scheduledEndAt || null)}</span>
                   : <span className="text-sm text-gray-500">Offen</span>}
               </KV>
             </div>

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -33,6 +33,7 @@ export interface CaseDetail {
   status: string;
   assignee_text: string | null;
   scheduled_at: string | null;
+  scheduled_end_at: string | null;
   internal_notes: string | null;
   review_sent_at: string | null;
 }

--- a/src/web/src/components/ops/AppointmentPicker.tsx
+++ b/src/web/src/components/ops/AppointmentPicker.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState } from "react";
+import { MiniCalendar } from "./MiniCalendar";
+import { TimeSlotSelector } from "./TimeSlotSelector";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AppointmentPickerProps {
+  /** Pre-selected start (ISO string or null) */
+  initialStart: string | null;
+  /** Pre-selected end (ISO string or null) */
+  initialEnd: string | null;
+  brandColor: string;
+  onConfirm: (startIso: string, endIso: string) => void;
+  onCancel: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isoToDateStr(iso: string): string {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function isoToTime(iso: string): string {
+  const d = new Date(iso);
+  const h = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  // Snap to nearest 15
+  const snapped = Math.round(parseInt(min) / 15) * 15;
+  const sm = snapped === 60 ? "00" : String(snapped).padStart(2, "0");
+  const sh = snapped === 60 ? String(parseInt(h) + 1).padStart(2, "0") : h;
+  return `${sh}:${sm}`;
+}
+
+function bumpTime(time: string, minutes: number): string {
+  const [h, m] = time.split(":").map(Number);
+  const total = h * 60 + m + minutes;
+  const nh = Math.min(20, Math.floor(total / 60));
+  const nm = total % 60;
+  return `${String(nh).padStart(2, "0")}:${String(nm - (nm % 15)).padStart(2, "0")}`;
+}
+
+function toIso(dateStr: string, time: string): string {
+  return new Date(`${dateStr}T${time}:00`).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AppointmentPicker({
+  initialStart, initialEnd, brandColor, onConfirm, onCancel,
+}: AppointmentPickerProps) {
+  // Derive initial values
+  const now = new Date();
+  const initStartDate = initialStart ? isoToDateStr(initialStart) : null;
+  const initEndDate = initialEnd ? isoToDateStr(initialEnd) : null;
+  const initStartTime = initialStart ? isoToTime(initialStart) : "08:00";
+  const initEndTime = initialEnd ? isoToTime(initialEnd) : "09:00";
+
+  const [startDate, setStartDate] = useState<string | null>(initStartDate);
+  const [endDate, setEndDate] = useState<string | null>(initEndDate);
+  const [startTime, setStartTime] = useState(initStartTime);
+  const [endTime, setEndTime] = useState(initEndTime);
+
+  // Calendar navigation
+  const initMonth = initialStart ? new Date(initialStart).getMonth() + 1 : now.getMonth() + 1;
+  const initYear = initialStart ? new Date(initialStart).getFullYear() : now.getFullYear();
+  const [calMonth, setCalMonth] = useState(initMonth);
+  const [calYear, setCalYear] = useState(initYear);
+
+  function prevMonth() {
+    setCalMonth(m => m === 1 ? 12 : m - 1);
+    if (calMonth === 1) setCalYear(y => y - 1);
+  }
+
+  function nextMonth() {
+    setCalMonth(m => m === 12 ? 1 : m + 1);
+    if (calMonth === 12) setCalYear(y => y + 1);
+  }
+
+  // Date click state machine
+  function handleDateClick(dateStr: string) {
+    if (!startDate) {
+      setStartDate(dateStr);
+      setEndDate(null);
+    } else if (!endDate) {
+      if (dateStr === startDate) {
+        setStartDate(null);
+      } else if (dateStr > startDate) {
+        setEndDate(dateStr);
+      } else {
+        setEndDate(startDate);
+        setStartDate(dateStr);
+      }
+    } else {
+      setStartDate(dateStr);
+      setEndDate(null);
+    }
+  }
+
+  // Time validation: single day → endTime must be > startTime
+  function handleStartTimeChange(t: string) {
+    setStartTime(t);
+    if (startDate && !endDate && t >= endTime) {
+      setEndTime(bumpTime(t, 15));
+    }
+  }
+
+  function handleEndTimeChange(t: string) {
+    if (startDate && !endDate && t <= startTime) {
+      setEndTime(bumpTime(startTime, 15));
+    } else {
+      setEndTime(t);
+    }
+  }
+
+  // Confirm
+  const canConfirm = !!startDate;
+  const handleConfirm = () => {
+    if (!startDate) return;
+    const effEndDate = endDate ?? startDate;
+    onConfirm(toIso(startDate, startTime), toIso(effEndDate, endTime));
+  };
+
+  return (
+    <div className="border border-gray-200 rounded-xl bg-white shadow-sm p-4 mt-3">
+      <div className="flex flex-col md:flex-row gap-4">
+        {/* Calendar */}
+        <div className="flex-1 min-w-[240px]">
+          <MiniCalendar
+            startDate={startDate}
+            endDate={endDate}
+            month={calMonth}
+            year={calYear}
+            brandColor={brandColor}
+            onDateClick={handleDateClick}
+            onPrevMonth={prevMonth}
+            onNextMonth={nextMonth}
+          />
+        </div>
+
+        {/* Time columns */}
+        <div className="flex gap-3 md:gap-2">
+          <div className="flex-1 md:w-20">
+            <TimeSlotSelector
+              label="Von"
+              value={startTime}
+              brandColor={brandColor}
+              onChange={handleStartTimeChange}
+            />
+          </div>
+          <div className="flex-1 md:w-20">
+            <TimeSlotSelector
+              label="Bis"
+              value={endTime}
+              brandColor={brandColor}
+              onChange={handleEndTimeChange}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Summary + Actions */}
+      <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-100">
+        <div className="text-sm text-gray-600">
+          {startDate ? (
+            <span className="font-medium text-gray-800">
+              {formatPickerSummary(startDate, endDate, startTime, endTime)}
+            </span>
+          ) : (
+            <span className="text-gray-400">Tag wählen</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            className="rounded-lg px-4 py-1.5 text-xs font-semibold text-white shadow-sm disabled:opacity-40 transition-colors"
+            style={{ backgroundColor: brandColor }}
+            onMouseEnter={(e) => { e.currentTarget.style.opacity = "0.9"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.opacity = canConfirm ? "1" : "0.4"; }}
+          >
+            Übernehmen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary formatter
+// ---------------------------------------------------------------------------
+
+function formatPickerSummary(
+  startDate: string, endDate: string | null,
+  startTime: string, endTime: string,
+): string {
+  const sd = new Date(startDate + "T12:00:00");
+  const dayFmt: Intl.DateTimeFormatOptions = {
+    weekday: "short", day: "2-digit", month: "2-digit",
+    timeZone: "Europe/Zurich",
+  };
+
+  if (!endDate || endDate === startDate) {
+    // Same day
+    return `${sd.toLocaleDateString("de-CH", dayFmt)} · ${startTime}–${endTime}`;
+  }
+
+  const ed = new Date(endDate + "T12:00:00");
+  return `${sd.toLocaleDateString("de-CH", dayFmt)} ${startTime} – ${ed.toLocaleDateString("de-CH", dayFmt)} ${endTime}`;
+}

--- a/src/web/src/components/ops/MiniCalendar.tsx
+++ b/src/web/src/components/ops/MiniCalendar.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useMemo } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MiniCalendarProps {
+  /** Currently selected start date (YYYY-MM-DD) */
+  startDate: string | null;
+  /** Currently selected end date (YYYY-MM-DD) */
+  endDate: string | null;
+  /** Visible month (1-indexed) */
+  month: number;
+  /** Visible year */
+  year: number;
+  /** Tenant brand color for accents */
+  brandColor: string;
+  onDateClick: (dateStr: string) => void;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WEEKDAYS = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"];
+
+function toDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function todayStr(): string {
+  return toDateStr(new Date());
+}
+
+const MONTH_NAMES = [
+  "Januar", "Februar", "März", "April", "Mai", "Juni",
+  "Juli", "August", "September", "Oktober", "November", "Dezember",
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function MiniCalendar({
+  startDate, endDate, month, year, brandColor,
+  onDateClick, onPrevMonth, onNextMonth,
+}: MiniCalendarProps) {
+  const today = todayStr();
+
+  // Build grid: array of { dateStr, dayNum, isCurrentMonth }
+  const cells = useMemo(() => {
+    const firstOfMonth = new Date(year, month - 1, 1);
+    // Monday = 0, Sunday = 6
+    const startDow = (firstOfMonth.getDay() + 6) % 7;
+    const daysInMonth = new Date(year, month, 0).getDate();
+
+    const result: { dateStr: string; dayNum: number; isCurrentMonth: boolean }[] = [];
+
+    // Previous month padding
+    const prevMonthDays = new Date(year, month - 1, 0).getDate();
+    for (let i = startDow - 1; i >= 0; i--) {
+      const d = prevMonthDays - i;
+      const dt = new Date(year, month - 2, d);
+      result.push({ dateStr: toDateStr(dt), dayNum: d, isCurrentMonth: false });
+    }
+
+    // Current month
+    for (let d = 1; d <= daysInMonth; d++) {
+      const dt = new Date(year, month - 1, d);
+      result.push({ dateStr: toDateStr(dt), dayNum: d, isCurrentMonth: true });
+    }
+
+    // Next month padding (fill to 42 = 6 rows, or at least complete the last row)
+    const remainder = result.length % 7;
+    if (remainder > 0) {
+      const fill = 7 - remainder;
+      for (let d = 1; d <= fill; d++) {
+        const dt = new Date(year, month, d);
+        result.push({ dateStr: toDateStr(dt), dayNum: d, isCurrentMonth: false });
+      }
+    }
+
+    return result;
+  }, [year, month]);
+
+  return (
+    <div className="select-none">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <button
+          type="button"
+          onClick={onPrevMonth}
+          className="p-1.5 rounded-md text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+          </svg>
+        </button>
+        <span className="text-sm font-semibold text-gray-800">
+          {MONTH_NAMES[month - 1]} {year}
+        </span>
+        <button
+          type="button"
+          onClick={onNextMonth}
+          className="p-1.5 rounded-md text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 mb-1">
+        {WEEKDAYS.map(wd => (
+          <div key={wd} className="text-center text-[10px] font-medium text-gray-400 uppercase tracking-wide py-1">
+            {wd}
+          </div>
+        ))}
+      </div>
+
+      {/* Day grid */}
+      <div className="grid grid-cols-7">
+        {cells.map(({ dateStr, dayNum, isCurrentMonth }) => {
+          const isToday = dateStr === today;
+          const isStart = dateStr === startDate;
+          const isEnd = dateStr === endDate;
+          const isSelected = isStart || isEnd;
+          const inRange =
+            startDate && endDate && dateStr > startDate && dateStr < endDate;
+
+          return (
+            <button
+              key={dateStr}
+              type="button"
+              onClick={() => isCurrentMonth && onDateClick(dateStr)}
+              disabled={!isCurrentMonth}
+              className="relative flex items-center justify-center h-8 text-xs font-medium transition-all duration-150"
+              style={{
+                color: isSelected
+                  ? "#fff"
+                  : !isCurrentMonth
+                  ? "#d1d5db"
+                  : undefined,
+                backgroundColor: isSelected
+                  ? brandColor
+                  : inRange
+                  ? `${brandColor}1a`
+                  : undefined,
+                borderRadius: isSelected ? "9999px" : undefined,
+                cursor: !isCurrentMonth ? "default" : "pointer",
+              }}
+              onMouseEnter={(e) => {
+                if (isCurrentMonth && !isSelected) {
+                  e.currentTarget.style.backgroundColor = `${brandColor}14`;
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (!isSelected && !inRange) {
+                  e.currentTarget.style.backgroundColor = "";
+                } else if (inRange && !isSelected) {
+                  e.currentTarget.style.backgroundColor = `${brandColor}1a`;
+                }
+              }}
+            >
+              <span
+                className="relative z-10"
+                style={
+                  isToday && !isSelected
+                    ? {
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        width: "28px",
+                        height: "28px",
+                        borderRadius: "9999px",
+                        boxShadow: `inset 0 0 0 2px ${brandColor}`,
+                      }
+                    : undefined
+                }
+              >
+                {dayNum}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/ops/TimeSlotSelector.tsx
+++ b/src/web/src/components/ops/TimeSlotSelector.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TimeSlotSelectorProps {
+  label: string; // "Von" or "Bis"
+  value: string; // "15:00"
+  brandColor: string;
+  onChange: (time: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Generate 15-min slots 06:00..20:00
+// ---------------------------------------------------------------------------
+
+const SLOTS: string[] = [];
+for (let h = 6; h <= 20; h++) {
+  for (let m = 0; m < 60; m += 15) {
+    SLOTS.push(`${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TimeSlotSelector({ label, value, brandColor, onChange }: TimeSlotSelectorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  // Auto-scroll to selected slot on mount / value change
+  useEffect(() => {
+    if (selectedRef.current && containerRef.current) {
+      const container = containerRef.current;
+      const el = selectedRef.current;
+      const top = el.offsetTop - container.offsetTop - container.clientHeight / 2 + el.clientHeight / 2;
+      container.scrollTo({ top: Math.max(0, top), behavior: "smooth" });
+    }
+  }, [value]);
+
+  return (
+    <div className="flex flex-col">
+      <span className="text-[10px] font-medium text-gray-400 uppercase tracking-wide mb-1.5 px-1">
+        {label}
+      </span>
+      <div
+        ref={containerRef}
+        className="max-h-[200px] md:max-h-[200px] overflow-y-auto border border-gray-200 rounded-lg shadow-sm bg-white"
+      >
+        {SLOTS.map(slot => {
+          const isSelected = slot === value;
+          return (
+            <button
+              key={slot}
+              ref={isSelected ? selectedRef : undefined}
+              type="button"
+              onClick={() => onChange(slot)}
+              className="w-full px-3 py-1.5 text-xs font-medium text-left transition-colors"
+              style={{
+                backgroundColor: isSelected ? brandColor : undefined,
+                color: isSelected ? "#fff" : "#374151",
+                borderRadius: isSelected ? "0.5rem" : undefined,
+              }}
+              onMouseEnter={(e) => {
+                if (!isSelected) e.currentTarget.style.backgroundColor = `${brandColor}14`;
+              }}
+              onMouseLeave={(e) => {
+                if (!isSelected) e.currentTarget.style.backgroundColor = "";
+              }}
+            >
+              {slot}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260317000000_scheduled_end_at.sql
+++ b/supabase/migrations/20260317000000_scheduled_end_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cases ADD COLUMN scheduled_end_at timestamptz;
+COMMENT ON COLUMN cases.scheduled_end_at IS 'End of appointment window. NULL = legacy 60-min default.';


### PR DESCRIPTION
## Summary
- Replace native `<input type="datetime-local">` with custom branded mini-calendar + 15-min time slot selectors
- Add `scheduled_end_at` DB column for von-bis appointment ranges (single day + multi-day)
- Warning banner when saving a changed Termin without sending it to the customer
- ICS calendar invite + email body now show the actual von-bis range

## Changes
- **Migration:** `scheduled_end_at timestamptz` on `cases`
- **API:** PATCH route accepts `scheduled_end_at`, send-invite uses it for ICS duration
- **MiniCalendar:** Month grid, Mo-So, brand color accents (today ring, selected fill, range tint)
- **TimeSlotSelector:** 06:00-20:00, 15-min steps, auto-scroll to selected
- **AppointmentPicker:** Orchestrates calendar + Von/Bis columns + Übernehmen
- **CaseDetailForm:** Removed quick-pick (Heute/Morgen + 08/11/15), inline picker, range display, "Termin senden →" right-aligned, save-without-send warning

## Test plan
- [ ] Open case detail, click Bearbeiten on Übersicht
- [ ] Click "Termin wählen" → picker opens inline
- [ ] Select single day → Von/Bis times shown, endTime auto-bumps if <= startTime
- [ ] Select date range (click 2 dates) → range highlighted with brand color tint
- [ ] Click Übernehmen → picker closes, summary shows range format
- [ ] "Termin senden →" button appears right-aligned
- [ ] Click Speichern with changed Termin → amber warning banner appears
- [ ] "Jetzt senden" sends invite, "Nur speichern" saves without sending
- [ ] Verify ICS attachment has correct DTSTART/DTEND
- [ ] Mobile: calendar + time columns stack vertically
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)