### PR TITLE
fix: login rate-limit detection + logout confirmation

### DIFF
--- a/src/web/app/ops/(auth)/login/LoginForm.tsx
+++ b/src/web/app/ops/(auth)/login/LoginForm.tsx
@@ -82,20 +82,27 @@ export function LoginForm() {
       if (error) {
         setStatus("error");
         const msg = error.message?.toLowerCase() ?? "";
-        // User-friendly error for non-existent accounts
+        // Rate limit check FIRST — Supabase says "For security purposes,
+        // you can only request this once every X seconds"
         if (
+          msg.includes("security purposes") ||
+          msg.includes("rate limit") ||
+          msg.includes("too many")
+        ) {
+          // Parse wait seconds from Supabase message if possible
+          const match = error.message?.match(/every\s+(\d+)\s+seconds/i);
+          const wait = match ? Math.max(parseInt(match[1], 10), 60) : 60;
+          setErrorMsg(
+            `Bitte ${wait} Sekunden warten und erneut versuchen.`
+          );
+          setCooldown(wait);
+        } else if (
           msg.includes("user not found") ||
-          msg.includes("signups not allowed") ||
-          msg.includes("for security purposes")
+          msg.includes("signups not allowed")
         ) {
           setErrorMsg(
             "Kein Konto mit dieser E-Mail-Adresse. Bitte Admin kontaktieren."
           );
-        } else if (msg.includes("rate limit") || msg.includes("too many")) {
-          setErrorMsg(
-            "Zu viele Anmeldeversuche. Bitte 60 Sekunden warten und erneut versuchen."
-          );
-          setCooldown(60);
         } else {
           setErrorMsg(error.message);
         }

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -154,17 +154,43 @@ export function OpsShell({
   );
 
   // ── Footer ──────────────────────────────────────────────────────────
+  const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
+
   const footer = (
     <div className="px-4 py-4 border-t border-gray-800">
       <p className="text-[11px] text-gray-500 truncate mb-2">{userEmail}</p>
-      <form action="/api/ops/logout" method="POST">
+      {showLogoutConfirm ? (
+        <div className="space-y-2">
+          <p className="text-[11px] text-amber-400">
+            Nach Abmeldung ist ein neuer E-Mail-Code nötig.
+          </p>
+          <div className="flex gap-2">
+            <form action="/api/ops/logout" method="POST">
+              <button
+                type="submit"
+                className="text-[11px] text-red-400 hover:text-red-300 transition-colors font-medium"
+              >
+                Ja, abmelden
+              </button>
+            </form>
+            <button
+              type="button"
+              onClick={() => setShowLogoutConfirm(false)}
+              className="text-[11px] text-gray-500 hover:text-gray-300 transition-colors"
+            >
+              Abbrechen
+            </button>
+          </div>
+        </div>
+      ) : (
         <button
-          type="submit"
+          type="button"
+          onClick={() => setShowLogoutConfirm(true)}
           className="text-[11px] text-gray-600 hover:text-gray-400 transition-colors"
         >
           Abmelden
         </button>
-      </form>
+      )}
     </div>
   );
 


### PR DESCRIPTION
## Summary
- **Bug fix**: Supabase "For security purposes..." error was misclassified as "Kein Konto" — now correctly shows rate-limit countdown
- **Accurate timer**: Parses actual wait duration from Supabase error (not hardcoded 60s)
- **Logout confirmation**: "Nach Abmeldung ist ein neuer E-Mail-Code nötig." with Ja/Abbrechen — prevents accidental logout with 7-day sessions

## Test plan
- [ ] Login → Abmelden klicken → Bestätigungsdialog erscheint
- [ ] "Abbrechen" → bleibt eingeloggt
- [ ] "Ja, abmelden" → Logout → Login-Seite
- [ ] Sofort wieder E-Mail eingeben → korrekte Rate-Limit-Meldung (nicht "Kein Konto")
- [ ] Nach Ablauf des Countdowns → Code kann gesendet werden

🤖 Generated with [Claude Code](https://claude.com/claude-code)