### PR TITLE
fix: high-end OTP email + professional sidebar footer

### DIFF
--- a/src/web/app/api/ops/auth/send-code/route.ts
+++ b/src/web/app/api/ops/auth/send-code/route.ts
@@ -88,6 +88,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "server_error" }, { status: 500 });
     }
 
+    // Format code with spaces for readability: "210 798"
+    const codeFormatted = `${code.slice(0, 3)} ${code.slice(3)}`;
+
     const emailRes = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {
@@ -97,14 +100,55 @@ export async function POST(req: NextRequest) {
       body: JSON.stringify({
         from: "Leitsystem <noreply@flowsight.ch>",
         to: [normalizedEmail],
-        subject: `Ihr Anmeldecode: ${code}`,
+        subject: `${codeFormatted} — Ihr Anmeldecode`,
         text: [
-          `Ihr Anmeldecode für das Leitsystem: ${code}`,
+          `Ihr Anmeldecode: ${codeFormatted}`,
           "",
+          "Geben Sie diesen Code im Leitsystem ein, um sich anzumelden.",
           "Der Code ist 10 Minuten gültig.",
           "",
-          "Falls Sie diese Anmeldung nicht angefordert haben, ignorieren Sie diese E-Mail.",
+          "Falls Sie diese Anmeldung nicht angefordert haben, können Sie diese E-Mail ignorieren.",
         ].join("\n"),
+        html: `<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background-color:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f1f5f9;padding:40px 20px;">
+    <tr><td align="center">
+      <table width="100%" cellpadding="0" cellspacing="0" style="max-width:440px;background-color:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+        <!-- Header -->
+        <tr><td style="background-color:#1a2744;padding:28px 32px;text-align:center;">
+          <div style="width:44px;height:44px;border-radius:12px;background:rgba(212,168,67,0.2);border:1px solid rgba(212,168,67,0.3);display:inline-flex;align-items:center;justify-content:center;margin-bottom:12px;">
+            <span style="color:#d4a843;font-size:20px;font-weight:700;">&#9670;</span>
+          </div>
+          <p style="margin:0;color:#94a3b8;font-size:13px;letter-spacing:0.5px;">ANMELDECODE</p>
+        </td></tr>
+        <!-- Code -->
+        <tr><td style="padding:36px 32px 20px;text-align:center;">
+          <div style="font-size:36px;font-weight:700;letter-spacing:8px;color:#1a2744;font-family:'SF Mono',SFMono-Regular,Consolas,'Liberation Mono',Menlo,monospace;padding:16px 0;border-bottom:2px solid #e2e8f0;">
+            ${codeFormatted}
+          </div>
+        </td></tr>
+        <!-- Text -->
+        <tr><td style="padding:16px 32px 32px;text-align:center;">
+          <p style="margin:0 0 8px;color:#475569;font-size:14px;line-height:1.6;">
+            Geben Sie diesen Code im Leitsystem ein.
+          </p>
+          <p style="margin:0;color:#94a3b8;font-size:12px;">
+            Gültig für 10 Minuten.
+          </p>
+        </td></tr>
+        <!-- Footer -->
+        <tr><td style="padding:20px 32px;background-color:#f8fafc;border-top:1px solid #e2e8f0;text-align:center;">
+          <p style="margin:0;color:#94a3b8;font-size:11px;line-height:1.5;">
+            Falls Sie diese Anmeldung nicht angefordert haben,<br>können Sie diese E-Mail ignorieren.
+          </p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`,
       }),
     });
 

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -156,20 +156,49 @@ export function OpsShell({
   // ── Footer ──────────────────────────────────────────────────────────
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
 
+  // User initials for avatar
+  const userInitials = userEmail
+    .split("@")[0]
+    .split(".")
+    .map((p) => p[0]?.toUpperCase() ?? "")
+    .join("")
+    .slice(0, 2);
+
   const footer = (
     <div className="px-4 py-4 border-t border-gray-800">
-      <p className="text-[11px] text-gray-500 truncate mb-2">{userEmail}</p>
+      {/* User info row */}
+      <div className="flex items-center gap-3 mb-3">
+        <div
+          className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 text-[11px] font-semibold"
+          style={{ backgroundColor: `${color}33`, color }}
+        >
+          {userInitials}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-[12px] text-gray-300 font-medium truncate leading-tight">
+            {userEmail.split("@")[0].replace(".", " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+          </p>
+          <p className="text-[10px] text-gray-600 truncate leading-tight mt-0.5">
+            {userEmail}
+          </p>
+        </div>
+      </div>
+
+      {/* Logout */}
       {showLogoutConfirm ? (
-        <div className="space-y-2">
-          <p className="text-[11px] text-amber-400">
+        <div className="bg-gray-900 rounded-lg p-3 space-y-2">
+          <p className="text-[11px] text-amber-400/90">
             Nach Abmeldung ist ein neuer E-Mail-Code nötig.
           </p>
-          <div className="flex gap-2">
+          <div className="flex gap-3">
             <form action="/api/ops/logout" method="POST">
               <button
                 type="submit"
-                className="text-[11px] text-red-400 hover:text-red-300 transition-colors font-medium"
+                className="flex items-center gap-1.5 text-[11px] text-red-400 hover:text-red-300 transition-colors font-medium"
               >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5.636 5.636a9 9 0 1 0 12.728 0M12 3v9" />
+                </svg>
                 Ja, abmelden
               </button>
             </form>
@@ -186,8 +215,11 @@ export function OpsShell({
         <button
           type="button"
           onClick={() => setShowLogoutConfirm(true)}
-          className="text-[11px] text-gray-600 hover:text-gray-400 transition-colors"
+          className="flex items-center gap-2 w-full px-2 py-1.5 rounded-lg text-[11px] text-gray-500 hover:text-gray-300 hover:bg-gray-800/50 transition-colors"
         >
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5.636 5.636a9 9 0 1 0 12.728 0M12 3v9" />
+          </svg>
           Abmelden
         </button>
       )}


### PR DESCRIPTION
## Summary
- **OTP E-Mail redesigned**: HTML-Template mit Navy-Header, Gold-Icon, grossem Code in Monospace, clean Footer. Betreff zeigt Code zuerst ("210 798 — Ihr Anmeldecode") für schnelles Scannen.
- **Sidebar Footer redesigned**: User-Avatar mit Initialen (brand-farbig), Name aus E-Mail abgeleitet, Power-Icon bei Abmelden, Logout-Bestätigung in eigenem Card.

## Test plan
- [ ] Login → E-Mail kommt als HTML mit gebrandetem Design
- [ ] Betreff: "XXX XXX — Ihr Anmeldecode"
- [ ] Code ist gross und gut lesbar
- [ ] Sidebar: Avatar-Kreis mit Initialen sichtbar
- [ ] Name (z.B. "Gunnar Wende") über E-Mail-Adresse
- [ ] Power-Icon neben "Abmelden"
- [ ] Logout-Bestätigung in dunklem Card

🤖 Generated with [Claude Code](https://claude.com/claude-code)