### PR TITLE
fix: footer order, no double Leitsystem, responsive dot

### DIFF
--- a/src/web/app/api/ops/pwa/icon/route.tsx
+++ b/src/web/app/api/ops/pwa/icon/route.tsx
@@ -17,9 +17,12 @@ export async function GET(request: Request) {
   const isMaskable = searchParams.get("maskable") === "1";
 
   const radius = isMaskable ? 0 : Math.round(size * 0.22);
-  // Small, elegant dot: ~13% diameter (~1.3% area) — minimalist brand mark
-  // Maskable: slightly smaller to stay within 80% safe zone
-  const dotSize = Math.round(size * (isMaskable ? 0.10 : 0.13));
+  // Responsive dot: larger % at small sizes so it stays visible.
+  // Mobile homescreen (192px): 13% = 25px — good.
+  // Desktop taskbar/favicon (≤64px): 28% = ~14-18px — visible.
+  // Large (512px): 13% = 67px — elegant.
+  const baseRatio = size <= 64 ? 0.28 : size <= 128 ? 0.20 : 0.13;
+  const dotSize = Math.round(size * (isMaskable ? baseRatio * 0.8 : baseRatio));
 
   return new ImageResponse(
     (

--- a/src/web/app/ops/(auth)/login/page.tsx
+++ b/src/web/app/ops/(auth)/login/page.tsx
@@ -49,6 +49,9 @@ export default function OpsLoginPage() {
         {/* ── Swiss trust footer ────────────────────────────── */}
         <div className="mt-8 text-center space-y-2">
           <div className="flex items-center justify-center gap-1.5">
+            <span className="text-xs" style={{ color: "#64645f" }}>
+              Verschlüsselt. DSGVO-konform. Entwickelt für die Schweiz.
+            </span>
             <svg
               width="14"
               height="14"
@@ -60,9 +63,6 @@ export default function OpsLoginPage() {
               <rect x="3.5" y="5.5" width="7" height="3" rx="0.5" fill="white" />
               <rect x="5.5" y="3.5" width="3" height="7" rx="0.5" fill="white" />
             </svg>
-            <span className="text-xs" style={{ color: "#64645f" }}>
-              Entwickelt in der Schweiz. Verschlüsselt. DSGVO-konform.
-            </span>
           </div>
           <p className="text-xs" style={{ color: "#7b8fb3" }}>
             Nur autorisierte Nutzer. Kein Zugang? Admin kontaktieren.

--- a/src/web/app/ops/(dashboard)/layout.tsx
+++ b/src/web/app/ops/(dashboard)/layout.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
     const identity = await resolveTenantIdentity(user);
     const tabLabel = identity?.leitsystemName ?? "Leitsystem";
-    return { title: { absolute: `${tabLabel} Leitsystem` } };
+    return { title: { absolute: "Leitsystem" } };
   } catch {
     return { title: { absolute: "Leitsystem" } };
   }


### PR DESCRIPTION
## Summary
- **Bug 17:** Footer reordered: "Verschlüsselt. DSGVO-konform. Entwickelt für die Schweiz. 🇨🇭" — Swiss flag at end
- **Bug 18:** PWA title bar "Leitsystem - Weinberger Leitsystem" → just "Leitsystem" (no redundancy)
- **Bug 19:** Icon dot responsive by size: 28% at ≤64px (taskbar), 20% at ≤128px, 13% at 192px+ (mobile homescreen unchanged)

## Test plan
- [ ] Login footer: correct text order + flag at end
- [ ] PWA title bar: just "Leitsystem" (not doubled)
- [ ] Desktop taskbar icon: dot visible after reinstall
- [ ] Mobile homescreen: dot same size as before (good)

🤖 Generated with [Claude Code](https://claude.com/claude-code)