### PR TITLE
fix: server-side session cookies + spam-safe sender domain

### DIFF
--- a/src/web/app/api/ops/auth/send-code/route.ts
+++ b/src/web/app/api/ops/auth/send-code/route.ts
@@ -98,7 +98,7 @@ export async function POST(req: NextRequest) {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        from: "Leitsystem <noreply@flowsight.ch>",
+        from: process.env.MAIL_FROM ?? "Leitsystem <noreply@send.flowsight.ch>",
         to: [normalizedEmail],
         subject: `${codeFormatted} — Ihr Anmeldecode`,
         text: [

--- a/src/web/app/api/ops/auth/verify-code/route.ts
+++ b/src/web/app/api/ops/auth/verify-code/route.ts
@@ -1,13 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
 import { getServiceClient } from "@/src/lib/supabase/server";
 
 /**
- * Custom OTP verification — creates a Supabase session after verifying our own code.
+ * Custom OTP verification — creates a Supabase session server-side.
  *
  * Flow:
  * 1. Check code against otp_codes table
- * 2. If valid: use admin.generateLink to get a session token
- * 3. Return the hashed_token so the client can create a session via verifyOtp
+ * 2. If valid: use admin.generateLink to get a magic link token
+ * 3. Verify the token via a response-bound auth client (cookies on response)
+ * 4. Return response with session cookies — client just redirects to dashboard
  */
 export async function POST(req: NextRequest) {
   try {
@@ -52,7 +54,6 @@ export async function POST(req: NextRequest) {
       .eq("id", record.id);
 
     // Generate a magic link via admin API (no rate limit)
-    // This gives us a hashed_token that the client can use to create a session
     const { data: linkData, error: linkError } =
       await supabase.auth.admin.generateLink({
         type: "magiclink",
@@ -64,11 +65,44 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "session_error" }, { status: 500 });
     }
 
-    // Return the token hash — client uses verifyOtp to create session
-    return NextResponse.json({
-      ok: true,
-      token_hash: linkData.properties.hashed_token,
+    // ── Create response-bound auth client ─────────────────────────────
+    // Must write cookies directly to the response object (not via
+    // next/headers cookies() which doesn't reliably carry over).
+    const response = NextResponse.json({ ok: true });
+
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY;
+
+    if (!url || !key) {
+      return NextResponse.json({ error: "session_error" }, { status: 500 });
+    }
+
+    const authClient = createServerClient(url, key, {
+      cookies: {
+        getAll() {
+          return req.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
+        },
+      },
     });
+
+    // Verify the token — this creates the session and triggers setAll
+    const { error: verifyError } = await authClient.auth.verifyOtp({
+      token_hash: linkData.properties.hashed_token,
+      type: "magiclink",
+    });
+
+    if (verifyError) {
+      console.error("[verify-code] verifyOtp error:", verifyError.message);
+      return NextResponse.json({ error: "session_error" }, { status: 500 });
+    }
+
+    // Response carries session cookies — client just redirects to dashboard.
+    return response;
   } catch (err) {
     console.error("[verify-code] unexpected error:", err);
     return NextResponse.json({ error: "server_error" }, { status: 500 });


### PR DESCRIPTION
## Summary
- **Bug 1 (Spam):** OTP email sent from `noreply@flowsight.ch` (not a verified Resend domain) → landed in spam. Now uses `noreply@send.flowsight.ch` (verified).
- **Bug 2 (Login-Loop):** `verify-code` route returned `token_hash` but never set session cookies on the response → browser showed green success then looped back to login. Now creates a response-bound Supabase auth client that writes session cookies directly onto the `NextResponse` object.

## Test plan
- [ ] Login with techniker email → code arrives in inbox (not spam)
- [ ] Enter code → redirects to Leitstand (no loop back to login)
- [ ] Login with admin email → same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)