### PR TITLE
feat: PWA — installable Leitsystem with dynamic tenant branding

### DIFF
--- a/src/web/app/api/ops/pwa/icon/route.tsx
+++ b/src/web/app/api/ops/pwa/icon/route.tsx
@@ -1,0 +1,42 @@
+import { ImageResponse } from "next/og";
+
+/**
+ * Dynamic PWA icon — navy background + gold circle.
+ * Sizes: ?size=192 | ?size=512 (default)
+ * Used by manifest.json and apple-touch-icon.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const size = Math.min(
+    Math.max(parseInt(searchParams.get("size") || "512", 10), 48),
+    1024
+  );
+  const radius = Math.round(size * 0.22);
+  const circleSize = Math.round(size * 0.44);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: size,
+          height: size,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#1a2744",
+          borderRadius: radius,
+        }}
+      >
+        <div
+          style={{
+            width: circleSize,
+            height: circleSize,
+            borderRadius: "50%",
+            backgroundColor: "#d4a843",
+          }}
+        />
+      </div>
+    ),
+    { width: size, height: size }
+  );
+}

--- a/src/web/app/api/ops/pwa/manifest/route.ts
+++ b/src/web/app/api/ops/pwa/manifest/route.ts
@@ -1,0 +1,70 @@
+import { getAuthClient } from "@/src/lib/supabase/server-auth";
+import { resolveTenantIdentity } from "@/src/lib/tenants/resolveTenantIdentity";
+
+/**
+ * Dynamic PWA manifest — tenant-branded.
+ *
+ * When the user is logged in, the manifest uses the tenant's short name
+ * (e.g. "Weinberger AG") so the homescreen icon shows THEIR brand,
+ * not "FlowSight". Identity Contract R4 compliance.
+ *
+ * Fallback for unauthenticated: generic "Leitsystem".
+ */
+export async function GET() {
+  let name = "Leitsystem";
+  let shortName = "Leitsystem";
+
+  try {
+    const supabase = await getAuthClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (user) {
+      const identity = await resolveTenantIdentity(user);
+      if (identity) {
+        shortName = identity.shortName;
+        name = `${identity.shortName} Leitsystem`;
+      }
+    }
+  } catch {
+    // Fall through to defaults — manifest must always return valid JSON
+  }
+
+  const manifest = {
+    name,
+    short_name: shortName,
+    description: "Fälle, Termine und Team auf einen Blick.",
+    start_url: "/ops/cases",
+    scope: "/ops/",
+    display: "standalone" as const,
+    background_color: "#1a2744",
+    theme_color: "#1a2744",
+    orientation: "portrait-primary" as const,
+    icons: [
+      {
+        src: "/api/ops/pwa/icon?size=192",
+        sizes: "192x192",
+        type: "image/png",
+      },
+      {
+        src: "/api/ops/pwa/icon?size=512",
+        sizes: "512x512",
+        type: "image/png",
+      },
+      {
+        src: "/api/ops/pwa/icon?size=512",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "maskable",
+      },
+    ],
+  };
+
+  return new Response(JSON.stringify(manifest), {
+    headers: {
+      "Content-Type": "application/manifest+json",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/src/web/app/ops/(dashboard)/layout.tsx
+++ b/src/web/app/ops/(dashboard)/layout.tsx
@@ -8,6 +8,7 @@ import { OpsShell } from "@/src/components/ops/OpsShell";
 /**
  * Tab title: "{short_name} Leitsystem" — Identity Contract E2.
  * Uses title.absolute to bypass root layout's " — FlowSight" template (R4).
+ * PWA manifest + apple-touch-icon for homescreen installation.
  */
 export async function generateMetadata(): Promise<Metadata> {
   try {
@@ -19,7 +20,18 @@ export async function generateMetadata(): Promise<Metadata> {
 
     const identity = await resolveTenantIdentity(user);
     const tabLabel = identity?.shortName ?? "Leitsystem";
-    return { title: { absolute: `${tabLabel} Leitsystem` } };
+    return {
+      title: { absolute: `${tabLabel} Leitsystem` },
+      manifest: "/api/ops/pwa/manifest",
+      icons: {
+        apple: "/api/ops/pwa/icon?size=180",
+      },
+      other: {
+        "mobile-web-app-capable": "yes",
+        "apple-mobile-web-app-capable": "yes",
+        "apple-mobile-web-app-status-bar-style": "black-translucent",
+      },
+    };
   } catch {
     return { title: { absolute: "Leitsystem" } };
   }

--- a/src/web/app/ops/(dashboard)/offline/page.tsx
+++ b/src/web/app/ops/(dashboard)/offline/page.tsx
@@ -1,0 +1,38 @@
+/**
+ * Offline fallback page — shown by service worker when no network + no cache.
+ * Intentionally simple. No data fetching. Works without JS.
+ */
+export default function OfflinePage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-6">
+      <div className="w-16 h-16 rounded-2xl bg-gray-200 flex items-center justify-center mb-6">
+        <svg
+          className="w-8 h-8 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+          />
+        </svg>
+      </div>
+      <h1 className="text-lg font-bold text-gray-900 mb-2">
+        Keine Verbindung
+      </h1>
+      <p className="text-sm text-gray-500 max-w-xs">
+        Das Leitsystem braucht eine Internetverbindung. Bitte prüfe dein WLAN
+        oder mobile Daten und versuche es erneut.
+      </p>
+      <button
+        onClick={() => window.location.reload()}
+        className="mt-6 rounded-lg bg-slate-800 px-5 py-2.5 text-sm font-medium text-white hover:bg-slate-700 transition-colors"
+      >
+        Erneut versuchen
+      </button>
+    </div>
+  );
+}

--- a/src/web/public/sw.js
+++ b/src/web/public/sw.js
@@ -1,0 +1,115 @@
+/**
+ * FlowSight Leitsystem — Service Worker
+ *
+ * Strategy:
+ * - Static assets (/_next/static/): cache-first (content-hashed, safe forever)
+ * - Pages & API: network-first (fresh data, offline fallback)
+ * - Offline: show cached shell or fallback page
+ *
+ * This SW is intentionally minimal. Its primary purposes are:
+ * 1. Making the app installable as PWA
+ * 2. Caching static assets for fast loads
+ * 3. Providing offline fallback
+ * 4. Future: push notification handling (Phase 2)
+ */
+
+const CACHE_NAME = "flowsight-v1";
+const OFFLINE_URL = "/ops/offline";
+
+// ── Install ────────────────────────────────────────────────────────────────
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) =>
+      // Pre-cache the offline fallback page
+      cache.add(OFFLINE_URL).catch(() => {
+        // Offline page might not exist yet during first install — that's OK
+      })
+    )
+  );
+  // Activate immediately (don't wait for old SW to die)
+  self.skipWaiting();
+});
+
+// ── Activate ───────────────────────────────────────────────────────────────
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  // Take control of all open tabs immediately
+  self.clients.claim();
+});
+
+// ── Fetch ──────────────────────────────────────────────────────────────────
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  // Only handle GET requests
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+
+  // Skip non-HTTP(S) requests (e.g. chrome-extension://)
+  if (!url.protocol.startsWith("http")) return;
+
+  // ── Static assets: cache-first ──
+  // Next.js static assets are content-hashed — safe to cache indefinitely
+  if (url.pathname.startsWith("/_next/static/")) {
+    event.respondWith(
+      caches.match(request).then(
+        (cached) =>
+          cached ||
+          fetch(request).then((response) => {
+            // Only cache successful responses
+            if (response.ok) {
+              const clone = response.clone();
+              caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+            }
+            return response;
+          })
+      )
+    );
+    return;
+  }
+
+  // ── Manifest & icons: cache with revalidation ──
+  if (
+    url.pathname.includes("/pwa/manifest") ||
+    url.pathname.includes("/pwa/icon")
+  ) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          }
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  // ── API requests: network-only (too dynamic to cache reliably) ──
+  if (url.pathname.startsWith("/api/")) {
+    return; // Let browser handle normally
+  }
+
+  // ── Pages: network-first with offline fallback ──
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request).catch(() =>
+        caches
+          .match(request)
+          .then((cached) => cached || caches.match(OFFLINE_URL))
+      )
+    );
+    return;
+  }
+});

--- a/src/web/src/components/ops/InstallPrompt.tsx
+++ b/src/web/src/components/ops/InstallPrompt.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * PWA Install Prompt — cross-platform.
+ *
+ * Android/Desktop Chrome: intercepts beforeinstallprompt → custom banner.
+ * iOS Safari: detects UA → shows manual instructions.
+ * Already installed: hidden (display-mode: standalone check).
+ * Dismissed: hidden for 7 days (localStorage).
+ */
+
+// Extend window for beforeinstallprompt event
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+const DISMISS_KEY = "pwa-install-dismissed";
+const DISMISS_DAYS = 7;
+
+function isDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  const val = localStorage.getItem(DISMISS_KEY);
+  if (!val) return false;
+  const expiry = parseInt(val, 10);
+  if (Date.now() > expiry) {
+    localStorage.removeItem(DISMISS_KEY);
+    return false;
+  }
+  return true;
+}
+
+function setDismissed() {
+  localStorage.setItem(
+    DISMISS_KEY,
+    String(Date.now() + DISMISS_DAYS * 24 * 60 * 60 * 1000)
+  );
+}
+
+function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    // iOS Safari standalone mode
+    ("standalone" in window.navigator &&
+      (window.navigator as unknown as { standalone: boolean }).standalone)
+  );
+}
+
+function getDevice(): "ios" | "android" | "desktop" {
+  if (typeof window === "undefined") return "desktop";
+  const ua = navigator.userAgent.toLowerCase();
+  if (/iphone|ipad|ipod/.test(ua)) return "ios";
+  if (/android/.test(ua)) return "android";
+  return "desktop";
+}
+
+export function InstallPrompt() {
+  const [show, setShow] = useState(false);
+  // Initialize device from SSR-safe default, updated via lazy initializer
+  const [device] = useState<"ios" | "android" | "desktop">(() => getDevice());
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [showIOSSteps, setShowIOSSteps] = useState(false);
+
+  useEffect(() => {
+    // Don't show if already installed or recently dismissed
+    if (isStandalone() || isDismissed()) return;
+
+    // Android/Desktop: capture the install prompt
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setShow(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+
+    // iOS: no beforeinstallprompt event, show our own prompt
+    const d = getDevice();
+    if (d === "ios") {
+      // Small delay so the page loads first
+      const timer = setTimeout(() => setShow(true), 2000);
+      return () => {
+        clearTimeout(timer);
+        window.removeEventListener("beforeinstallprompt", handler);
+      };
+    }
+
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === "accepted") {
+      setShow(false);
+    }
+    setDeferredPrompt(null);
+  }, [deferredPrompt]);
+
+  const handleDismiss = useCallback(() => {
+    setDismissed();
+    setShow(false);
+  }, []);
+
+  if (!show) return null;
+
+  // ── iOS: manual instructions ──────────────────────────────────────────
+  if (device === "ios") {
+    return (
+      <div className="mx-4 mb-4 rounded-xl border border-blue-200 bg-blue-50 p-4 shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-gray-900">
+              Als App installieren
+            </p>
+            <p className="text-xs text-gray-600 mt-0.5">
+              Leitsystem auf den Homescreen legen — 1 Tipp und du bist drin.
+            </p>
+          </div>
+          <button
+            onClick={handleDismiss}
+            className="text-gray-400 hover:text-gray-600 shrink-0 mt-0.5"
+            aria-label="Schliessen"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18 18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {!showIOSSteps ? (
+          <button
+            onClick={() => setShowIOSSteps(true)}
+            className="mt-3 w-full rounded-lg bg-blue-600 px-4 py-2 text-xs font-semibold text-white hover:bg-blue-500 transition-colors"
+          >
+            Anleitung anzeigen
+          </button>
+        ) : (
+          <div className="mt-3 space-y-3">
+            <div className="flex items-start gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center">
+                1
+              </span>
+              <div>
+                <p className="text-sm font-medium text-gray-900">
+                  Teilen-Button antippen
+                </p>
+                <p className="text-xs text-gray-500">
+                  Das Quadrat mit dem Pfeil nach oben{" "}
+                  <span className="inline-block text-blue-600 font-bold">
+                    ↗
+                  </span>{" "}
+                  — unten in der Safari-Leiste.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center">
+                2
+              </span>
+              <div>
+                <p className="text-sm font-medium text-gray-900">
+                  &quot;Zum Home-Bildschirm&quot;
+                </p>
+                <p className="text-xs text-gray-500">
+                  Im Menü nach unten scrollen und antippen.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center">
+                3
+              </span>
+              <div>
+                <p className="text-sm font-medium text-gray-900">
+                  &quot;Hinzufügen&quot; antippen
+                </p>
+                <p className="text-xs text-gray-500">
+                  Oben rechts bestätigen — fertig. Das Icon liegt auf deinem
+                  Homescreen.
+                </p>
+              </div>
+            </div>
+
+            <button
+              onClick={handleDismiss}
+              className="text-xs text-gray-500 hover:text-gray-700 transition-colors"
+            >
+              Verstanden, nicht mehr anzeigen
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ── Android / Desktop: native install prompt ───────────────────────────
+  return (
+    <div className="mx-4 mb-4 rounded-xl border border-blue-200 bg-blue-50 p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1">
+          <p className="text-sm font-semibold text-gray-900">
+            Als App installieren
+          </p>
+          <p className="text-xs text-gray-600 mt-0.5">
+            Leitsystem auf den Homescreen legen — Vollbild, kein Browser, ein
+            Tipp und du bist drin.
+          </p>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="text-gray-400 hover:text-gray-600 shrink-0 mt-0.5"
+          aria-label="Schliessen"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18 18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+      <div className="flex gap-2 mt-3">
+        <button
+          onClick={handleInstall}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-xs font-semibold text-white hover:bg-blue-500 transition-colors"
+        >
+          Installieren
+        </button>
+        <button
+          onClick={handleDismiss}
+          className="rounded-lg border border-gray-200 bg-white px-4 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+        >
+          Später
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { InstallPrompt } from "./InstallPrompt";
+import { ServiceWorkerRegistration } from "./ServiceWorkerRegistration";
 
 // ---------------------------------------------------------------------------
 // Navigation — 3 items only, mirroring the Leitsystem architecture
@@ -232,10 +234,12 @@ export function OpsShell({
 
       {/* Main content */}
       <main className="md:ml-64">
+        <InstallPrompt />
         <div className="max-w-6xl mx-auto px-4 py-6">
           {children}
         </div>
       </main>
+      <ServiceWorkerRegistration />
     </div>
   );
 }

--- a/src/web/src/components/ops/ServiceWorkerRegistration.tsx
+++ b/src/web/src/components/ops/ServiceWorkerRegistration.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Registers the service worker on mount.
+ * Placed in the OpsShell so it runs once per session.
+ * Silent — no UI, no errors shown to user.
+ */
+export function ServiceWorkerRegistration() {
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      !("serviceWorker" in navigator) ||
+      process.env.NODE_ENV === "development"
+    ) {
+      return;
+    }
+
+    navigator.serviceWorker.register("/sw.js").catch(() => {
+      // Silent fail — SW is a progressive enhancement
+    });
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- **Dynamic manifest**: App name = tenant short_name (e.g. "Weinberger AG Leitsystem") — homescreen icon shows THEIR brand, not FlowSight
- **Dynamic icon**: Navy + gold circle generated at any size via `next/og` ImageResponse
- **Service worker**: Cache-first for static assets, network-first for pages, offline fallback
- **Install prompt**: Cross-platform — Android (native `beforeinstallprompt`), iOS Safari (step-by-step instructions), 7-day dismiss memory
- **Offline page**: "Keine Verbindung" with retry button
- **Meta tags**: `apple-touch-icon`, `apple-mobile-web-app-capable`, manifest link

## Architecture
```
/api/ops/pwa/manifest  → dynamic JSON (tenant-branded)
/api/ops/pwa/icon      → dynamic PNG (?size=192|512)
/public/sw.js          → service worker
/ops/offline           → offline fallback page
InstallPrompt.tsx      → cross-platform install banner
ServiceWorkerRegistration.tsx → silent SW registration
```

## Test plan
- [ ] Desktop Chrome: visit /ops/cases → install icon appears in address bar → install → opens as standalone app
- [ ] Android Chrome: visit /ops/cases → install banner shows → tap Install → icon on homescreen with tenant name
- [ ] iOS Safari: visit /ops/cases → blue install banner with 3-step instructions → follow steps → icon on homescreen
- [ ] Dismiss banner → doesn't reappear for 7 days
- [ ] Already installed (standalone mode) → no banner shown
- [ ] /api/ops/pwa/manifest → returns JSON with tenant short_name
- [ ] /api/ops/pwa/icon?size=512 → returns 512x512 PNG (navy + gold)
- [ ] Go offline → navigate → "Keine Verbindung" page with retry button
- [ ] Reopen installed PWA → opens at /ops/cases, no browser chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)