### PR TITLE
fix: UI polish from founder testing (#224 feedback)

### DIFF
--- a/src/web/app/ops/(auth)/login/LoginForm.tsx
+++ b/src/web/app/ops/(auth)/login/LoginForm.tsx
@@ -81,15 +81,21 @@ export function LoginForm() {
 
       if (error) {
         setStatus("error");
+        const msg = error.message?.toLowerCase() ?? "";
         // User-friendly error for non-existent accounts
         if (
-          error.message?.toLowerCase().includes("user not found") ||
-          error.message?.toLowerCase().includes("signups not allowed") ||
-          error.message?.toLowerCase().includes("for security purposes")
+          msg.includes("user not found") ||
+          msg.includes("signups not allowed") ||
+          msg.includes("for security purposes")
         ) {
           setErrorMsg(
             "Kein Konto mit dieser E-Mail-Adresse. Bitte Admin kontaktieren."
           );
+        } else if (msg.includes("rate limit") || msg.includes("too many")) {
+          setErrorMsg(
+            "Zu viele Anmeldeversuche. Bitte 60 Sekunden warten und erneut versuchen."
+          );
+          setCooldown(60);
         } else {
           setErrorMsg(error.message);
         }

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -523,69 +523,65 @@ export function CaseDetailForm({
               />
             )}
 
-            {/* Send invite + notify melder buttons — after picker closes, if termin is set */}
-            {scheduledAt && !pickerOpen && (
-              <div className="space-y-2 mt-2 pt-2 border-t border-gray-200/60 mb-3">
-                <div className="flex items-center justify-end gap-2">
-                  {/* Melder benachrichtigen — visible when contact info exists */}
-                  {(contactEmail || contactPhone) && (
-                    <button onClick={handleNotifyMelder} disabled={melderNotifyState === "sending"}
-                      className="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-40 transition-colors"
-                    >{melderNotifyState === "sending" ? "Sende…" : melderNotifyState === "sent" ? "Gesendet ✓" : "Meldende/n benachrichtigen"}</button>
-                  )}
-                  <button onClick={handleSendInvite} disabled={inviteState === "sending"}
-                    className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-40 transition-colors"
-                  >{inviteState === "sending" ? "Sende…" : inviteState === "sent" ? "Gesendet ✓" : "Termin senden →"}</button>
-                </div>
-                {/* Self-send confirmation */}
-                {selfSendConfirm && (
-                  <div className="flex items-center justify-end gap-2 p-2 bg-amber-50 border border-amber-200 rounded-lg">
-                    <p className="text-xs text-amber-800 mr-auto">Du bist selbst zugewiesen. Trotzdem senden?</p>
-                    <button onClick={() => { setSelfSendConfirm(false); doSendInvite(); }}
-                      className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 transition-colors"
-                    >Ja, senden</button>
-                    <button onClick={() => setSelfSendConfirm(false)}
-                      className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
-                    >Abbrechen</button>
-                  </div>
-                )}
-                {melderNotifyState === "error" && (
-                  <p className="text-xs text-red-600 text-right">Benachrichtigung fehlgeschlagen.</p>
-                )}
-              </div>
-            )}
-
             {/* Warning banner: Termin changed but not sent */}
             {showTerminWarning && (
-              <div className="flex items-center justify-between gap-3 mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-                <p className="text-sm text-amber-800">
-                  Termin eingetragen, aber noch nicht an den Kunden gesendet.
+              <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                <p className="text-sm text-amber-800 mb-2">
+                  Termin geändert. Beteiligte benachrichtigen?
                 </p>
-                <div className="flex items-center gap-2 flex-shrink-0">
+                <div className="flex flex-wrap items-center gap-2">
                   <button
                     type="button"
                     onClick={async () => {
                       setShowTerminWarning(false);
-                      await handleSendInvite();
+                      await saveSteuerung();
+                      // Send ICS to staff
+                      await doSendInvite();
+                      // Notify melder if contact exists
+                      if (contactEmail || contactPhone) {
+                        await handleNotifyMelder();
+                      }
                     }}
-                    className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 transition-colors"
-                  >Jetzt senden</button>
+                    className="rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-gray-800 transition-colors"
+                  >Speichern &amp; alle benachrichtigen</button>
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      setShowTerminWarning(false);
+                      await saveSteuerung();
+                      await doSendInvite();
+                    }}
+                    className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                  >Nur Mitarbeiter benachrichtigen</button>
                   <button
                     type="button"
                     onClick={async () => {
                       setShowTerminWarning(false);
                       await saveSteuerung();
                     }}
-                    className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+                    className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-400 hover:text-gray-600 hover:bg-gray-50 transition-colors"
                   >Nur speichern</button>
                 </div>
+                {/* Self-send notice */}
+                {currentStaffName && assigneeText === currentStaffName && (
+                  <p className="text-[11px] text-amber-700 mt-2">Hinweis: Du bist selbst zugewiesen — die Mitarbeiter-E-Mail geht an dich.</p>
+                )}
               </div>
+            )}
+
+            {/* Status feedback for melder notification */}
+            {melderNotifyState === "sent" && (
+              <p className="text-xs text-emerald-600 text-right mt-1">Meldende/r benachrichtigt ✓</p>
+            )}
+            {melderNotifyState === "error" && (
+              <p className="text-xs text-red-600 text-right mt-1">Benachrichtigung fehlgeschlagen.</p>
             )}
 
             <EditActions
               onSave={() => {
                 const terminChanged = scheduledAt !== baseline.scheduled_at || scheduledEndAt !== baseline.scheduled_end_at;
-                if (terminChanged && !terminSentForCurrent) {
+                const hasTermin = !!scheduledAt;
+                if (terminChanged && hasTermin && !terminSentForCurrent) {
                   setShowTerminWarning(true);
                 } else {
                   saveSteuerung();
@@ -624,6 +620,19 @@ export function CaseDetailForm({
                   : <span className="text-sm text-gray-500">Offen</span>}
               </KV>
             </div>
+
+            {/* Quick actions (read-only view) */}
+            {scheduledAt && (contactEmail || contactPhone) && (
+              <div className="flex items-center gap-2 mt-3 pt-2 border-t border-gray-200/40 print:hidden">
+                <button onClick={handleNotifyMelder} disabled={melderNotifyState === "sending"}
+                  className="text-xs text-gray-500 hover:text-gray-700 transition-colors"
+                >{melderNotifyState === "sending" ? "Sende…" : melderNotifyState === "sent" ? "Meldende/r benachrichtigt ✓" : "Meldende/n über Termin benachrichtigen"}</button>
+                <span className="text-gray-300">|</span>
+                <button onClick={handleSendInvite} disabled={inviteState === "sending"}
+                  className="text-xs text-gray-500 hover:text-gray-700 transition-colors"
+                >{inviteState === "sending" ? "Sende…" : inviteState === "sent" ? "Termin gesendet ✓" : "Termin an Mitarbeiter senden"}</button>
+              </div>
+            )}
 
             {/* Save state feedback */}
             {(saveState === "saved" || saveState === "error") && (

--- a/src/web/app/ops/(dashboard)/settings/page.tsx
+++ b/src/web/app/ops/(dashboard)/settings/page.tsx
@@ -195,13 +195,13 @@ export default function SettingsPage() {
                 <Toggle
                   checked={notifyTerminEmail}
                   onChange={setNotifyTerminEmail}
-                  label="Terminbestätigung an Meldende (E-Mail)"
+                  label="E-Mail-Terminbestätigung an Meldende"
                   description="Meldende erhalten eine E-Mail wenn ein Termin eingeplant wird"
                 />
                 <Toggle
                   checked={notifyTerminSms}
                   onChange={setNotifyTerminSms}
-                  label="Terminbestätigung an Meldende (SMS)"
+                  label="SMS-Terminbestätigung an Meldende"
                   description="Meldende erhalten eine SMS mit den Termindetails"
                 />
                 <Toggle
@@ -220,7 +220,7 @@ export default function SettingsPage() {
                 <Toggle
                   checked={notifyTerminReminderSms}
                   onChange={setNotifyTerminReminderSms}
-                  label="24h-Erinnerung an Meldende (SMS)"
+                  label="24h-Erinnerung an Meldende per SMS"
                   description="Meldende erhalten am Vortag eine SMS-Erinnerung an den Termin"
                 />
               </div>
@@ -232,6 +232,14 @@ export default function SettingsPage() {
               saved={notifySaved}
               error={notifyError}
               onSave={saveNotify}
+              onCancel={() => {
+                setNotifyEmail(notifyBaseline.email);
+                setNotifySms(notifyBaseline.sms);
+                setNotifyTerminEmail(notifyBaseline.terminEmail);
+                setNotifyTerminSms(notifyBaseline.terminSms);
+                setNotifyTerminReminderSms(notifyBaseline.terminReminderSms);
+                setNotifyStaffAssignment(notifyBaseline.staffAssignment);
+              }}
             />
           )}
         </Section>
@@ -258,6 +266,7 @@ export default function SettingsPage() {
               saved={reviewSaved}
               error={reviewError}
               onSave={saveReview}
+              onCancel={() => setGoogleReviewUrl(reviewBaseline)}
             />
           )}
         </Section>
@@ -293,11 +302,13 @@ function CardSaveBar({
   saved,
   error,
   onSave,
+  onCancel,
 }: {
   saving: boolean;
   saved: boolean;
   error: string | null;
   onSave: () => void;
+  onCancel?: () => void;
 }) {
   return (
     <div className="mt-4 pt-3 border-t border-gray-100 flex items-center gap-3">
@@ -308,6 +319,15 @@ function CardSaveBar({
       >
         {saving ? "Speichern…" : "Speichern"}
       </button>
+      {onCancel && (
+        <button
+          onClick={onCancel}
+          disabled={saving}
+          className="rounded-lg border border-gray-200 bg-white px-5 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300 transition-colors disabled:opacity-50"
+        >
+          Abbrechen
+        </button>
+      )}
       {saved && (
         <span className="text-xs text-emerald-600 font-medium">Gespeichert</span>
       )}

--- a/src/web/src/components/ops/StaffManager.tsx
+++ b/src/web/src/components/ops/StaffManager.tsx
@@ -34,6 +34,7 @@ export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState("");
+  const [showRoleInfo, setShowRoleInfo] = useState(false);
 
   // Form state
   const [name, setName] = useState("");
@@ -172,7 +173,15 @@ export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Rolle</label>
+              <label className="flex items-center gap-1.5 text-xs font-medium text-gray-600 mb-1">
+                Rolle
+                <button
+                  type="button"
+                  onClick={() => setShowRoleInfo(p => !p)}
+                  className="inline-flex items-center justify-center w-4 h-4 rounded-full border border-gray-300 text-gray-400 hover:text-gray-600 hover:border-gray-400 transition-colors text-[10px] font-bold leading-none"
+                  title="Was bedeuten die Rollen?"
+                >i</button>
+              </label>
               <select
                 value={role}
                 onChange={(e) => setRole(e.target.value)}
@@ -181,6 +190,36 @@ export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
                 <option value="admin">Admin</option>
                 <option value="techniker">Techniker</option>
               </select>
+              {showRoleInfo && (
+                <div className="mt-2 p-3 bg-white border border-gray-200 rounded-lg shadow-sm text-xs text-gray-600 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold text-gray-900 text-sm">Rollen im Leitsystem</span>
+                    <button onClick={() => setShowRoleInfo(false)} className="text-gray-400 hover:text-gray-600 transition-colors">
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+                    </button>
+                  </div>
+                  <div className="space-y-2">
+                    <div className="p-2.5 bg-slate-50 rounded-lg">
+                      <p className="font-semibold text-gray-800 mb-1">Admin (Inhaber / Büroleitung)</p>
+                      <ul className="space-y-0.5 text-gray-500">
+                        <li>Sieht alle Fälle im Betrieb</li>
+                        <li>Kann Fälle zuweisen und Mitarbeiter verwalten</li>
+                        <li>Zugriff auf Einstellungen und Benachrichtigungen</li>
+                        <li>Kann Termine versenden und Meldende benachrichtigen</li>
+                      </ul>
+                    </div>
+                    <div className="p-2.5 bg-slate-50 rounded-lg">
+                      <p className="font-semibold text-gray-800 mb-1">Techniker (Monteur / Servicemitarbeiter)</p>
+                      <ul className="space-y-0.5 text-gray-500">
+                        <li>Sieht nur Fälle, die ihm zugewiesen sind</li>
+                        <li>Kann Status, Priorität und Termin ändern</li>
+                        <li>Kann keine Fälle zuweisen oder umverteilen</li>
+                        <li>Kein Zugriff auf Einstellungen</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">E-Mail</label>


### PR DESCRIPTION
## Summary
- **Role info button**: (i) next to "Rolle" in team form — explains Admin vs Techniker in Handwerker-Sprache
- **Toggle labels**: Consistent wording across all notification toggles in settings
- **Cancel buttons**: Abbrechen button on all settings cards (Benachrichtigungen + Google Review)
- **Button simplification**: Replaced 5-button chaos in case edit with unified termin warning flow (3 clear choices)
- **Rate limit message**: German error + 60s cooldown timer for OTP rate limit on login

## Test plan
- [ ] Settings → Team → click (i) next to Rolle → info panel shows Admin/Techniker descriptions
- [ ] Settings → Benachrichtigungen → toggle any → Abbrechen resets, Speichern saves
- [ ] Case edit → change Termin → amber warning with 3 options appears
- [ ] Login → trigger rate limit → German message with countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)