### PR TITLE
feat: notifications, RBAC & settings architecture

### DIFF
--- a/src/web/app/api/lifecycle/tick/route.ts
+++ b/src/web/app/api/lifecycle/tick/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/src/lib/supabase/server";
+import { sendSms } from "@/src/lib/sms/sendSms";
 
 // ---------------------------------------------------------------------------
 // POST /api/lifecycle/tick
@@ -101,10 +102,15 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // ── 24h Termin reminders ──────────────────────────────────────────────
+  const reminderResults = await processTerminReminders(supabase, now);
+
   return NextResponse.json({
     processed: trials.length,
     actions: results.length,
     results,
+    reminders_sent: reminderResults.length,
+    reminders: reminderResults,
   });
 }
 
@@ -257,6 +263,106 @@ async function executeMilestone(
       error: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+// ---------------------------------------------------------------------------
+// 24h Termin reminders — SMS to Melder before scheduled appointments
+// ---------------------------------------------------------------------------
+
+interface ReminderResult {
+  case_id: string;
+  sent: boolean;
+  reason?: string;
+}
+
+async function processTerminReminders(
+  supabase: ReturnType<typeof getServiceClient>,
+  now: Date,
+): Promise<ReminderResult[]> {
+  const results: ReminderResult[] = [];
+
+  // Cases with scheduled_at in next 36h (handles cron timing variance)
+  const windowEnd = new Date(now.getTime() + 36 * 60 * 60 * 1000);
+
+  const { data: cases } = await supabase
+    .from("cases")
+    .select("id, tenant_id, seq_number, scheduled_at, scheduled_end_at, category, contact_phone, reporter_name")
+    .gte("scheduled_at", now.toISOString())
+    .lte("scheduled_at", windowEnd.toISOString())
+    .in("status", ["scheduled", "in_arbeit"])
+    .not("contact_phone", "is", null);
+
+  if (!cases || cases.length === 0) return results;
+
+  // Check which cases already have a termin_reminder_sent event (idempotency)
+  const caseIds = cases.map(c => c.id);
+  const { data: existingEvents } = await supabase
+    .from("case_events")
+    .select("case_id")
+    .in("case_id", caseIds)
+    .eq("event_type", "termin_reminder_sent");
+
+  const alreadySent = new Set((existingEvents ?? []).map(e => e.case_id));
+
+  // Group cases by tenant to batch-check modules
+  const tenantIds = [...new Set(cases.map(c => c.tenant_id))];
+  const { data: tenants } = await supabase
+    .from("tenants")
+    .select("id, name, phone, modules")
+    .in("id", tenantIds);
+
+  const tenantMap = new Map(
+    (tenants ?? []).map(t => [t.id, t])
+  );
+
+  for (const c of cases) {
+    if (alreadySent.has(c.id)) continue;
+    if (!c.contact_phone) continue;
+
+    const tenant = tenantMap.get(c.tenant_id);
+    if (!tenant) continue;
+
+    const modules = (tenant.modules ?? {}) as Record<string, unknown>;
+    if (modules.notify_termin_reminder_sms === false) {
+      results.push({ case_id: c.id, sent: false, reason: "toggle_off" });
+      continue;
+    }
+    if (modules.sms !== true) {
+      results.push({ case_id: c.id, sent: false, reason: "sms_disabled" });
+      continue;
+    }
+
+    const senderName = typeof modules.sms_sender_name === "string" ? modules.sms_sender_name : tenant.name;
+    const tenantPhone = typeof tenant.phone === "string" ? tenant.phone : "";
+
+    const start = new Date(c.scheduled_at);
+    const day = start.toLocaleDateString("de-CH", { weekday: "short", timeZone: "Europe/Zurich" }).replace(/\.$/, "");
+    const date = start.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", timeZone: "Europe/Zurich" });
+    const time = start.toLocaleTimeString("de-CH", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" });
+
+    let endTime = "";
+    if (c.scheduled_end_at) {
+      const end = new Date(c.scheduled_end_at);
+      endTime = `–${end.toLocaleTimeString("de-CH", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" })}`;
+    }
+
+    const phoneStr = tenantPhone ? ` Bei Fragen: ${tenantPhone}.` : "";
+    const smsBody = `${senderName}: Erinnerung — Ihr Termin morgen ${day} ${date}, ${time}${endTime}.${phoneStr}`;
+
+    const smsResult = await sendSms(c.contact_phone, smsBody, senderName);
+
+    // Insert idempotency guard event
+    await supabase.from("case_events").insert({
+      case_id: c.id,
+      event_type: "termin_reminder_sent",
+      title: "24h-Erinnerung an Meldende/n gesendet",
+      metadata: { sms_sent: smsResult.sent, reason: smsResult.reason ?? null },
+    });
+
+    results.push({ case_id: c.id, sent: smsResult.sent, reason: smsResult.reason });
+  }
+
+  return results;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/web/app/api/ops/cases/[id]/notify-melder/route.ts
+++ b/src/web/app/api/ops/cases/[id]/notify-melder/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { getServiceClient } from "@/src/lib/supabase/server";
+import { getAuthClient } from "@/src/lib/supabase/server-auth";
+import { resolveTenantIdentityById } from "@/src/lib/tenants/resolveTenantIdentity";
+import { formatCaseId } from "@/src/lib/cases/formatCaseId";
+import { sendTerminConfirmationToMelder } from "@/src/lib/email/resend";
+import { sendSms } from "@/src/lib/sms/sendSms";
+
+// ---------------------------------------------------------------------------
+// POST /api/ops/cases/[id]/notify-melder
+// Send termin confirmation to the reporter (Melder) via email + SMS
+// ---------------------------------------------------------------------------
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const base: Record<string, unknown> = {
+    _tag: "notify_melder",
+    case_id: id,
+  };
+
+  // ── Auth ──────────────────────────────────────────────────────────────
+  const supabaseAuth = await getAuthClient();
+  const { data: { user } } = await supabaseAuth.auth.getUser();
+  if (!user) {
+    console.log(JSON.stringify({ ...base, decision: "skipped", reason: "unauthorized" }));
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // ── Load case ─────────────────────────────────────────────────────────
+  const supabase = getServiceClient();
+  const { data: row, error: dbError } = await supabase
+    .from("cases")
+    .select("id, tenant_id, seq_number, scheduled_at, scheduled_end_at, category, city, contact_phone, contact_email, reporter_name")
+    .eq("id", id)
+    .single();
+
+  if (dbError || !row) {
+    console.log(JSON.stringify({ ...base, decision: "skipped", reason: "case_not_found" }));
+    return NextResponse.json({ error: "Case not found" }, { status: 404 });
+  }
+
+  if (!row.scheduled_at) {
+    console.log(JSON.stringify({ ...base, decision: "skipped", reason: "no_scheduled_at" }));
+    return NextResponse.json({ error: "No termin scheduled" }, { status: 400 });
+  }
+
+  if (!row.contact_email && !row.contact_phone) {
+    console.log(JSON.stringify({ ...base, decision: "skipped", reason: "no_contact" }));
+    return NextResponse.json({ error: "No contact info" }, { status: 400 });
+  }
+
+  // ── Load tenant identity + modules ────────────────────────────────────
+  const [identity, { data: tenantRow }] = await Promise.all([
+    resolveTenantIdentityById(row.tenant_id),
+    supabase.from("tenants").select("modules, phone").eq("id", row.tenant_id).single(),
+  ]);
+
+  const modules = (tenantRow?.modules ?? {}) as Record<string, unknown>;
+  const tenantDisplayName = identity?.displayName ?? "Ihr Servicebetrieb";
+  const caseLabel = formatCaseId(row.seq_number, identity?.caseIdPrefix);
+  const smsEnabled = modules.sms === true;
+  const senderName = typeof modules.sms_sender_name === "string" ? modules.sms_sender_name : tenantDisplayName;
+  const tenantPhone = typeof tenantRow?.phone === "string" ? tenantRow.phone : undefined;
+
+  let emailSent = false;
+  let smsSent = false;
+
+  // ── Send email ────────────────────────────────────────────────────────
+  if (row.contact_email && modules.notify_termin_email !== false) {
+    emailSent = await sendTerminConfirmationToMelder(
+      {
+        caseLabel,
+        tenantDisplayName,
+        reporterName: row.reporter_name ?? undefined,
+        category: row.category,
+        scheduledAt: row.scheduled_at,
+        scheduledEndAt: row.scheduled_end_at,
+        tenantPhone,
+      },
+      row.contact_email,
+    );
+  }
+
+  // ── Send SMS ──────────────────────────────────────────────────────────
+  if (row.contact_phone && smsEnabled && modules.notify_termin_sms !== false) {
+    const start = new Date(row.scheduled_at);
+    const day = start.toLocaleDateString("de-CH", { weekday: "short", timeZone: "Europe/Zurich" }).replace(/\.$/, "");
+    const date = start.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", timeZone: "Europe/Zurich" });
+    const time = start.toLocaleTimeString("de-CH", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" });
+
+    let endTime = "";
+    if (row.scheduled_end_at) {
+      const end = new Date(row.scheduled_end_at);
+      endTime = `–${end.toLocaleTimeString("de-CH", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" })}`;
+    }
+
+    const phoneStr = tenantPhone ? ` Bei Fragen: ${tenantPhone}.` : "";
+    const smsBody = `${senderName}: Ihr Termin am ${day} ${date}, ${time}${endTime}.${phoneStr}`;
+
+    const result = await sendSms(row.contact_phone, smsBody, senderName);
+    smsSent = result.sent;
+  }
+
+  // ── Log event ─────────────────────────────────────────────────────────
+  await supabase.from("case_events").insert({
+    case_id: id,
+    event_type: "melder_termin_notified",
+    title: "Terminbestätigung an Meldende/n gesendet",
+    metadata: { email_sent: emailSent, sms_sent: smsSent, user_id: user.id },
+  }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
+
+  console.log(JSON.stringify({
+    ...base,
+    decision: "sent",
+    email_sent: emailSent,
+    sms_sent: smsSent,
+  }));
+
+  return NextResponse.json({ ok: true, email_sent: emailSent, sms_sent: smsSent });
+}

--- a/src/web/app/api/ops/cases/[id]/route.ts
+++ b/src/web/app/api/ops/cases/[id]/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { getServiceClient } from "@/src/lib/supabase/server";
+import { getAuthClient } from "@/src/lib/supabase/server-auth";
 import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
+import { sendAssignmentNotification } from "@/src/lib/email/resend";
+import { resolveTenantIdentityById } from "@/src/lib/tenants/resolveTenantIdentity";
+import { formatCaseId } from "@/src/lib/cases/formatCaseId";
+import { resolveStaffRole } from "@/src/lib/staff/resolveStaffRole";
 
 // ---------------------------------------------------------------------------
 // Allowed values for ops fields
@@ -56,6 +61,17 @@ const OPS_UPDATABLE_FIELDS = [
 ] as const;
 
 type OpsField = (typeof OPS_UPDATABLE_FIELDS)[number];
+
+/** Techniker can update these fields but NOT assignee_text */
+const TECHNIKER_UPDATABLE_FIELDS = [
+  "status",
+  "urgency",
+  "category",
+  "description",
+  "scheduled_at",
+  "scheduled_end_at",
+  "internal_notes",
+] as const;
 
 // ---------------------------------------------------------------------------
 // GET /api/ops/cases/[id] — fetch single case (authenticated)
@@ -125,8 +141,23 @@ export async function PATCH(
     return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
   }
 
-  // Allowlist: prospects get restricted fields, others get full ops fields
-  const allowedFields = scope.isProspect ? PROSPECT_ALLOWED_FIELDS : OPS_UPDATABLE_FIELDS;
+  // Resolve staff role for RBAC
+  let staffRole: "admin" | "techniker" | null = null;
+  if (scope.tenantId && !scope.isProspect) {
+    const authClient = await getAuthClient();
+    const { data: { user } } = await authClient.auth.getUser();
+    if (user?.email) {
+      const ctx = await resolveStaffRole(user.email, scope.tenantId);
+      if (ctx) staffRole = ctx.role;
+    }
+  }
+
+  // Allowlist: prospects get restricted fields, techniker limited, others get full ops fields
+  const allowedFields: readonly string[] = scope.isProspect
+    ? PROSPECT_ALLOWED_FIELDS
+    : staffRole === "techniker"
+      ? TECHNIKER_UPDATABLE_FIELDS
+      : OPS_UPDATABLE_FIELDS;
   const update: Record<string, unknown> = {};
   for (const field of allowedFields) {
     if (field in body) {
@@ -177,7 +208,7 @@ export async function PATCH(
     const supabase = getServiceClient();
 
     // Tenant isolation check: read case first to verify tenant ownership
-    const { data: existing } = await supabase.from("cases").select("status, tenant_id").eq("id", id).single();
+    const { data: existing } = await supabase.from("cases").select("status, tenant_id, assignee_text").eq("id", id).single();
     if (!existing) {
       return NextResponse.json({ error: "Case not found." }, { status: 404 });
     }
@@ -193,7 +224,7 @@ export async function PATCH(
       .update(update)
       .eq("id", id)
       .select(
-        "id, status, urgency, category, plz, city, description, assignee_text, scheduled_at, scheduled_end_at, internal_notes, contact_email, contact_phone, street, house_number, reporter_name, updated_at"
+        "id, seq_number, status, urgency, category, plz, city, description, assignee_text, scheduled_at, scheduled_end_at, internal_notes, contact_email, contact_phone, street, house_number, reporter_name, updated_at"
       )
       .single();
 
@@ -232,6 +263,48 @@ export async function PATCH(
       }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
     }
 
+    // ── Assignment notification (fire-and-forget) ───────────────────
+    let assignmentSent = false;
+    if (
+      "assignee_text" in update &&
+      update.assignee_text &&
+      update.assignee_text !== existing.assignee_text
+    ) {
+      // Look up staff email + tenant identity
+      const [{ data: staffMatch }, identity, { data: tenantRow }] = await Promise.all([
+        supabase
+          .from("staff")
+          .select("email")
+          .eq("tenant_id", existing.tenant_id)
+          .eq("display_name", update.assignee_text as string)
+          .eq("is_active", true)
+          .limit(1)
+          .maybeSingle(),
+        resolveTenantIdentityById(existing.tenant_id),
+        supabase.from("tenants").select("modules").eq("id", existing.tenant_id).single(),
+      ]);
+
+      const modules = (tenantRow?.modules ?? {}) as Record<string, unknown>;
+      const notifyEnabled = modules.notify_staff_assignment !== false;
+
+      if (staffMatch?.email && notifyEnabled && identity) {
+        const baseUrl = process.env.APP_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? "https://flowsight.ch";
+        const caseLabel = formatCaseId(row.seq_number, identity.caseIdPrefix);
+        assignmentSent = await sendAssignmentNotification({
+          caseId: id,
+          caseLabel,
+          tenantDisplayName: identity.displayName,
+          staffName: update.assignee_text as string,
+          staffEmail: staffMatch.email,
+          category: row.category,
+          city: row.city,
+          urgency: row.urgency,
+          description: row.description,
+          deepLink: `${baseUrl}/ops/cases/${id}`,
+        });
+      }
+    }
+
     // Structured log — no PII
     const updatedFields = Object.keys(update) as OpsField[];
     console.log(
@@ -241,6 +314,7 @@ export async function PATCH(
         case_id: id,
         user_id: scope.userId,
         fields: updatedFields,
+        ...(assignmentSent && { assignment_sent: true }),
       })
     );
 

--- a/src/web/app/api/ops/settings/route.ts
+++ b/src/web/app/api/ops/settings/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/src/lib/supabase/server";
+import { getAuthClient } from "@/src/lib/supabase/server-auth";
 import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
+import { resolveStaffRole } from "@/src/lib/staff/resolveStaffRole";
 
 /**
  * GET /api/ops/settings — Current tenant settings (modules JSONB subset)
@@ -14,14 +16,34 @@ const EDITABLE_KEYS = [
   "default_appointment_duration_min",
   "notify_reporter_email",
   "notify_reporter_sms",
+  "notify_termin_email",
+  "notify_termin_sms",
+  "notify_termin_reminder_sms",
+  "notify_staff_assignment",
   "business_calendar_email",
 ] as const;
 
 type EditableKey = (typeof EDITABLE_KEYS)[number];
 
+async function checkTechnikerBlock(scope: { tenantId?: string | null; isProspect?: boolean }) {
+  if (scope.tenantId && !scope.isProspect) {
+    const authClient = await getAuthClient();
+    const { data: { user } } = await authClient.auth.getUser();
+    if (user?.email) {
+      const ctx = await resolveStaffRole(user.email, scope.tenantId);
+      if (ctx?.role === "techniker") return true;
+    }
+  }
+  return false;
+}
+
 export async function GET() {
   const scope = await resolveTenantScope();
   if (!scope) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (await checkTechnikerBlock(scope)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const supabase = getServiceClient();
 
@@ -47,6 +69,10 @@ export async function GET() {
       default_appointment_duration_min: (modules.default_appointment_duration_min as number) ?? 60,
       notify_reporter_email: modules.notify_reporter_email !== false,
       notify_reporter_sms: modules.notify_reporter_sms !== false,
+      notify_termin_email: modules.notify_termin_email !== false,
+      notify_termin_sms: modules.notify_termin_sms !== false,
+      notify_termin_reminder_sms: modules.notify_termin_reminder_sms !== false,
+      notify_staff_assignment: modules.notify_staff_assignment !== false,
       business_calendar_email: (modules.business_calendar_email as string) ?? "",
     },
   });
@@ -55,6 +81,10 @@ export async function GET() {
 export async function PATCH(request: NextRequest) {
   const scope = await resolveTenantScope();
   if (!scope) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (await checkTechnikerBlock(scope)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   let body: Record<string, unknown>;
   try {
@@ -82,7 +112,11 @@ export async function PATCH(request: NextRequest) {
       } else if (key === "default_appointment_duration_min") {
         const num = Number(val);
         modules[key] = Number.isFinite(num) && num > 0 && num <= 480 ? num : 60;
-      } else if (key === "notify_reporter_email" || key === "notify_reporter_sms") {
+      } else if (
+        key === "notify_reporter_email" || key === "notify_reporter_sms" ||
+        key === "notify_termin_email" || key === "notify_termin_sms" ||
+        key === "notify_termin_reminder_sms" || key === "notify_staff_assignment"
+      ) {
         modules[key] = val === true;
       }
     }

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -141,11 +141,17 @@ export function CaseDetailForm({
   isProspect = false,
   caseEvents = [],
   brandColor = "#64748b",
+  currentStaffName,
+  staffRole,
 }: {
   initialData: CaseDetail;
   isProspect?: boolean;
   caseEvents?: CaseEvent[];
   brandColor?: string;
+  /** Staff display_name matching logged-in user's email (for self-send guard) */
+  currentStaffName?: string | null;
+  /** Role-based access: "admin" | "techniker" | undefined (full access) */
+  staffRole?: "admin" | "techniker";
 }) {
   // ── Field state ──────────────────────────────────────────────────────
   const [status, setStatus] = useState(initialData.status);
@@ -190,6 +196,8 @@ export function CaseDetailForm({
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState("");
   const [inviteState, setInviteState] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [melderNotifyState, setMelderNotifyState] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [selfSendConfirm, setSelfSendConfirm] = useState(false);
   const [reviewState, setReviewState] = useState<"idle" | "sending" | "sent" | "error">("idle");
   const [reviewMsg, setReviewMsg] = useState("");
   const [localEvents, setLocalEvents] = useState(caseEvents);
@@ -327,7 +335,7 @@ export function CaseDetailForm({
   }
 
   // ── Invite ───────────────────────────────────────────────────────────
-  async function handleSendInvite() {
+  async function doSendInvite() {
     if (steuerungDirty) {
       const ok = await saveSteuerung();
       if (!ok) return;
@@ -341,6 +349,33 @@ export function CaseDetailForm({
       setTimeout(() => setInviteState("idle"), 3000);
     } catch {
       setInviteState("error");
+    }
+  }
+
+  function handleSendInvite() {
+    // Self-send guard: if assigned to yourself, confirm first
+    if (currentStaffName && assigneeText === currentStaffName && !selfSendConfirm) {
+      setSelfSendConfirm(true);
+      return;
+    }
+    setSelfSendConfirm(false);
+    doSendInvite();
+  }
+
+  // ── Melder benachrichtigen ──────────────────────────────────────────
+  async function handleNotifyMelder() {
+    setMelderNotifyState("sending");
+    try {
+      const res = await fetch(`/api/ops/cases/${initialData.id}/notify-melder`, { method: "POST" });
+      if (!res.ok) throw new Error("Fehler");
+      setMelderNotifyState("sent");
+      setLocalEvents(prev => [...prev, {
+        id: crypto.randomUUID(), event_type: "melder_termin_notified",
+        title: "Terminbestätigung an Meldende/n gesendet", created_at: new Date().toISOString(),
+      }]);
+      setTimeout(() => setMelderNotifyState("idle"), 3000);
+    } catch {
+      setMelderNotifyState("error");
     }
   }
 
@@ -444,7 +479,9 @@ export function CaseDetailForm({
               </div>
               <div>
                 <label className={lbl}>Zuständig</label>
-                {staffMembers.length > 0 ? (
+                {staffRole === "techniker" ? (
+                  <p className={`${inp} bg-gray-50 text-gray-500`}>{assigneeText || "—"}</p>
+                ) : staffMembers.length > 0 ? (
                   <select value={assigneeText} onChange={e => setAssigneeText(e.target.value)} className={inp}>
                     <option value="">— Offen —</option>
                     {staffMembers.map(s => <option key={s.display_name} value={s.display_name}>{s.display_name}</option>)}
@@ -486,12 +523,35 @@ export function CaseDetailForm({
               />
             )}
 
-            {/* Send invite button — after picker closes, if termin is set */}
+            {/* Send invite + notify melder buttons — after picker closes, if termin is set */}
             {scheduledAt && !pickerOpen && (
-              <div className="flex items-center justify-end mt-2 pt-2 border-t border-gray-200/60 mb-3">
-                <button onClick={handleSendInvite} disabled={inviteState === "sending"}
-                  className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-40 transition-colors"
-                >{inviteState === "sending" ? "Sende…" : inviteState === "sent" ? "Gesendet ✓" : "Termin senden →"}</button>
+              <div className="space-y-2 mt-2 pt-2 border-t border-gray-200/60 mb-3">
+                <div className="flex items-center justify-end gap-2">
+                  {/* Melder benachrichtigen — visible when contact info exists */}
+                  {(contactEmail || contactPhone) && (
+                    <button onClick={handleNotifyMelder} disabled={melderNotifyState === "sending"}
+                      className="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-40 transition-colors"
+                    >{melderNotifyState === "sending" ? "Sende…" : melderNotifyState === "sent" ? "Gesendet ✓" : "Meldende/n benachrichtigen"}</button>
+                  )}
+                  <button onClick={handleSendInvite} disabled={inviteState === "sending"}
+                    className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-40 transition-colors"
+                  >{inviteState === "sending" ? "Sende…" : inviteState === "sent" ? "Gesendet ✓" : "Termin senden →"}</button>
+                </div>
+                {/* Self-send confirmation */}
+                {selfSendConfirm && (
+                  <div className="flex items-center justify-end gap-2 p-2 bg-amber-50 border border-amber-200 rounded-lg">
+                    <p className="text-xs text-amber-800 mr-auto">Du bist selbst zugewiesen. Trotzdem senden?</p>
+                    <button onClick={() => { setSelfSendConfirm(false); doSendInvite(); }}
+                      className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 transition-colors"
+                    >Ja, senden</button>
+                    <button onClick={() => setSelfSendConfirm(false)}
+                      className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+                    >Abbrechen</button>
+                  </div>
+                )}
+                {melderNotifyState === "error" && (
+                  <p className="text-xs text-red-600 text-right">Benachrichtigung fehlgeschlagen.</p>
+                )}
               </div>
             )}
 

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getServiceClient } from "@/src/lib/supabase/server";
+import { getAuthClient } from "@/src/lib/supabase/server-auth";
 import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 import { resolveTenantIdentityById } from "@/src/lib/tenants/resolveTenantIdentity";
 import { formatCaseId } from "@/src/lib/cases/formatCaseId";
@@ -92,6 +93,29 @@ export default async function CaseDetailPage({
   const isProspect = scope?.isProspect ?? false;
   const brandColor = identity?.primaryColor ?? "#64748b";
 
+  // Resolve logged-in user for self-send guard + RBAC
+  const authClient = await getAuthClient();
+  const { data: { user } } = await authClient.auth.getUser();
+  const userEmail = user?.email ?? "";
+
+  // Look up staff record matching user's email for this tenant
+  let currentStaffName: string | null = null;
+  let staffRole: "admin" | "techniker" | undefined;
+  if (userEmail && caseData.tenant_id) {
+    const { data: staffMatch } = await supabase
+      .from("staff")
+      .select("display_name, role")
+      .eq("tenant_id", caseData.tenant_id)
+      .eq("email", userEmail)
+      .eq("is_active", true)
+      .limit(1)
+      .maybeSingle();
+    if (staffMatch) {
+      currentStaffName = staffMatch.display_name;
+      staffRole = staffMatch.role === "techniker" ? "techniker" : "admin";
+    }
+  }
+
   return (
     <>
       {/* Header: back + category + meta + actions */}
@@ -129,6 +153,8 @@ export default async function CaseDetailPage({
         isProspect={isProspect}
         caseEvents={caseEvents}
         brandColor={brandColor}
+        currentStaffName={currentStaffName}
+        staffRole={staffRole}
       />
 
     </>

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -2,6 +2,7 @@ import { getServiceClient } from "@/src/lib/supabase/server";
 import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
 import { resolveTenantIdentity } from "@/src/lib/tenants/resolveTenantIdentity";
+import { resolveStaffRole } from "@/src/lib/staff/resolveStaffRole";
 import { ZentraleView } from "@/src/components/ops/ZentraleView";
 import type { ZentraleCase, TodayAppointment } from "@/src/components/ops/ZentraleView";
 
@@ -46,6 +47,20 @@ export default async function OpsCasesPage({
     .order("created_at", { ascending: false })
     .limit(200);
   if (filterTenantId) casesQuery = casesQuery.eq("tenant_id", filterTenantId);
+
+  // ── RBAC: Techniker sees only assigned cases ──────────────────────
+  if (scope && !scope.isAdmin && scope.tenantId) {
+    try {
+      const authClient2 = await getAuthClient();
+      const { data: { user: authUser2 } } = await authClient2.auth.getUser();
+      if (authUser2?.email) {
+        const ctx = await resolveStaffRole(authUser2.email, scope.tenantId);
+        if (ctx?.role === "techniker") {
+          casesQuery = casesQuery.eq("assignee_text", ctx.displayName);
+        }
+      }
+    } catch { /* fallback: no filter */ }
+  }
 
   // ── Query 2: Today's appointments with staff + case join ───────────
   const todayZurich = new Intl.DateTimeFormat("en-CA", {

--- a/src/web/app/ops/(dashboard)/faelle/page.tsx
+++ b/src/web/app/ops/(dashboard)/faelle/page.tsx
@@ -5,6 +5,7 @@ import { CaseListClient } from "@/src/components/ops/CaseListClient";
 import type { CaseRow } from "@/src/components/ops/CaseListClient";
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
 import { resolveTenantIdentity } from "@/src/lib/tenants/resolveTenantIdentity";
+import { resolveStaffRole } from "@/src/lib/staff/resolveStaffRole";
 
 // ---------------------------------------------------------------------------
 // Filter definitions
@@ -73,6 +74,20 @@ export default async function FaellePage({
     .eq("is_demo", false)
     .order("created_at", { ascending: false });
   if (filterTenantId) listQuery = listQuery.eq("tenant_id", filterTenantId);
+
+  // ── RBAC: Techniker sees only assigned cases ──────────────────────
+  if (scope && !scope.isAdmin && scope.tenantId) {
+    try {
+      const authClient = await getAuthClient();
+      const { data: { user: authUser } } = await authClient.auth.getUser();
+      if (authUser?.email) {
+        const ctx = await resolveStaffRole(authUser.email, scope.tenantId);
+        if (ctx?.role === "techniker") {
+          listQuery = listQuery.eq("assignee_text", ctx.displayName);
+        }
+      }
+    } catch { /* fallback: no filter */ }
+  }
 
   // ── Apply filters (AND combination) ─────────────────────────────
   if (filterStatus) {

--- a/src/web/app/ops/(dashboard)/layout.tsx
+++ b/src/web/app/ops/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
 import { resolveTenantIdentity } from "@/src/lib/tenants/resolveTenantIdentity";
+import { resolveStaffRole } from "@/src/lib/staff/resolveStaffRole";
 import { OpsShell } from "@/src/components/ops/OpsShell";
 
 /**
@@ -37,11 +38,19 @@ export default async function DashboardLayout({
 
   const identity = await resolveTenantIdentity(user);
 
+  // Resolve staff role for RBAC
+  let staffRole: "admin" | "techniker" | undefined;
+  if (identity?.tenantId && user.email) {
+    const ctx = await resolveStaffRole(user.email, identity.tenantId);
+    if (ctx) staffRole = ctx.role;
+  }
+
   return (
     <OpsShell
       userEmail={user.email ?? ""}
       tenantName={identity?.displayName ?? undefined}
       brandColor={identity?.primaryColor ?? undefined}
+      staffRole={staffRole}
     >
       {children}
     </OpsShell>

--- a/src/web/app/ops/(dashboard)/settings/page.tsx
+++ b/src/web/app/ops/(dashboard)/settings/page.tsx
@@ -1,12 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { StaffManager } from "@/src/components/ops/StaffManager";
 
 interface Settings {
   google_review_url: string;
   notify_reporter_email: boolean;
   notify_reporter_sms: boolean;
+  notify_termin_email: boolean;
+  notify_termin_sms: boolean;
+  notify_termin_reminder_sms: boolean;
+  notify_staff_assignment: boolean;
 }
 
 interface SettingsData {
@@ -16,13 +21,21 @@ interface SettingsData {
 }
 
 export default function SettingsPage() {
+  const router = useRouter();
   const [data, setData] = useState<SettingsData | null>(null);
   const [loading, setLoading] = useState(true);
 
   // Form state — Benachrichtigungen
   const [notifyEmail, setNotifyEmail] = useState(true);
   const [notifySms, setNotifySms] = useState(true);
-  const [notifyBaseline, setNotifyBaseline] = useState({ email: true, sms: true });
+  const [notifyTerminEmail, setNotifyTerminEmail] = useState(true);
+  const [notifyTerminSms, setNotifyTerminSms] = useState(true);
+  const [notifyTerminReminderSms, setNotifyTerminReminderSms] = useState(true);
+  const [notifyStaffAssignment, setNotifyStaffAssignment] = useState(true);
+  const [notifyBaseline, setNotifyBaseline] = useState({
+    email: true, sms: true,
+    terminEmail: true, terminSms: true, terminReminderSms: true, staffAssignment: true,
+  });
   const [notifySaving, setNotifySaving] = useState(false);
   const [notifySaved, setNotifySaved] = useState(false);
   const [notifyError, setNotifyError] = useState<string | null>(null);
@@ -36,7 +49,10 @@ export default function SettingsPage() {
 
   useEffect(() => {
     fetch("/api/ops/settings")
-      .then((res) => (res.ok ? res.json() : null))
+      .then((res) => {
+        if (res.status === 403) { router.replace("/ops/cases"); return null; }
+        return res.ok ? res.json() : null;
+      })
       .then((d: SettingsData | null) => {
         if (d) {
           setData(d);
@@ -44,18 +60,28 @@ export default function SettingsPage() {
           setReviewBaseline(d.settings.google_review_url);
           setNotifyEmail(d.settings.notify_reporter_email);
           setNotifySms(d.settings.notify_reporter_sms);
+          setNotifyTerminEmail(d.settings.notify_termin_email);
+          setNotifyTerminSms(d.settings.notify_termin_sms);
+          setNotifyTerminReminderSms(d.settings.notify_termin_reminder_sms);
+          setNotifyStaffAssignment(d.settings.notify_staff_assignment);
           setNotifyBaseline({
             email: d.settings.notify_reporter_email,
             sms: d.settings.notify_reporter_sms,
+            terminEmail: d.settings.notify_termin_email,
+            terminSms: d.settings.notify_termin_sms,
+            terminReminderSms: d.settings.notify_termin_reminder_sms,
+            staffAssignment: d.settings.notify_staff_assignment,
           });
         }
       })
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, []);
+  }, [router]);
 
   const notifyDirty =
-    notifyEmail !== notifyBaseline.email || notifySms !== notifyBaseline.sms;
+    notifyEmail !== notifyBaseline.email || notifySms !== notifyBaseline.sms ||
+    notifyTerminEmail !== notifyBaseline.terminEmail || notifyTerminSms !== notifyBaseline.terminSms ||
+    notifyTerminReminderSms !== notifyBaseline.terminReminderSms || notifyStaffAssignment !== notifyBaseline.staffAssignment;
   const reviewDirty = googleReviewUrl !== reviewBaseline;
 
   async function saveNotify() {
@@ -69,10 +95,18 @@ export default function SettingsPage() {
         body: JSON.stringify({
           notify_reporter_email: notifyEmail,
           notify_reporter_sms: notifySms,
+          notify_termin_email: notifyTerminEmail,
+          notify_termin_sms: notifyTerminSms,
+          notify_termin_reminder_sms: notifyTerminReminderSms,
+          notify_staff_assignment: notifyStaffAssignment,
         }),
       });
       if (res.ok) {
-        setNotifyBaseline({ email: notifyEmail, sms: notifySms });
+        setNotifyBaseline({
+          email: notifyEmail, sms: notifySms,
+          terminEmail: notifyTerminEmail, terminSms: notifyTerminSms,
+          terminReminderSms: notifyTerminReminderSms, staffAssignment: notifyStaffAssignment,
+        });
         setNotifySaved(true);
         setTimeout(() => setNotifySaved(false), 3000);
       } else {
@@ -132,21 +166,65 @@ export default function SettingsPage() {
         {/* Benachrichtigungen — per-card save */}
         <Section
           title="Benachrichtigungen"
-          description="Automatische Rückmeldung an Meldende nach Fallerfassung."
+          description="Automatische Benachrichtigungen an Meldende und Mitarbeiter."
         >
-          <div className="space-y-3">
-            <Toggle
-              checked={notifyEmail}
-              onChange={setNotifyEmail}
-              label="E-Mail-Bestätigung"
-              description="Meldende erhalten eine E-Mail mit Fallnummer und Zusammenfassung"
-            />
-            <Toggle
-              checked={notifySms}
-              onChange={setNotifySms}
-              label="SMS-Bestätigung"
-              description="Meldende erhalten eine SMS-Bestätigung nach der Meldung"
-            />
+          <div className="space-y-5">
+            {/* Sub-section: Bei Fallerfassung */}
+            <div>
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Bei Fallerfassung</p>
+              <div className="space-y-3">
+                <Toggle
+                  checked={notifyEmail}
+                  onChange={setNotifyEmail}
+                  label="E-Mail-Bestätigung an Meldende"
+                  description="Meldende erhalten eine E-Mail mit Fallnummer und Zusammenfassung"
+                />
+                <Toggle
+                  checked={notifySms}
+                  onChange={setNotifySms}
+                  label="SMS-Bestätigung an Meldende"
+                  description="Meldende erhalten eine SMS-Bestätigung nach der Meldung"
+                />
+              </div>
+            </div>
+
+            {/* Sub-section: Bei Terminzuweisung */}
+            <div>
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Bei Terminzuweisung</p>
+              <div className="space-y-3">
+                <Toggle
+                  checked={notifyTerminEmail}
+                  onChange={setNotifyTerminEmail}
+                  label="Terminbestätigung an Meldende (E-Mail)"
+                  description="Meldende erhalten eine E-Mail wenn ein Termin eingeplant wird"
+                />
+                <Toggle
+                  checked={notifyTerminSms}
+                  onChange={setNotifyTerminSms}
+                  label="Terminbestätigung an Meldende (SMS)"
+                  description="Meldende erhalten eine SMS mit den Termindetails"
+                />
+                <Toggle
+                  checked={notifyStaffAssignment}
+                  onChange={setNotifyStaffAssignment}
+                  label="E-Mail an Mitarbeiter bei Zuweisung"
+                  description="Mitarbeiter erhalten eine E-Mail wenn ihnen ein Fall zugewiesen wird"
+                />
+              </div>
+            </div>
+
+            {/* Sub-section: Erinnerungen */}
+            <div>
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Erinnerungen</p>
+              <div className="space-y-3">
+                <Toggle
+                  checked={notifyTerminReminderSms}
+                  onChange={setNotifyTerminReminderSms}
+                  label="24h-Erinnerung an Meldende (SMS)"
+                  description="Meldende erhalten am Vortag eine SMS-Erinnerung an den Termin"
+                />
+              </div>
+            </div>
           </div>
           {notifyDirty && (
             <CardSaveBar

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -53,12 +53,15 @@ export function OpsShell({
   userEmail,
   tenantName,
   brandColor,
+  staffRole,
   children,
 }: {
   userEmail: string;
   tenantName?: string;
   /** Tenant brand color hex (e.g. "#004994"). Falls back to neutral slate if not set. */
   brandColor?: string;
+  /** Staff role for RBAC — techniker sees limited nav */
+  staffRole?: "admin" | "techniker";
   children: React.ReactNode;
 }) {
   // Identity Contract R4: No "FlowSight" visible to end users
@@ -73,6 +76,11 @@ export function OpsShell({
   const color = brandColor ?? "#64748b";
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const pathname = usePathname();
+
+  // RBAC: hide Einstellungen for techniker
+  const visibleNavItems = staffRole === "techniker"
+    ? NAV_ITEMS.filter(item => item.href !== "/ops/settings")
+    : NAV_ITEMS;
 
   function isNavActive(href: string): boolean {
     if (href === "/ops/cases") {
@@ -116,7 +124,7 @@ export function OpsShell({
   const navLinks = (
     <nav className="flex-1 px-3 py-5">
       <div className="space-y-1">
-        {NAV_ITEMS.map((item) => {
+        {visibleNavItems.map((item) => {
           const active = isNavActive(item.href);
           return (
             <Link

--- a/src/web/src/lib/email/resend.ts
+++ b/src/web/src/lib/email/resend.ts
@@ -686,6 +686,170 @@ export async function sendSalesLeadNotification(
 }
 
 // ---------------------------------------------------------------------------
+// Assignment notification email (staff gets notified when assigned to a case)
+// ---------------------------------------------------------------------------
+
+interface AssignmentNotificationPayload {
+  caseId: string;
+  caseLabel: string;
+  tenantDisplayName: string;
+  staffName: string;
+  staffEmail: string;
+  category: string;
+  city: string;
+  urgency: string;
+  description: string;
+  deepLink: string;
+}
+
+/**
+ * Send an email to a staff member when they are assigned to a case.
+ * Identity Contract E4: From = "{tenant} via FlowSight".
+ * No console.log — caller merges into existing log line.
+ */
+export async function sendAssignmentNotification(
+  payload: AssignmentNotificationPayload
+): Promise<boolean> {
+  if (!process.env.RESEND_API_KEY) return false;
+
+  const from = buildFromAddress(payload.tenantDisplayName);
+
+  const urgencyLabel =
+    payload.urgency === "notfall" ? "NOTFALL" :
+    payload.urgency === "dringend" ? "Dringend" : "Normal";
+
+  try {
+    const { error } = await getResend().emails.send({
+      from,
+      to: payload.staffEmail,
+      subject: `Neuer Fall zugewiesen — ${payload.caseLabel} ${payload.category}`,
+      text: [
+        `Hallo ${payload.staffName}`,
+        ``,
+        `Dir wurde ein neuer Fall zugewiesen:`,
+        `──────────────────────`,
+        `Fall-Nr:     ${payload.caseLabel}`,
+        `Kategorie:   ${payload.category}`,
+        `Ort:         ${payload.city}`,
+        `Dringlichkeit: ${urgencyLabel}`,
+        `──────────────────────`,
+        `Beschreibung:`,
+        payload.description,
+        ``,
+        `Fall öffnen: ${payload.deepLink}`,
+        `(Login erforderlich)`,
+      ].join("\n"),
+    });
+
+    if (error) {
+      Sentry.captureException(error, {
+        tags: {
+          _tag: "resend", area: "email", provider: "resend",
+          email_type: "assignment_notification", case_id: payload.caseId,
+          decision: "failed", error_code: "RESEND_API_ERROR",
+        },
+      });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: {
+        _tag: "resend", area: "email", provider: "resend",
+        email_type: "assignment_notification", case_id: payload.caseId,
+        decision: "failed", error_code: "RESEND_EXCEPTION",
+      },
+    });
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Termin confirmation to reporter (Melder)
+// ---------------------------------------------------------------------------
+
+interface TerminConfirmationPayload {
+  caseLabel: string;
+  tenantDisplayName: string;
+  reporterName?: string;
+  category: string;
+  scheduledAt: string;
+  scheduledEndAt?: string | null;
+  tenantPhone?: string;
+}
+
+/**
+ * Send a termin confirmation email to the Melder.
+ * Identity Contract R4: NO "FlowSight" visible. From = tenant name only.
+ * No console.log — caller owns the log.
+ */
+export async function sendTerminConfirmationToMelder(
+  payload: TerminConfirmationPayload,
+  recipientEmail: string,
+): Promise<boolean> {
+  if (!process.env.RESEND_API_KEY) return false;
+
+  // R4: No "FlowSight" visible to end users — use tenant name directly
+  const addr = process.env.MAIL_FROM ?? "noreply@send.flowsight.ch";
+  const safe = payload.tenantDisplayName.replace(/[<>"]/g, "");
+  const from = `${safe} <${addr}>`;
+
+  const start = new Date(payload.scheduledAt);
+  const dateFmt: Intl.DateTimeFormatOptions = { weekday: "short", day: "2-digit", month: "2-digit", timeZone: "Europe/Zurich" };
+  const timeFmt: Intl.DateTimeFormatOptions = { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" };
+
+  let terminStr = `${start.toLocaleDateString("de-CH", dateFmt)}, ${start.toLocaleTimeString("de-CH", timeFmt)}`;
+  if (payload.scheduledEndAt) {
+    const end = new Date(payload.scheduledEndAt);
+    terminStr += `–${end.toLocaleTimeString("de-CH", timeFmt)}`;
+  }
+
+  const greeting = payload.reporterName ? `Guten Tag ${payload.reporterName}` : "Guten Tag";
+  const phoneLine = payload.tenantPhone ? `Bei Fragen erreichen Sie uns unter ${payload.tenantPhone}.` : "";
+
+  try {
+    const { error } = await getResend().emails.send({
+      from,
+      to: recipientEmail,
+      subject: `Ihr Termin — ${payload.tenantDisplayName}`,
+      text: [
+        greeting,
+        ``,
+        `Wir haben Ihren Termin eingeplant:`,
+        ``,
+        `Termin:    ${terminStr}`,
+        `Kategorie: ${payload.category}`,
+        ``,
+        ...(phoneLine ? [phoneLine, ``] : []),
+        `Freundliche Grüsse`,
+        `Ihr Service-Team`,
+      ].join("\n"),
+    });
+
+    if (error) {
+      Sentry.captureException(error, {
+        tags: {
+          _tag: "resend", area: "email", provider: "resend",
+          email_type: "termin_confirmation_melder",
+          decision: "failed", error_code: "RESEND_API_ERROR",
+        },
+      });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: {
+        _tag: "resend", area: "email", provider: "resend",
+        email_type: "termin_confirmation_melder",
+        decision: "failed", error_code: "RESEND_EXCEPTION",
+      },
+    });
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // ICS Appointment Email (L9: ICS v2 per E-Mail)
 // ---------------------------------------------------------------------------
 

--- a/src/web/src/lib/staff/resolveStaffRole.ts
+++ b/src/web/src/lib/staff/resolveStaffRole.ts
@@ -1,0 +1,40 @@
+import "server-only";
+
+import { getServiceClient } from "@/src/lib/supabase/server";
+
+export interface StaffContext {
+  staffId: string;
+  displayName: string;
+  role: "admin" | "techniker";
+  email: string;
+}
+
+/**
+ * Resolve staff role from user email + tenant ID.
+ * Returns null if no matching staff record found (backwards compatible = full access).
+ */
+export async function resolveStaffRole(
+  userEmail: string,
+  tenantId: string,
+): Promise<StaffContext | null> {
+  if (!userEmail || !tenantId) return null;
+
+  const supabase = getServiceClient();
+  const { data } = await supabase
+    .from("staff")
+    .select("id, display_name, role, email")
+    .eq("tenant_id", tenantId)
+    .eq("email", userEmail)
+    .eq("is_active", true)
+    .limit(1)
+    .maybeSingle();
+
+  if (!data) return null;
+
+  return {
+    staffId: data.id,
+    displayName: data.display_name,
+    role: data.role === "techniker" ? "techniker" : "admin",
+    email: data.email,
+  };
+}


### PR DESCRIPTION
## Summary

- **Assignment email:** Staff gets notified via email when assigned to a case (with case summary + deep link)
- **"Meldende/n benachrichtigen" button:** Sends termin confirmation to reporter via email + SMS
- **Self-send guard:** Warning when clicking "Termin senden" if you're the assigned staff member
- **24h termin reminder:** Lifecycle tick sends SMS reminder to Melder 24h before scheduled appointments
- **RBAC (resolveStaffRole):** Techniker can only see assigned cases, cannot change assignee, no settings access
- **Settings expansion:** 4 new notification toggles (termin email/SMS, staff assignment, 24h reminder) with restructured UI sub-sections

## New files
- `src/web/app/api/ops/cases/[id]/notify-melder/route.ts` — Melder notification API
- `src/web/src/lib/staff/resolveStaffRole.ts` — Staff role resolution utility

## Test plan
- [ ] Assign staff member to case → staff receives email with case summary + link
- [ ] Schedule termin + click "Meldende/n benachrichtigen" → Melder gets email + SMS
- [ ] "Termin senden" still works → staff gets ICS calendar invite
- [ ] Self-send: assign yourself + click "Termin senden" → warning before send
- [ ] Settings API accepts 4 new toggle keys, toggle off → notification suppressed
- [ ] Case with scheduled_at in next 36h + contact_phone → SMS sent by tick
- [ ] Same case on next tick run → no duplicate (case_events guard)
- [ ] Staff with role=techniker → sees only assigned cases, no settings nav
- [ ] Techniker cannot change assignee_text (API restricts fields)
- [ ] Techniker visiting /ops/settings → redirect to /ops/cases
- [ ] Admin/no-staff-record → full access (backwards compatible)
- [ ] Settings page: 6 toggles visible under 3 sub-headings, per-card save works
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)