### PR TITLE
fix: service worker + install prompt on login page

### DIFF
--- a/src/web/app/ops/(auth)/layout.tsx
+++ b/src/web/app/ops/(auth)/layout.tsx
@@ -1,7 +1,10 @@
+import { ServiceWorkerRegistration } from "@/src/components/ops/ServiceWorkerRegistration";
+
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-slate-950">
       {children}
+      <ServiceWorkerRegistration />
     </div>
   );
 }

--- a/src/web/app/ops/(auth)/login/page.tsx
+++ b/src/web/app/ops/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { LoginForm } from "./LoginForm";
+import { InstallPrompt } from "@/src/components/ops/InstallPrompt";
 
 export default function OpsLoginPage() {
   return (
@@ -21,6 +22,10 @@ export default function OpsLoginPage() {
         <p className="text-slate-600 text-xs mt-8 text-center">
           Nur autorisierte Benutzer. Kein Konto? Admin kontaktieren.
         </p>
+
+        <div className="mt-6">
+          <InstallPrompt />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Register service worker on auth layout (login page) — required for Edge/Chrome to show install icon
- Add InstallPrompt banner below login form — visible CTA for installation

## Test plan
- [ ] Edge: visit /ops/login → install icon appears in address bar after page load
- [ ] Edge: "Installieren" banner visible below login form
- [ ] Chrome: same behavior
- [ ] After login: dashboard install prompt still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)