### PR TITLE
fix: bulletproof login — no more false Kein Konto errors

### DIFF
--- a/src/web/app/api/ops/logout/route.ts
+++ b/src/web/app/api/ops/logout/route.ts
@@ -3,7 +3,9 @@ import { getAuthClient } from "@/src/lib/supabase/server-auth";
 
 export async function POST() {
   const supabase = await getAuthClient();
-  await supabase.auth.signOut();
+  // scope: 'local' — only clears this session's cookies, doesn't call
+  // Supabase auth server. Faster logout, no side effects on rate limits.
+  await supabase.auth.signOut({ scope: "local" });
 
   return NextResponse.redirect(new URL("/ops/login", process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL ?? "http://localhost:3000"), {
     status: 303, // POST → GET redirect

--- a/src/web/app/ops/(auth)/login/LoginForm.tsx
+++ b/src/web/app/ops/(auth)/login/LoginForm.tsx
@@ -82,29 +82,35 @@ export function LoginForm() {
       if (error) {
         setStatus("error");
         const msg = error.message?.toLowerCase() ?? "";
-        // Rate limit check FIRST — Supabase says "For security purposes,
-        // you can only request this once every X seconds"
-        if (
+
+        // "user not found" = genuinely no account (rare, Supabase explicit)
+        if (msg.includes("user not found")) {
+          setErrorMsg(
+            "Kein Konto mit dieser E-Mail-Adresse. Bitte Admin kontaktieren."
+          );
+        } else if (
+          // Rate limit — Supabase returns "For security purposes..." OR
+          // "Signups not allowed for otp" (ambiguous: could be rate limit
+          // OR missing user with shouldCreateUser:false — treat as rate limit
+          // to avoid false "Kein Konto" for existing users)
           msg.includes("security purposes") ||
           msg.includes("rate limit") ||
-          msg.includes("too many")
+          msg.includes("too many") ||
+          msg.includes("signups not allowed") ||
+          msg.includes("email rate limit")
         ) {
-          // Parse wait seconds from Supabase message if possible
           const match = error.message?.match(/every\s+(\d+)\s+seconds/i);
           const wait = match ? Math.max(parseInt(match[1], 10), 60) : 60;
           setErrorMsg(
             `Bitte ${wait} Sekunden warten und erneut versuchen.`
           );
           setCooldown(wait);
-        } else if (
-          msg.includes("user not found") ||
-          msg.includes("signups not allowed")
-        ) {
-          setErrorMsg(
-            "Kein Konto mit dieser E-Mail-Adresse. Bitte Admin kontaktieren."
-          );
         } else {
-          setErrorMsg(error.message);
+          // Unknown error — show with retry hint
+          setErrorMsg(
+            `${error.message} — Bitte in 60 Sekunden erneut versuchen.`
+          );
+          setCooldown(60);
         }
       } else {
         setStatus("idle");
@@ -219,7 +225,15 @@ export function LoginForm() {
 
       if (error) {
         setStatus("error");
-        setErrorMsg(error.message);
+        const msg = error.message?.toLowerCase() ?? "";
+        if (msg.includes("user not found")) {
+          setErrorMsg("Kein Konto mit dieser E-Mail-Adresse.");
+        } else {
+          const match = error.message?.match(/every\s+(\d+)\s+seconds/i);
+          const wait = match ? Math.max(parseInt(match[1], 10), 60) : 60;
+          setErrorMsg(`Bitte ${wait} Sekunden warten.`);
+          setCooldown(wait);
+        }
       } else {
         setStatus("idle");
         setCode(["", "", "", "", "", ""]);

--- a/src/web/public/sw.js
+++ b/src/web/public/sw.js
@@ -13,7 +13,7 @@
  * 4. Future: push notification handling (Phase 2)
  */
 
-const CACHE_NAME = "flowsight-v1";
+const CACHE_NAME = "flowsight-v2";
 const OFFLINE_URL = "/ops/offline";
 
 // ── Install ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Root Cause gefunden:** Supabase gibt "Signups not allowed for otp" zurück für BEIDES: nicht existierende User UND rate-limitierte existierende User (Anti-Enumeration-Schutz). Alter Code zeigte "Kein Konto" für beide Fälle.
- **Fix:** Nur noch `"user not found"` (explizit) zeigt "Kein Konto". `"signups not allowed"` → Rate-Limit-Meldung mit Countdown.
- **Logout:** `scope: 'local'` — kein Server-Roundtrip, sofortiges Logout
- **Service Worker:** Cache v1→v2 — zwingt alle Browser, neuen Code zu laden

## Was sich ändert für den Nutzer
- Logout → sofort wieder Login → korrekte Meldung "Bitte X Sekunden warten"
- Keine falsche "Kein Konto" Meldung mehr für existierende Accounts
- Nach Countdown: Code senden funktioniert sofort

## Test plan
- [ ] Einloggen → Abmelden bestätigen → sofort E-Mail eingeben → zeigt Countdown (nicht "Kein Konto")
- [ ] Countdown abwarten → Code senden → Code kommt per E-Mail
- [ ] Falsche E-Mail eingeben → nach 60s Retry → zeigt Countdown (kein irreführendes "Kein Konto")
- [ ] Komplett neue E-Mail (nicht im System) → zeigt Countdown (konservativ, kein Info-Leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)