### PR TITLE
fix: settings redesign + staff save bug + smart invite routing

### DIFF
--- a/src/web/app/api/ops/cases/[id]/send-invite/route.ts
+++ b/src/web/app/api/ops/cases/[id]/send-invite/route.ts
@@ -120,7 +120,7 @@ export async function POST(
   const supabase = getServiceClient();
   const { data: row, error: dbError } = await supabase
     .from("cases")
-    .select("id, tenant_id, seq_number, scheduled_at, scheduled_end_at, category, city")
+    .select("id, tenant_id, seq_number, scheduled_at, scheduled_end_at, category, city, assignee_text")
     .eq("id", id)
     .single();
 
@@ -143,17 +143,38 @@ export async function POST(
     });
   }
 
-  // ── Resolve recipient: tenant calendar email → fallback env var ──────
-  const { data: tenant } = await supabase
-    .from("tenants")
-    .select("modules")
-    .eq("id", row.tenant_id)
-    .single();
-  const modules = (tenant?.modules ?? {}) as Record<string, unknown>;
-  const calendarEmail = typeof modules.business_calendar_email === "string"
-    ? modules.business_calendar_email.trim()
-    : "";
-  const to = calendarEmail || process.env.MAIL_REPLY_TO;
+  // ── Resolve recipient: assigned staff email → tenant calendar email → env var
+  let recipientEmail: string | undefined;
+
+  // 1. Try assigned staff member's email
+  if (row.assignee_text) {
+    const { data: staffMatch } = await supabase
+      .from("staff")
+      .select("email")
+      .eq("tenant_id", row.tenant_id)
+      .eq("display_name", row.assignee_text)
+      .eq("is_active", true)
+      .limit(1)
+      .maybeSingle();
+    if (staffMatch?.email) recipientEmail = staffMatch.email;
+  }
+
+  // 2. Fallback: tenant calendar email
+  if (!recipientEmail) {
+    const { data: tenant } = await supabase
+      .from("tenants")
+      .select("modules")
+      .eq("id", row.tenant_id)
+      .single();
+    const modules = (tenant?.modules ?? {}) as Record<string, unknown>;
+    const calendarEmail = typeof modules.business_calendar_email === "string"
+      ? modules.business_calendar_email.trim()
+      : "";
+    if (calendarEmail) recipientEmail = calendarEmail;
+  }
+
+  // 3. Fallback: global env var
+  const to = recipientEmail || process.env.MAIL_REPLY_TO;
 
   if (!to) {
     return respond(400, { ok: false, error: "missing_calendar_email" }, {

--- a/src/web/app/ops/(dashboard)/settings/page.tsx
+++ b/src/web/app/ops/(dashboard)/settings/page.tsx
@@ -7,12 +7,11 @@ interface Settings {
   google_review_url: string;
   notify_reporter_email: boolean;
   notify_reporter_sms: boolean;
-  business_calendar_email: string;
 }
 
 interface SettingsData {
+  tenant_id: string;
   tenant_name: string;
-  case_id_prefix: string;
   settings: Settings;
 }
 
@@ -27,7 +26,6 @@ export default function SettingsPage() {
   const [googleReviewUrl, setGoogleReviewUrl] = useState("");
   const [notifyEmail, setNotifyEmail] = useState(true);
   const [notifySms, setNotifySms] = useState(true);
-  const [calendarEmail, setCalendarEmail] = useState("");
 
   useEffect(() => {
     fetch("/api/ops/settings")
@@ -38,7 +36,6 @@ export default function SettingsPage() {
           setGoogleReviewUrl(d.settings.google_review_url);
           setNotifyEmail(d.settings.notify_reporter_email);
           setNotifySms(d.settings.notify_reporter_sms);
-          setCalendarEmail(d.settings.business_calendar_email);
         }
       })
       .catch(() => setError("Einstellungen konnten nicht geladen werden."))
@@ -57,7 +54,6 @@ export default function SettingsPage() {
           google_review_url: googleReviewUrl,
           notify_reporter_email: notifyEmail,
           notify_reporter_sms: notifySms,
-          business_calendar_email: calendarEmail,
         }),
       });
       if (res.ok) {
@@ -85,55 +81,34 @@ export default function SettingsPage() {
         )}
       </div>
 
-      {/* Betriebsinformationen — prominent, read-only */}
-      <div className="bg-white border border-gray-200 rounded-xl p-5 mb-6">
-        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
-          Betrieb
-        </h3>
-        <div className="grid grid-cols-2 gap-4 text-sm">
-          <div>
-            <p className="text-gray-400 text-xs mb-0.5">Betriebsname</p>
-            <p className="text-gray-900 font-medium">
-              {data?.tenant_name ?? "—"}
-            </p>
-          </div>
-          <div>
-            <p className="text-gray-400 text-xs mb-0.5">Fall-Präfix</p>
-            <p className="text-gray-900 font-medium">
-              {data?.case_id_prefix ?? "—"}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {/* Editable settings */}
       <div className="space-y-5">
-        {/* Team — inline StaffManager */}
+        {/* Team */}
         <Section
           title="Team"
-          description="Mitarbeiter für Fall-Zuweisung und Kalendereinladungen."
+          description="Mitarbeiter verwalten. Die E-Mail-Adresse wird für Kalendereinladungen bei Terminzuweisung verwendet."
         >
-          <StaffManager />
+          <StaffManager tenantId={data?.tenant_id} embedded />
         </Section>
 
-        {/* Kalender-E-Mail */}
+        {/* Benachrichtigungen */}
         <Section
-          title="Kalender"
-          description="E-Mail-Adresse für Termineinladungen an den Betrieb."
+          title="Benachrichtigungen"
+          description="Automatische Rückmeldung an Meldende nach Fallerfassung."
         >
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">
-            Kalender-E-Mail
-          </label>
-          <input
-            type="email"
-            value={calendarEmail}
-            onChange={(e) => setCalendarEmail(e.target.value)}
-            placeholder="betrieb@example.ch"
-            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400"
-          />
-          <p className="mt-1.5 text-xs text-gray-400">
-            Termineinladungen werden an diese Adresse gesendet und erscheinen direkt in Ihrem Kalender (Outlook, Google, etc.)
-          </p>
+          <div className="space-y-3">
+            <Toggle
+              checked={notifyEmail}
+              onChange={setNotifyEmail}
+              label="E-Mail-Bestätigung"
+              description="Meldende erhalten eine E-Mail mit Fallnummer und Zusammenfassung"
+            />
+            <Toggle
+              checked={notifySms}
+              onChange={setNotifySms}
+              label="SMS-Bestätigung"
+              description="Meldende erhalten eine SMS-Bestätigung nach der Meldung"
+            />
+          </div>
         </Section>
 
         {/* Google Review */}
@@ -152,27 +127,6 @@ export default function SettingsPage() {
             Suchen Sie Ihren Betrieb auf Google Maps &rarr; &quot;Rezension
             schreiben&quot; &rarr; Link kopieren
           </p>
-        </Section>
-
-        {/* Bestätigungen */}
-        <Section
-          title="Bestätigungen an Meldende"
-          description="Automatische Rückmeldung nach Fallerfassung."
-        >
-          <div className="space-y-3">
-            <Toggle
-              checked={notifyEmail}
-              onChange={setNotifyEmail}
-              label="E-Mail-Bestätigung"
-              description="Meldende erhalten eine E-Mail mit Fallnummer und Zusammenfassung"
-            />
-            <Toggle
-              checked={notifySms}
-              onChange={setNotifySms}
-              label="SMS-Bestätigung"
-              description="Meldende erhalten eine SMS-Bestätigung nach der Meldung"
-            />
-          </div>
         </Section>
       </div>
 

--- a/src/web/src/components/ops/StaffManager.tsx
+++ b/src/web/src/components/ops/StaffManager.tsx
@@ -11,11 +11,27 @@ interface StaffMember {
   is_active: boolean;
 }
 
-export function StaffManager() {
+interface StaffManagerProps {
+  /** Pass tenant_id for admin users (otherwise API resolves from session) */
+  tenantId?: string;
+  /** Hide the top header (when embedded in another section) */
+  embedded?: boolean;
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  techniker: "Techniker",
+  projektleiter: "Projektleiter",
+  buero: "Büro",
+  inhaber: "Inhaber",
+  lernender: "Lernender",
+};
+
+export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
   const [staff, setStaff] = useState<StaffMember[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState("");
 
   // Form state
   const [name, setName] = useState("");
@@ -45,6 +61,7 @@ export function StaffManager() {
     setEmail("");
     setEditingId(null);
     setShowForm(false);
+    setErrorMsg("");
   }
 
   function startEdit(s: StaffMember) {
@@ -54,36 +71,46 @@ export function StaffManager() {
     setEmail(s.email ?? "");
     setEditingId(s.id);
     setShowForm(true);
+    setErrorMsg("");
   }
 
   async function handleSave() {
     if (!name.trim()) return;
     setSaving(true);
+    setErrorMsg("");
 
-    const body = {
+    const body: Record<string, unknown> = {
       display_name: name.trim(),
       role,
       phone: phone.trim() || null,
       email: email.trim() || null,
     };
 
-    if (editingId) {
-      await fetch(`/api/ops/staff/${editingId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-    } else {
-      await fetch("/api/ops/staff", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
+    // Include tenant_id for admin users
+    if (tenantId) {
+      body.tenant_id = tenantId;
     }
 
+    try {
+      const url = editingId ? `/api/ops/staff/${editingId}` : "/api/ops/staff";
+      const method = editingId ? "PATCH" : "POST";
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? `Fehler (${res.status})`);
+      }
+
+      resetForm();
+      fetchStaff();
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Speichern fehlgeschlagen.");
+    }
     setSaving(false);
-    resetForm();
-    fetchStaff();
   }
 
   async function handleDeactivate(id: string) {
@@ -97,24 +124,37 @@ export function StaffManager() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-4">
-        <div>
-          <h2 className="text-lg font-bold text-gray-900">Team</h2>
-          <p className="text-sm text-gray-500">Team verwalten — für Fall-Zuweisung und Einsatzplanung</p>
+      {!embedded && (
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-lg font-bold text-gray-900">Team</h2>
+            <p className="text-sm text-gray-500">Team verwalten — für Fall-Zuweisung und Einsatzplanung</p>
+          </div>
+          {!showForm && (
+            <button
+              onClick={() => setShowForm(true)}
+              className="rounded-lg bg-slate-800 px-3.5 py-2 text-xs font-medium text-white hover:bg-slate-700 shadow-sm transition-colors"
+            >
+              + Mitarbeiter
+            </button>
+          )}
         </div>
-        {!showForm && (
+      )}
+
+      {embedded && !showForm && (
+        <div className="flex justify-end mb-3">
           <button
             onClick={() => setShowForm(true)}
             className="rounded-lg bg-slate-800 px-3.5 py-2 text-xs font-medium text-white hover:bg-slate-700 shadow-sm transition-colors"
           >
             + Mitarbeiter
           </button>
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Form */}
       {showForm && (
-        <div className="bg-white border border-gray-200 rounded-xl p-4 mb-4 shadow-sm">
+        <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 mb-4">
           <h3 className="text-sm font-semibold text-gray-900 mb-3">
             {editingId ? "Mitarbeiter bearbeiten" : "Neuer Mitarbeiter"}
           </h3>
@@ -126,7 +166,7 @@ export function StaffManager() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Max Muster"
-                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400/30"
               />
             </div>
             <div>
@@ -134,7 +174,7 @@ export function StaffManager() {
               <select
                 value={role}
                 onChange={(e) => setRole(e.target.value)}
-                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400/30"
               >
                 <option value="techniker">Techniker</option>
                 <option value="projektleiter">Projektleiter</option>
@@ -144,27 +184,28 @@ export function StaffManager() {
               </select>
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Telefon</label>
-              <input
-                type="tel"
-                value={phone}
-                onChange={(e) => setPhone(e.target.value)}
-                placeholder="+41 79 123 45 67"
-                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
-              />
-            </div>
-            <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">E-Mail</label>
               <input
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="max@firma.ch"
-                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400/30"
+              />
+              <p className="mt-1 text-[11px] text-gray-400">Für Kalendereinladungen bei Terminzuweisung</p>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Telefon</label>
+              <input
+                type="tel"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                placeholder="+41 79 123 45 67"
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400/30"
               />
             </div>
           </div>
-          <div className="flex gap-2 mt-3">
+          <div className="flex items-center gap-3 mt-3">
             <button
               onClick={handleSave}
               disabled={!name.trim() || saving}
@@ -178,13 +219,14 @@ export function StaffManager() {
             >
               Abbrechen
             </button>
+            {errorMsg && <span className="text-xs text-red-600">{errorMsg}</span>}
           </div>
         </div>
       )}
 
       {/* Staff list */}
       {staff.length === 0 ? (
-        <div className="text-center py-12 text-gray-400 text-sm">
+        <div className="text-center py-8 text-gray-400 text-sm">
           Noch keine Mitarbeiter erfasst.
         </div>
       ) : (
@@ -194,8 +236,8 @@ export function StaffManager() {
               <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-200 bg-slate-50/80">
                 <th className="px-4 py-3 font-medium">Name</th>
                 <th className="px-4 py-3 font-medium">Rolle</th>
-                <th className="px-4 py-3 font-medium hidden sm:table-cell">Telefon</th>
                 <th className="px-4 py-3 font-medium hidden sm:table-cell">E-Mail</th>
+                <th className="px-4 py-3 font-medium hidden sm:table-cell">Telefon</th>
                 <th className="px-4 py-3 font-medium w-24"></th>
               </tr>
             </thead>
@@ -203,9 +245,9 @@ export function StaffManager() {
               {staff.map((s) => (
                 <tr key={s.id} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
                   <td className="px-4 py-3 font-medium text-gray-900">{s.display_name}</td>
-                  <td className="px-4 py-3 text-gray-600 capitalize">{s.role}</td>
-                  <td className="px-4 py-3 text-gray-500 hidden sm:table-cell">{s.phone ?? "—"}</td>
+                  <td className="px-4 py-3 text-gray-600">{ROLE_LABELS[s.role] ?? s.role}</td>
                   <td className="px-4 py-3 text-gray-500 hidden sm:table-cell">{s.email ?? "—"}</td>
+                  <td className="px-4 py-3 text-gray-500 hidden sm:table-cell">{s.phone ?? "—"}</td>
                   <td className="px-4 py-3">
                     <div className="flex gap-1">
                       <button


### PR DESCRIPTION
## Summary
- **Bug fix:** Staff creation failed silently for admin users (tenant_id was null). Now passes tenant_id from settings context.
- **Settings redesign:** Removed "Betrieb" (read-only, redundant) and "Kalender" (merged into staff email). Only 3 cards: Team, Benachrichtigungen, Google-Bewertungen.
- **Smart invite routing:** "Termin senden" now resolves recipient in 3 tiers: assigned staff email → tenant calendar email → env var fallback.

## Test plan
- [ ] Go to /ops/settings → add a staff member with email → saves successfully
- [ ] No "Betrieb" card visible
- [ ] No "Kalender" card visible
- [ ] Staff email hint says "Für Kalendereinladungen bei Terminzuweisung"
- [ ] Assign staff to case → "Termin senden" → invite goes to that staff member's email
- [ ] No double "Team" header
- [ ] Role labels in German (Techniker, Büro, etc.)
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)