### PR TITLE
fix: remove KI buzzwords, clean PWA titles (#230)

### DIFF
--- a/src/web/app/layout.tsx
+++ b/src/web/app/layout.tsx
@@ -15,11 +15,11 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: {
     default:
-      "FlowSight – KI-Telefonassistent & Ops-Dashboard für Sanitär & Heizung",
+      "FlowSight – Telefonassistent & Leitsystem für Sanitär & Heizung",
     template: "%s — FlowSight",
   },
   description:
-    "24/7 Anrufannahme mit KI, strukturierte Fälle im Dashboard, Website + Online-Auftragsformular. Für Sanitär- und Heizungsbetriebe im Raum Zürich.",
+    "24/7 Anrufannahme, strukturierte Falllisten und Einsatzplanung. Für Sanitär- und Heizungsbetriebe im Raum Zürich.",
   metadataBase: new URL("https://flowsight.ch"),
   icons: {
     icon: "/favicon.svg",
@@ -29,17 +29,17 @@ export const metadata: Metadata = {
     locale: "de_CH",
     siteName: "FlowSight",
     title:
-      "FlowSight – KI-Telefonassistent & Ops-Dashboard für Sanitär & Heizung",
+      "FlowSight – Telefonassistent & Leitsystem für Sanitär & Heizung",
     description:
-      "24/7 Anrufannahme mit KI, strukturierte Fälle im Dashboard, Website + Online-Auftragsformular. Für Sanitär- und Heizungsbetriebe im Raum Zürich.",
+      "24/7 Anrufannahme, strukturierte Falllisten und Einsatzplanung. Für Sanitär- und Heizungsbetriebe im Raum Zürich.",
     url: "https://flowsight.ch",
   },
   twitter: {
     card: "summary_large_image",
     title:
-      "FlowSight – KI-Telefonassistent & Ops-Dashboard für Sanitär & Heizung",
+      "FlowSight – Telefonassistent & Leitsystem für Sanitär & Heizung",
     description:
-      "24/7 Anrufannahme mit KI, strukturierte Fälle im Dashboard, Website + Online-Auftragsformular. Für Sanitär- und Heizungsbetriebe im Raum Zürich.",
+      "24/7 Anrufannahme, strukturierte Falllisten und Einsatzplanung. Für Sanitär- und Heizungsbetriebe im Raum Zürich.",
   },
   other: {
     "theme-color": "#1a2744",

--- a/src/web/app/ops/(auth)/layout.tsx
+++ b/src/web/app/ops/(auth)/layout.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { ServiceWorkerRegistration } from "@/src/components/ops/ServiceWorkerRegistration";
+
+/** Clean title for the login page — no FlowSight branding (Identity R4). */
+export const metadata: Metadata = {
+  title: { absolute: "Leitsystem" },
+};
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/web/app/ops/(auth)/login/page.tsx
+++ b/src/web/app/ops/(auth)/login/page.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
 import { LoginForm } from "./LoginForm";
-import { InstallPrompt } from "@/src/components/ops/InstallPrompt";
 
 export default function OpsLoginPage() {
   return (
@@ -22,10 +21,6 @@ export default function OpsLoginPage() {
         <p className="text-slate-600 text-xs mt-8 text-center">
           Nur autorisierte Benutzer. Kein Konto? Admin kontaktieren.
         </p>
-
-        <div className="mt-6">
-          <InstallPrompt />
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Root layout: "KI-Telefonassistent & Ops-Dashboard" → "Telefonassistent & Leitsystem für Sanitär & Heizung" (Handwerker-Sprache)
- Auth layout: login page tab title = "Leitsystem" (no FlowSight branding, Identity R4)
- Login page: InstallPrompt removed — PWA install now only from dashboard where tenant name is in manifest

## Test plan
- [ ] Open /ops/login → tab shows "Leitsystem", no "KI" or "FlowSight"
- [ ] Install PWA from dashboard → app name = tenant short_name (e.g. "Weinberger AG Leitsystem")
- [ ] Google/social previews show "FlowSight – Telefonassistent & Leitsystem für Sanitär & Heizung"

🤖 Generated with [Claude Code](https://claude.com/claude-code)