### PR TITLE
fix: PWA icon — gold L initial, proper maskable

### DIFF
--- a/src/web/app/api/ops/pwa/icon/route.tsx
+++ b/src/web/app/api/ops/pwa/icon/route.tsx
@@ -1,9 +1,9 @@
 import { ImageResponse } from "next/og";
 
 /**
- * Dynamic PWA icon — navy background + gold circle.
+ * Dynamic PWA icon — navy background + gold "L" initial + subtle gold accent dot.
  * Sizes: ?size=192 | ?size=512 (default)
- * Used by manifest.json and apple-touch-icon.
+ * ?maskable=1 → full-bleed version for maskable icon (no border radius, extra padding)
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -11,8 +11,14 @@ export async function GET(request: Request) {
     Math.max(parseInt(searchParams.get("size") || "512", 10), 48),
     1024
   );
-  const radius = Math.round(size * 0.22);
-  const circleSize = Math.round(size * 0.44);
+  const isMaskable = searchParams.get("maskable") === "1";
+
+  // Maskable icons: content must fit within the inner 80% "safe zone"
+  // Regular icons: rounded corners, content can use more space
+  const radius = isMaskable ? 0 : Math.round(size * 0.22);
+  const fontSize = Math.round(size * (isMaskable ? 0.32 : 0.40));
+  const dotSize = Math.round(size * 0.07);
+  const dotOffset = Math.round(size * (isMaskable ? 0.33 : 0.36));
 
   return new ImageResponse(
     (
@@ -23,16 +29,35 @@ export async function GET(request: Request) {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          backgroundColor: "#1a2744",
+          backgroundColor: "#0f1d32",
           borderRadius: radius,
+          position: "relative",
         }}
       >
+        {/* Letter "L" */}
+        <span
+          style={{
+            fontSize,
+            fontWeight: 700,
+            color: "#d4a843",
+            fontFamily: "system-ui, sans-serif",
+            letterSpacing: "-0.02em",
+            lineHeight: 1,
+          }}
+        >
+          L
+        </span>
+        {/* Subtle gold dot — bottom right of the letter */}
         <div
           style={{
-            width: circleSize,
-            height: circleSize,
+            position: "absolute",
+            right: dotOffset,
+            bottom: dotOffset,
+            width: dotSize,
+            height: dotSize,
             borderRadius: "50%",
             backgroundColor: "#d4a843",
+            opacity: 0.6,
           }}
         />
       </div>

--- a/src/web/app/api/ops/pwa/manifest/route.ts
+++ b/src/web/app/api/ops/pwa/manifest/route.ts
@@ -39,22 +39,30 @@ export async function GET() {
     scope: "/ops/",
     display: "standalone" as const,
     display_override: ["standalone"],
-    background_color: "#020617",
-    theme_color: "#020617",
+    background_color: "#0f1d32",
+    theme_color: "#0f1d32",
     orientation: "portrait-primary" as const,
     icons: [
       {
         src: "/api/ops/pwa/icon?size=192",
         sizes: "192x192",
         type: "image/png",
+        purpose: "any",
       },
       {
         src: "/api/ops/pwa/icon?size=512",
         sizes: "512x512",
         type: "image/png",
+        purpose: "any",
       },
       {
-        src: "/api/ops/pwa/icon?size=512",
+        src: "/api/ops/pwa/icon?size=192&maskable=1",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "maskable",
+      },
+      {
+        src: "/api/ops/pwa/icon?size=512&maskable=1",
         sizes: "512x512",
         type: "image/png",
         purpose: "maskable",


### PR DESCRIPTION
## Summary
- **Bug 11:** Gold circle was 44% of icon size — way too large on homescreen
- **New icon design:**
  - Navy background (#0f1d32) with gold "L" initial (Leitsystem)
  - Subtle small gold accent dot (7% size, 60% opacity) bottom-right
  - Clean, professional look at any size
- **Maskable icons:** Separate endpoint (`?maskable=1`) with no border radius and content within 80% safe zone — reduces browser badge overlay on Android/iOS
- **Icon purpose split:** `any` for regular display, `maskable` for adaptive icons

## Test plan
- [ ] Uninstall PWA → reinstall → icon shows gold "L" on navy (not huge dot)
- [ ] Mobile: add to homescreen → icon looks clean, minimal/no browser badge
- [ ] Desktop PWA: taskbar icon shows "L" clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)