### PR TITLE
fix: persistent 7-day sessions + login cooldown timer

### DIFF
--- a/src/web/app/ops/(auth)/login/LoginForm.tsx
+++ b/src/web/app/ops/(auth)/login/LoginForm.tsx
@@ -355,10 +355,14 @@ export function LoginForm() {
 
       <button
         type="submit"
-        disabled={status === "sending"}
+        disabled={status === "sending" || cooldown > 0}
         className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       >
-        {status === "sending" ? "Code wird gesendet\u2026" : "Code senden"}
+        {status === "sending"
+          ? "Code wird gesendet\u2026"
+          : cooldown > 0
+            ? `Neuer Versuch in ${cooldown}s`
+            : "Code senden"}
       </button>
     </form>
   );

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -21,6 +21,9 @@ export async function middleware(request: NextRequest) {
   if (!url || !key) return supabaseResponse;
 
   const supabase = createServerClient(url, key, {
+    cookieOptions: {
+      maxAge: 7 * 24 * 60 * 60,
+    },
     cookies: {
       getAll() {
         return request.cookies.getAll();

--- a/src/web/src/lib/supabase/browser.ts
+++ b/src/web/src/lib/supabase/browser.ts
@@ -21,5 +21,9 @@ export function getBrowserClient() {
 
   return createBrowserClient(url, key, {
     auth: { flowType: "implicit" },
+    cookieOptions: {
+      // Persist session across browser restarts (7 days = refresh token lifetime)
+      maxAge: 7 * 24 * 60 * 60,
+    },
   });
 }

--- a/src/web/src/lib/supabase/server-auth.ts
+++ b/src/web/src/lib/supabase/server-auth.ts
@@ -19,6 +19,9 @@ export async function getAuthClient() {
   }
 
   return createServerClient(url, key, {
+    cookieOptions: {
+      maxAge: 7 * 24 * 60 * 60,
+    },
     cookies: {
       getAll() {
         return cookieStore.getAll();


### PR DESCRIPTION
## Summary
- **Persistent sessions (7 days):** Auth cookies now survive browser restart — no daily OTP login needed. `maxAge=7d` on all 3 Supabase clients (browser, server-auth, middleware), matching Supabase's refresh token lifetime.
- **Login cooldown timer:** After rate limit hit, "Code senden" button shows countdown (`Neuer Versuch in 58s`) and is disabled — prevents repeated triggers.

## Why
Founder hit OTP rate limit during testing and had no visual feedback on when retry is possible. Additionally, session cookies were browser-session-only, forcing re-login on every browser restart — not viable for daily operations.

## Test plan
- [ ] Login → close browser completely → reopen → `/ops/cases` still accessible (no re-login)
- [ ] Login → trigger rate limit → button shows countdown, auto-enables after 60s
- [ ] After countdown: click "Code senden" → code arrives normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)