### PR TITLE
fix: re-login after logout + high-end login UI

### DIFF
--- a/src/web/app/api/ops/auth/verify-code/route.ts
+++ b/src/web/app/api/ops/auth/verify-code/route.ts
@@ -80,7 +80,9 @@ export async function POST(req: NextRequest) {
     const authClient = createServerClient(url, key, {
       cookies: {
         getAll() {
-          return req.cookies.getAll();
+          // Return empty — we're creating a fresh session, stale cookies
+          // from a previous login would cause verifyOtp to fail.
+          return [];
         },
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value, options }) => {

--- a/src/web/app/api/ops/logout/route.ts
+++ b/src/web/app/api/ops/logout/route.ts
@@ -1,13 +1,38 @@
-import { NextResponse } from "next/server";
-import { getAuthClient } from "@/src/lib/supabase/server-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
 
-export async function POST() {
-  const supabase = await getAuthClient();
-  // scope: 'local' — only clears this session's cookies, doesn't call
-  // Supabase auth server. Faster logout, no side effects on rate limits.
-  await supabase.auth.signOut({ scope: "local" });
+export async function POST(req: NextRequest) {
+  const appUrl =
+    process.env.NEXT_PUBLIC_APP_URL ??
+    process.env.APP_URL ??
+    "http://localhost:3000";
 
-  return NextResponse.redirect(new URL("/ops/login", process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL ?? "http://localhost:3000"), {
-    status: 303, // POST → GET redirect
+  const redirectResponse = NextResponse.redirect(new URL("/ops/login", appUrl), {
+    status: 303,
   });
+
+  const url =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  const key =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY;
+
+  if (url && key) {
+    const supabase = createServerClient(url, key, {
+      cookies: {
+        getAll() {
+          return req.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          // Write cookie deletions directly onto the redirect response
+          cookiesToSet.forEach(({ name, value, options }) => {
+            redirectResponse.cookies.set(name, value, options);
+          });
+        },
+      },
+    });
+
+    await supabase.auth.signOut({ scope: "local" });
+  }
+
+  return redirectResponse;
 }

--- a/src/web/app/ops/(auth)/login/LoginForm.tsx
+++ b/src/web/app/ops/(auth)/login/LoginForm.tsx
@@ -111,7 +111,6 @@ export function LoginForm() {
       setErrorMsg("");
 
       try {
-        // Step 1: Verify code against our DB
         const res = await fetch("/api/ops/auth/verify-code", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -123,11 +122,11 @@ export function LoginForm() {
         if (!res.ok) {
           setStatus("error");
           if (data.error === "invalid_code") {
-            setErrorMsg("Code ungültig. Bitte prüfen oder neuen Code anfordern.");
+            setErrorMsg("Code ungültig oder bereits verwendet.");
           } else if (data.error === "expired_code") {
             setErrorMsg("Code abgelaufen. Bitte neuen Code anfordern.");
           } else {
-            setErrorMsg("Verifizierung fehlgeschlagen. Bitte erneut versuchen.");
+            setErrorMsg("Anmeldung fehlgeschlagen. Bitte neuen Code anfordern.");
           }
           return;
         }
@@ -146,21 +145,17 @@ export function LoginForm() {
 
   // ── Code input handlers ────────────────────────────────────────────
   function handleCodeChange(index: number, value: string) {
-    // Only allow digits
     const digit = value.replace(/\D/g, "").slice(-1);
     const next = [...code];
     next[index] = digit;
     setCode(next);
 
-    // Clear error on input
     if (status === "error") setStatus("idle");
 
-    // Auto-advance to next field
     if (digit && index < 5) {
       codeRefs.current[index + 1]?.focus();
     }
 
-    // Auto-submit when all 6 digits entered
     if (digit && index === 5) {
       const fullCode = next.join("");
       if (fullCode.length === 6) {
@@ -230,12 +225,25 @@ export function LoginForm() {
   // ── Success state ──────────────────────────────────────────────────
   if (status === "success") {
     return (
-      <div className="bg-emerald-900/30 border border-emerald-700 rounded-lg p-4 text-center">
-        <p className="text-emerald-300 text-sm font-medium">
-          Anmeldung erfolgreich
-        </p>
-        <p className="text-emerald-400/70 text-sm mt-1">
-          Sie werden weitergeleitet&hellip;
+      <div className="text-center py-6">
+        <div className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-emerald-500/10 border border-emerald-500/20 mb-3">
+          <svg
+            className="w-5 h-5 text-emerald-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4.5 12.75l6 6 9-13.5"
+            />
+          </svg>
+        </div>
+        <p className="text-white text-sm font-medium">Anmeldung erfolgreich</p>
+        <p className="text-slate-500 text-xs mt-1">
+          Weiterleitung&hellip;
         </p>
       </div>
     );
@@ -245,26 +253,36 @@ export function LoginForm() {
   if (step === "code") {
     return (
       <div className="space-y-5">
-        <div>
-          <p className="text-slate-300 text-sm">
-            Wir haben einen 6-stelligen Code an
-          </p>
+        {/* Email confirmation */}
+        <div className="text-center">
+          <div className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-slate-800 border border-slate-700 mb-3">
+            <svg
+              className="w-5 h-5 text-slate-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+              />
+            </svg>
+          </div>
+          <p className="text-slate-400 text-sm">Code gesendet an</p>
           <p className="text-white text-sm font-medium mt-0.5">{email}</p>
-          <p className="text-slate-400 text-xs mt-1">
-            gesendet. Bitte prüfen Sie Ihr Postfach.
-          </p>
         </div>
 
         {/* 6-digit code input */}
         <div>
-          <label className="block text-sm font-medium text-slate-300 mb-2">
-            Code eingeben
-          </label>
-          <div className="flex gap-2 justify-center">
+          <div className="flex gap-2.5 justify-center">
             {code.map((digit, i) => (
               <input
                 key={i}
-                ref={(el) => { codeRefs.current[i] = el; }}
+                ref={(el) => {
+                  codeRefs.current[i] = el;
+                }}
                 type="text"
                 inputMode="numeric"
                 autoComplete="one-time-code"
@@ -274,11 +292,13 @@ export function LoginForm() {
                 onKeyDown={(e) => handleCodeKeyDown(i, e)}
                 onPaste={i === 0 ? handleCodePaste : undefined}
                 disabled={status === "verifying"}
-                className={`w-11 h-12 text-center text-lg font-bold rounded-lg border bg-slate-900 text-white focus:outline-none focus:ring-2 transition-colors ${
+                className={`w-11 h-13 text-center text-lg font-semibold rounded-xl border-2 bg-slate-950 text-white transition-all duration-150 focus:outline-none focus:ring-0 ${
                   status === "error"
-                    ? "border-red-500 focus:ring-red-500/30"
-                    : "border-slate-700 focus:border-blue-500 focus:ring-blue-500/30"
-                } disabled:opacity-50`}
+                    ? "border-red-500/60"
+                    : digit
+                      ? "border-slate-600"
+                      : "border-slate-800 focus:border-slate-500"
+                } disabled:opacity-40`}
               />
             ))}
           </div>
@@ -286,14 +306,30 @@ export function LoginForm() {
 
         {/* Error */}
         {status === "error" && errorMsg && (
-          <p className="text-red-400 text-sm text-center">{errorMsg}</p>
+          <div className="flex items-start gap-2 bg-red-500/5 border border-red-500/10 rounded-lg px-3 py-2.5">
+            <svg
+              className="w-4 h-4 text-red-400 mt-0.5 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+              />
+            </svg>
+            <p className="text-red-400 text-sm">{errorMsg}</p>
+          </div>
         )}
 
         {/* Verifying indicator */}
         {status === "verifying" && (
-          <p className="text-slate-400 text-sm text-center">
-            Wird geprüft&hellip;
-          </p>
+          <div className="flex items-center justify-center gap-2 py-1">
+            <div className="w-3.5 h-3.5 border-2 border-slate-600 border-t-white rounded-full animate-spin" />
+            <p className="text-slate-400 text-sm">Wird geprüft&hellip;</p>
+          </div>
         )}
 
         {/* Resend + back */}
@@ -306,7 +342,7 @@ export function LoginForm() {
               setErrorMsg("");
               setCode(["", "", "", "", "", ""]);
             }}
-            className="text-xs text-slate-500 hover:text-slate-300 transition-colors"
+            className="text-xs text-slate-600 hover:text-slate-400 transition-colors"
           >
             &larr; Andere E-Mail
           </button>
@@ -314,7 +350,7 @@ export function LoginForm() {
             type="button"
             onClick={handleResend}
             disabled={cooldown > 0 || status === "sending"}
-            className="text-xs text-blue-400 hover:text-blue-300 disabled:text-slate-600 disabled:cursor-not-allowed transition-colors"
+            className="text-xs text-slate-400 hover:text-white disabled:text-slate-700 disabled:cursor-not-allowed transition-colors"
           >
             {status === "sending"
               ? "Sende\u2026"
@@ -333,9 +369,9 @@ export function LoginForm() {
       <div>
         <label
           htmlFor="email"
-          className="block text-sm font-medium text-slate-300 mb-1"
+          className="block text-xs font-medium text-slate-500 mb-1.5 uppercase tracking-wider"
         >
-          E-Mail
+          E-Mail-Adresse
         </label>
         <input
           id="email"
@@ -347,24 +383,44 @@ export function LoginForm() {
             if (status === "error") setStatus("idle");
           }}
           placeholder="name@firma.ch"
-          className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-white placeholder:text-slate-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          className="w-full rounded-xl border-2 border-slate-800 bg-slate-950 px-3.5 py-2.5 text-white text-sm placeholder:text-slate-600 focus:border-slate-600 focus:outline-none focus:ring-0 transition-colors"
         />
       </div>
 
-      {(status === "error" || (urlError && status === "idle")) && (
-        <p className="text-red-400 text-sm">{errorMsg}</p>
+      {(status === "error" || (urlError && status === "idle")) && errorMsg && (
+        <div className="flex items-start gap-2 bg-red-500/5 border border-red-500/10 rounded-lg px-3 py-2.5">
+          <svg
+            className="w-4 h-4 text-red-400 mt-0.5 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+            />
+          </svg>
+          <p className="text-red-400 text-sm">{errorMsg}</p>
+        </div>
       )}
 
       <button
         type="submit"
         disabled={status === "sending" || cooldown > 0}
-        className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        className="w-full rounded-xl bg-white px-4 py-2.5 text-sm font-medium text-slate-950 hover:bg-slate-200 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150"
       >
-        {status === "sending"
-          ? "Code wird gesendet\u2026"
-          : cooldown > 0
-            ? `Neuer Versuch in ${cooldown}s`
-            : "Code senden"}
+        {status === "sending" ? (
+          <span className="inline-flex items-center gap-2">
+            <span className="w-3.5 h-3.5 border-2 border-slate-400 border-t-slate-900 rounded-full animate-spin" />
+            Code wird gesendet
+          </span>
+        ) : cooldown > 0 ? (
+          `Neuer Versuch in ${cooldown}s`
+        ) : (
+          "Anmeldecode senden"
+        )}
       </button>
     </form>
   );

--- a/src/web/app/ops/(auth)/login/page.tsx
+++ b/src/web/app/ops/(auth)/login/page.tsx
@@ -5,21 +5,51 @@ export default function OpsLoginPage() {
   return (
     <div className="min-h-screen bg-slate-950 flex items-center justify-center px-4">
       <div className="w-full max-w-sm">
-        <h1 className="text-2xl font-bold text-white mb-2">Zugang zum Leitstand</h1>
-        <p className="text-slate-400 text-sm mb-8">
-          Anmelden per E-Mail-Code
-        </p>
+        {/* ── Logo / Brand Mark ─────────────────────────────── */}
+        <div className="flex justify-center mb-8">
+          <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-slate-700 to-slate-800 border border-slate-700/50 flex items-center justify-center shadow-lg shadow-slate-900/50">
+            <svg
+              className="w-6 h-6 text-white"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+              />
+            </svg>
+          </div>
+        </div>
 
-        <Suspense
-          fallback={
-            <div className="text-slate-500 text-sm">Laden&hellip;</div>
-          }
-        >
-          <LoginForm />
-        </Suspense>
+        {/* ── Heading ───────────────────────────────────────── */}
+        <div className="text-center mb-8">
+          <h1 className="text-xl font-semibold text-white tracking-tight">
+            Leitsystem
+          </h1>
+          <p className="text-slate-500 text-sm mt-1">
+            Anmeldung per E-Mail-Code
+          </p>
+        </div>
 
-        <p className="text-slate-600 text-xs mt-8 text-center">
-          Nur autorisierte Benutzer. Kein Konto? Admin kontaktieren.
+        {/* ── Card ──────────────────────────────────────────── */}
+        <div className="bg-slate-900/50 border border-slate-800 rounded-2xl p-6 shadow-xl shadow-slate-950/50 backdrop-blur-sm">
+          <Suspense
+            fallback={
+              <div className="text-slate-500 text-sm text-center py-4">
+                Laden&hellip;
+              </div>
+            }
+          >
+            <LoginForm />
+          </Suspense>
+        </div>
+
+        {/* ── Footer ────────────────────────────────────────── */}
+        <p className="text-slate-700 text-xs mt-6 text-center">
+          Nur autorisierte Nutzer. Kein Zugang? Admin kontaktieren.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **Bug (Re-Login):** After logout, stale Supabase session cookies remained in the browser (logout route used `cookies()` from `next/headers` which doesn't write deletions to `NextResponse`). On re-login, `verify-code` read these stale cookies → `verifyOtp` conflict → "Sitzung konnte nicht erstellt werden".
- **Fix 1:** `verify-code` `getAll()` now returns `[]` — fresh session creation, no stale cookie interference
- **Fix 2:** `logout` route now uses response-bound auth client (writes cookie deletions directly onto redirect response)
- **Login Redesign:** High-end card layout with shield icon, refined typography, spinner loading states, proper error styling with icons, subtle glassmorphism card

## Test plan
- [ ] Login → works (first time)
- [ ] Logout → login again → works (no "Sitzung konnte nicht erstellt werden")
- [ ] Repeat 3x rapid logout/login → stable
- [ ] Wrong code → proper error message in styled box
- [ ] Visual: login page looks professional/high-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)