### PR TITLE
fix: PWA manifest available on login page

### DIFF
--- a/src/web/app/ops/(dashboard)/layout.tsx
+++ b/src/web/app/ops/(dashboard)/layout.tsx
@@ -8,7 +8,7 @@ import { OpsShell } from "@/src/components/ops/OpsShell";
 /**
  * Tab title: "{short_name} Leitsystem" — Identity Contract E2.
  * Uses title.absolute to bypass root layout's " — FlowSight" template (R4).
- * PWA manifest + apple-touch-icon for homescreen installation.
+ * PWA manifest + meta tags inherited from parent ops/layout.tsx.
  */
 export async function generateMetadata(): Promise<Metadata> {
   try {
@@ -20,18 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
     const identity = await resolveTenantIdentity(user);
     const tabLabel = identity?.shortName ?? "Leitsystem";
-    return {
-      title: { absolute: `${tabLabel} Leitsystem` },
-      manifest: "/api/ops/pwa/manifest",
-      icons: {
-        apple: "/api/ops/pwa/icon?size=180",
-      },
-      other: {
-        "mobile-web-app-capable": "yes",
-        "apple-mobile-web-app-capable": "yes",
-        "apple-mobile-web-app-status-bar-style": "black-translucent",
-      },
-    };
+    return { title: { absolute: `${tabLabel} Leitsystem` } };
   } catch {
     return { title: { absolute: "Leitsystem" } };
   }

--- a/src/web/app/ops/layout.tsx
+++ b/src/web/app/ops/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+
+/**
+ * Root ops layout — wraps BOTH (auth) and (dashboard) route groups.
+ * PWA manifest + meta tags here so they're available on login AND dashboard.
+ *
+ * On the login page (no session): manifest returns generic "Leitsystem".
+ * On dashboard pages (with session): manifest returns tenant name dynamically.
+ */
+export const metadata: Metadata = {
+  manifest: "/api/ops/pwa/manifest",
+  icons: {
+    apple: "/api/ops/pwa/icon?size=180",
+  },
+  other: {
+    "mobile-web-app-capable": "yes",
+    "apple-mobile-web-app-capable": "yes",
+    "apple-mobile-web-app-status-bar-style": "black-translucent",
+  },
+};
+
+export default function OpsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- Move manifest + apple-touch-icon meta from dashboard layout → new `ops/layout.tsx` (wraps both auth + dashboard)
- Now the browser sees the PWA manifest on `/ops/login` too → install icon appears before login
- On login page (no session): manifest returns generic "Leitsystem"
- After login (with session): manifest returns tenant name (e.g. "Weinberger AG")

## Test plan
- [ ] Visit /ops/login → Chrome shows install icon in address bar
- [ ] Install from login page → icon name = "Leitsystem"
- [ ] After login, dashboard still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)