### PR TITLE
fix: inline signal dot + smaller PWA icon

### DIFF
--- a/src/web/app/api/ops/pwa/icon/route.tsx
+++ b/src/web/app/api/ops/pwa/icon/route.tsx
@@ -17,9 +17,9 @@ export async function GET(request: Request) {
   const isMaskable = searchParams.get("maskable") === "1";
 
   const radius = isMaskable ? 0 : Math.round(size * 0.22);
-  // ~12% of icon area → diameter ≈ 35% of width
-  // Maskable: smaller (28%) to stay within 80% safe zone
-  const dotSize = Math.round(size * (isMaskable ? 0.28 : 0.35));
+  // Small, elegant dot: ~13% diameter (~1.3% area) — minimalist brand mark
+  // Maskable: slightly smaller to stay within 80% safe zone
+  const dotSize = Math.round(size * (isMaskable ? 0.10 : 0.13));
 
   return new ImageResponse(
     (

--- a/src/web/app/ops/(auth)/login/page.tsx
+++ b/src/web/app/ops/(auth)/login/page.tsx
@@ -8,21 +8,22 @@ export default function OpsLoginPage() {
       style={{ backgroundColor: "#faf8f5" }}
     >
       <div className="w-full max-w-[380px]">
-        {/* ── Signal Dot (brand mark) ───────────────────────── */}
-        <div className="flex justify-center mb-5">
-          <div
-            className="w-10 h-10 rounded-full"
-            style={{ backgroundColor: "#c8965a" }}
-          />
-        </div>
-
-        {/* ── Heading ───────────────────────────────────────── */}
+        {/* ── Heading with Signal Dot ─────────────────────── */}
         <div className="text-center mb-8">
           <h1
-            className="text-2xl font-bold tracking-tight"
+            className="text-2xl font-bold tracking-tight inline-flex items-baseline"
             style={{ color: "#1a2744" }}
           >
             Leitsystem
+            <span
+              className="inline-block rounded-full ml-[3px]"
+              style={{
+                width: "8px",
+                height: "8px",
+                backgroundColor: "#c8965a",
+                marginBottom: "1px",
+              }}
+            />
           </h1>
           <p className="text-sm mt-1.5" style={{ color: "#7b8fb3" }}>
             Sicherer Zugang per E-Mail-Code
@@ -48,7 +49,6 @@ export default function OpsLoginPage() {
         {/* ── Swiss trust footer ────────────────────────────── */}
         <div className="mt-8 text-center space-y-2">
           <div className="flex items-center justify-center gap-1.5">
-            {/* Swiss cross */}
             <svg
               width="14"
               height="14"
@@ -61,7 +61,7 @@ export default function OpsLoginPage() {
               <rect x="5.5" y="3.5" width="3" height="7" rx="0.5" fill="white" />
             </svg>
             <span className="text-xs" style={{ color: "#64645f" }}>
-              Daten in der Schweiz. Verschlüsselt. DSGVO-konform.
+              Entwickelt in der Schweiz. Verschlüsselt. DSGVO-konform.
             </span>
           </div>
           <p className="text-xs" style={{ color: "#7b8fb3" }}>


### PR DESCRIPTION
## Summary
- **Bug 15:** Gold dot was too dominant above heading. Now: 8px dot positioned as period after "Leitsystem●" (baseline, ~1/3 text height). Swiss text: "Entwickelt in der Schweiz" (accurate, not "Daten in der Schweiz").
- **Bug 16:** PWA icon dot was 35% diameter — now 13% (regular) / 10% (maskable). Small, minimalist, elegant.

## Test plan
- [ ] Login: "Leitsystem●" with small gold dot at text baseline
- [ ] Footer: "Entwickelt in der Schweiz" (not "Daten in der Schweiz")
- [ ] PWA icon: tiny gold dot on navy after reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)