### PR TITLE
feat: custom OTP — login works unlimited, no Supabase rate limit

### DIFF
--- a/src/web/app/api/ops/auth/send-code/route.ts
+++ b/src/web/app/api/ops/auth/send-code/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceClient } from "@/src/lib/supabase/server";
+
+/**
+ * Custom OTP send — bypasses Supabase's email rate limit entirely.
+ *
+ * Flow:
+ * 1. Generate 6-digit code
+ * 2. Store in otp_codes table
+ * 3. Send via Resend (our email provider, no Supabase limit)
+ *
+ * Rate limit: 1 code per 30 seconds per email (our own, generous limit).
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = await req.json();
+    if (!email || typeof email !== "string") {
+      return NextResponse.json({ error: "missing_email" }, { status: 400 });
+    }
+
+    const normalizedEmail = email.toLowerCase().trim();
+    const supabase = getServiceClient();
+
+    // Check if user exists in Supabase auth (admin API, no rate limit)
+    const { data: linkData, error: linkError } =
+      await supabase.auth.admin.generateLink({
+        type: "magiclink",
+        email: normalizedEmail,
+      });
+
+    if (linkError || !linkData?.properties?.hashed_token) {
+      const msg = linkError?.message?.toLowerCase() ?? "";
+      if (msg.includes("user not found") || msg.includes("not found")) {
+        return NextResponse.json({ error: "not_found" }, { status: 404 });
+      }
+      console.error("[send-code] generateLink error:", linkError?.message);
+      return NextResponse.json({ error: "server_error" }, { status: 500 });
+    }
+
+    // Rate limit: check last code sent for this email
+    const { data: recent } = await supabase
+      .from("otp_codes")
+      .select("created_at")
+      .eq("email", normalizedEmail)
+      .order("created_at", { ascending: false })
+      .limit(1);
+
+    if (recent && recent.length > 0) {
+      const lastSent = new Date(recent[0].created_at).getTime();
+      const elapsed = Date.now() - lastSent;
+      const waitMs = 30_000; // 30 seconds between codes
+      if (elapsed < waitMs) {
+        const waitSec = Math.ceil((waitMs - elapsed) / 1000);
+        return NextResponse.json(
+          { error: "rate_limit", wait: waitSec },
+          { status: 429 },
+        );
+      }
+    }
+
+    // Generate 6-digit code
+    const code = String(Math.floor(100000 + Math.random() * 900000));
+
+    // Clean up old codes for this email
+    await supabase
+      .from("otp_codes")
+      .delete()
+      .eq("email", normalizedEmail);
+
+    // Store new code
+    const { error: insertError } = await supabase
+      .from("otp_codes")
+      .insert({
+        email: normalizedEmail,
+        code,
+        expires_at: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      });
+
+    if (insertError) {
+      console.error("[send-code] insert error:", insertError.message);
+      return NextResponse.json({ error: "server_error" }, { status: 500 });
+    }
+
+    // Send code via Resend (our email service, no Supabase limit)
+    const resendKey = process.env.RESEND_API_KEY;
+    if (!resendKey) {
+      console.error("[send-code] Missing RESEND_API_KEY");
+      return NextResponse.json({ error: "server_error" }, { status: 500 });
+    }
+
+    const emailRes = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${resendKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "Leitsystem <noreply@flowsight.ch>",
+        to: [normalizedEmail],
+        subject: `Ihr Anmeldecode: ${code}`,
+        text: [
+          `Ihr Anmeldecode für das Leitsystem: ${code}`,
+          "",
+          "Der Code ist 10 Minuten gültig.",
+          "",
+          "Falls Sie diese Anmeldung nicht angefordert haben, ignorieren Sie diese E-Mail.",
+        ].join("\n"),
+      }),
+    });
+
+    if (!emailRes.ok) {
+      const body = await emailRes.text().catch(() => "");
+      console.error("[send-code] Resend error:", emailRes.status, body);
+      return NextResponse.json({ error: "email_failed" }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[send-code] unexpected error:", err);
+    return NextResponse.json({ error: "server_error" }, { status: 500 });
+  }
+}

--- a/src/web/app/api/ops/auth/verify-code/route.ts
+++ b/src/web/app/api/ops/auth/verify-code/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceClient } from "@/src/lib/supabase/server";
+
+/**
+ * Custom OTP verification — creates a Supabase session after verifying our own code.
+ *
+ * Flow:
+ * 1. Check code against otp_codes table
+ * 2. If valid: use admin.generateLink to get a session token
+ * 3. Return the hashed_token so the client can create a session via verifyOtp
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const { email, code } = await req.json();
+    if (!email || !code) {
+      return NextResponse.json({ error: "missing_fields" }, { status: 400 });
+    }
+
+    const normalizedEmail = email.toLowerCase().trim();
+    const supabase = getServiceClient();
+
+    // Look up valid code
+    const { data: otpRecords } = await supabase
+      .from("otp_codes")
+      .select("id, code, expires_at, used")
+      .eq("email", normalizedEmail)
+      .eq("code", code)
+      .eq("used", false)
+      .limit(1);
+
+    if (!otpRecords || otpRecords.length === 0) {
+      return NextResponse.json(
+        { error: "invalid_code" },
+        { status: 401 },
+      );
+    }
+
+    const record = otpRecords[0];
+
+    // Check expiry
+    if (new Date(record.expires_at) < new Date()) {
+      return NextResponse.json(
+        { error: "expired_code" },
+        { status: 401 },
+      );
+    }
+
+    // Mark code as used
+    await supabase
+      .from("otp_codes")
+      .update({ used: true })
+      .eq("id", record.id);
+
+    // Generate a magic link via admin API (no rate limit)
+    // This gives us a hashed_token that the client can use to create a session
+    const { data: linkData, error: linkError } =
+      await supabase.auth.admin.generateLink({
+        type: "magiclink",
+        email: normalizedEmail,
+      });
+
+    if (linkError || !linkData?.properties?.hashed_token) {
+      console.error("[verify-code] generateLink error:", linkError?.message);
+      return NextResponse.json({ error: "session_error" }, { status: 500 });
+    }
+
+    // Return the token hash — client uses verifyOtp to create session
+    return NextResponse.json({
+      ok: true,
+      token_hash: linkData.properties.hashed_token,
+    });
+  } catch (err) {
+    console.error("[verify-code] unexpected error:", err);
+    return NextResponse.json({ error: "server_error" }, { status: 500 });
+  }
+}

--- a/src/web/app/ops/(auth)/login/LoginForm.tsx
+++ b/src/web/app/ops/(auth)/login/LoginForm.tsx
@@ -6,7 +6,7 @@ import { getBrowserClient } from "@/src/lib/supabase/browser";
 
 const ERROR_MESSAGES: Record<string, string> = {
   invalid_link:
-    "Ung\u00fcltiger oder abgelaufener Link. Bitte erneut anfordern.",
+    "Ungültiger oder abgelaufener Link. Bitte erneut anfordern.",
   config: "Auth ist nicht konfiguriert. Bitte Admin kontaktieren.",
 };
 
@@ -62,61 +62,42 @@ export function LoginForm() {
     }
   }, [step]);
 
-  // ── Step 1: Send OTP code ──────────────────────────────────────────
+  // ── Step 1: Send OTP code via our own API (bypasses Supabase rate limit) ──
   async function handleSendCode(e: React.FormEvent) {
     e.preventDefault();
     setStatus("sending");
     setErrorMsg("");
 
     try {
-      const supabase = getBrowserClient();
-
-      // No emailRedirectTo → Supabase sends 6-digit OTP code, not a magic link
-      const { error } = await supabase.auth.signInWithOtp({
-        email,
-        options: {
-          shouldCreateUser: false,
-        },
+      const res = await fetch("/api/ops/auth/send-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
       });
 
-      if (error) {
-        setStatus("error");
-        const msg = error.message?.toLowerCase() ?? "";
+      const data = await res.json();
 
-        // "user not found" = genuinely no account (rare, Supabase explicit)
-        if (msg.includes("user not found")) {
+      if (!res.ok) {
+        setStatus("error");
+        if (data.error === "not_found") {
           setErrorMsg(
             "Kein Konto mit dieser E-Mail-Adresse. Bitte Admin kontaktieren."
           );
-        } else if (
-          // Rate limit — Supabase returns "For security purposes..." OR
-          // "Signups not allowed for otp" (ambiguous: could be rate limit
-          // OR missing user with shouldCreateUser:false — treat as rate limit
-          // to avoid false "Kein Konto" for existing users)
-          msg.includes("security purposes") ||
-          msg.includes("rate limit") ||
-          msg.includes("too many") ||
-          msg.includes("signups not allowed") ||
-          msg.includes("email rate limit")
-        ) {
-          const match = error.message?.match(/every\s+(\d+)\s+seconds/i);
-          const wait = match ? Math.max(parseInt(match[1], 10), 60) : 60;
-          setErrorMsg(
-            `Bitte ${wait} Sekunden warten und erneut versuchen.`
-          );
+        } else if (data.error === "rate_limit") {
+          const wait = data.wait ?? 30;
+          setErrorMsg(`Bitte ${wait} Sekunden warten und erneut versuchen.`);
           setCooldown(wait);
+        } else if (data.error === "email_failed") {
+          setErrorMsg("E-Mail konnte nicht gesendet werden. Bitte erneut versuchen.");
         } else {
-          // Unknown error — show with retry hint
-          setErrorMsg(
-            `${error.message} — Bitte in 60 Sekunden erneut versuchen.`
-          );
-          setCooldown(60);
+          setErrorMsg("Ein Fehler ist aufgetreten. Bitte erneut versuchen.");
+          setCooldown(30);
         }
       } else {
         setStatus("idle");
         setStep("code");
         setCode(["", "", "", "", "", ""]);
-        setCooldown(60);
+        setCooldown(30);
       }
     } catch {
       setStatus("error");
@@ -124,36 +105,50 @@ export function LoginForm() {
     }
   }
 
-  // ── Step 2: Verify OTP code ────────────────────────────────────────
+  // ── Step 2: Verify OTP code via our own API + create Supabase session ──
   const handleVerify = useCallback(
     async (fullCode: string) => {
       setStatus("verifying");
       setErrorMsg("");
 
       try {
-        const supabase = getBrowserClient();
-        const { error } = await supabase.auth.verifyOtp({
-          email,
-          token: fullCode,
-          type: "email",
+        // Step 1: Verify code against our DB
+        const res = await fetch("/api/ops/auth/verify-code", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, code: fullCode }),
         });
 
-        if (error) {
+        const data = await res.json();
+
+        if (!res.ok) {
           setStatus("error");
-          if (
-            error.message?.toLowerCase().includes("expired") ||
-            error.message?.toLowerCase().includes("invalid")
-          ) {
-            setErrorMsg(
-              "Code ung\u00fcltig oder abgelaufen. Bitte neuen Code anfordern."
-            );
+          if (data.error === "invalid_code") {
+            setErrorMsg("Code ungültig. Bitte prüfen oder neuen Code anfordern.");
+          } else if (data.error === "expired_code") {
+            setErrorMsg("Code abgelaufen. Bitte neuen Code anfordern.");
           } else {
-            setErrorMsg(error.message);
+            setErrorMsg("Verifizierung fehlgeschlagen. Bitte erneut versuchen.");
           }
-        } else {
-          setStatus("success");
-          router.push(nextPath);
+          return;
         }
+
+        // Step 2: Create Supabase session using the token hash
+        const supabase = getBrowserClient();
+        const { error: sessionError } = await supabase.auth.verifyOtp({
+          token_hash: data.token_hash,
+          type: "magiclink",
+        });
+
+        if (sessionError) {
+          setStatus("error");
+          setErrorMsg("Sitzung konnte nicht erstellt werden. Bitte erneut anmelden.");
+          console.error("[LoginForm] verifyOtp session error:", sessionError.message);
+          return;
+        }
+
+        setStatus("success");
+        router.push(nextPath);
       } catch {
         setStatus("error");
         setErrorMsg("Netzwerkfehler. Bitte erneut versuchen.");
@@ -217,27 +212,26 @@ export function LoginForm() {
     setErrorMsg("");
 
     try {
-      const supabase = getBrowserClient();
-      const { error } = await supabase.auth.signInWithOtp({
-        email,
-        options: { shouldCreateUser: false },
+      const res = await fetch("/api/ops/auth/send-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
       });
 
-      if (error) {
+      const data = await res.json();
+
+      if (!res.ok) {
         setStatus("error");
-        const msg = error.message?.toLowerCase() ?? "";
-        if (msg.includes("user not found")) {
-          setErrorMsg("Kein Konto mit dieser E-Mail-Adresse.");
+        if (data.error === "rate_limit") {
+          setErrorMsg(`Bitte ${data.wait ?? 30} Sekunden warten.`);
+          setCooldown(data.wait ?? 30);
         } else {
-          const match = error.message?.match(/every\s+(\d+)\s+seconds/i);
-          const wait = match ? Math.max(parseInt(match[1], 10), 60) : 60;
-          setErrorMsg(`Bitte ${wait} Sekunden warten.`);
-          setCooldown(wait);
+          setErrorMsg("Code konnte nicht gesendet werden.");
         }
       } else {
         setStatus("idle");
         setCode(["", "", "", "", "", ""]);
-        setCooldown(60);
+        setCooldown(30);
         codeRefs.current[0]?.focus();
       }
     } catch {
@@ -270,7 +264,7 @@ export function LoginForm() {
           </p>
           <p className="text-white text-sm font-medium mt-0.5">{email}</p>
           <p className="text-slate-400 text-xs mt-1">
-            gesendet. Bitte pr\u00fcfen Sie Ihr Postfach.
+            gesendet. Bitte prüfen Sie Ihr Postfach.
           </p>
         </div>
 
@@ -311,7 +305,7 @@ export function LoginForm() {
         {/* Verifying indicator */}
         {status === "verifying" && (
           <p className="text-slate-400 text-sm text-center">
-            Wird gepr\u00fcft&hellip;
+            Wird geprüft&hellip;
           </p>
         )}
 

--- a/supabase/migrations/20260317200000_otp_codes.sql
+++ b/supabase/migrations/20260317200000_otp_codes.sql
@@ -1,0 +1,16 @@
+-- Custom OTP codes table — bypasses Supabase email rate limits.
+-- Codes are verified server-side, then a Supabase session is created via admin API.
+CREATE TABLE IF NOT EXISTS otp_codes (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  email text NOT NULL,
+  code text NOT NULL,
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '10 minutes'),
+  used boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index for fast lookup
+CREATE INDEX idx_otp_codes_email_code ON otp_codes (email, code) WHERE NOT used;
+
+-- Auto-cleanup: delete codes older than 1 hour (cron or manual)
+-- For now, we clean up in the API route on each request.


### PR DESCRIPTION
## Summary
Supabase Free Plan limitiert OTP auf 3 E-Mails/Stunde pro Adresse. Nach Logout+Login-Tests wird man bis zu 1 Stunde ausgesperrt.

**Neues eigenes OTP-System:**
- Code-Versand über Resend (unser E-Mail-Provider) statt Supabase
- Code-Verifikation über eigene DB-Tabelle `otp_codes`
- Session-Erstellung über Supabase Admin API (`generateLink`) — kein Rate Limit
- Unser Limit: 1 Code pro 30 Sekunden, kein Stundenlimit
- 10 Minuten Code-Gültigkeit

## Test plan
- [ ] Abmelden → sofort E-Mail eingeben → Code senden → Code kommt per E-Mail
- [ ] Code eingeben → Anmeldung erfolgreich → Dashboard
- [ ] Sofort wieder abmelden → wieder E-Mail → nach 30s neuer Code
- [ ] 5x hintereinander Login/Logout → funktioniert jedes Mal
- [ ] Falsche E-Mail → "Kein Konto" Meldung
- [ ] Falscher Code → "Code ungültig" Meldung
- [ ] Code nach 10 Min → "Code abgelaufen" Meldung

🤖 Generated with [Claude Code](https://claude.com/claude-code)