### PR TITLE
fix: PWA icon dot visible on taskbar + small displays

### DIFF
--- a/src/web/app/api/ops/pwa/icon/route.tsx
+++ b/src/web/app/api/ops/pwa/icon/route.tsx
@@ -17,11 +17,13 @@ export async function GET(request: Request) {
   const isMaskable = searchParams.get("maskable") === "1";
 
   const radius = isMaskable ? 0 : Math.round(size * 0.22);
-  // Responsive dot: larger % at small sizes so it stays visible.
-  // Mobile homescreen (192px): 13% = 25px — good.
-  // Desktop taskbar/favicon (≤64px): 28% = ~14-18px — visible.
-  // Large (512px): 13% = 67px — elegant.
-  const baseRatio = size <= 64 ? 0.28 : size <= 128 ? 0.20 : 0.13;
+  // Responsive dot: must be clearly visible even at 32px taskbar size.
+  // 48px icon (taskbar): 38% = 18px dot — unmissable
+  // 96px icon (small UI): 30% = 29px dot — clear
+  // 192px icon (homescreen): 15% = 29px dot — elegant
+  // 512px icon (splash): 12% = 61px dot — refined
+  const baseRatio =
+    size <= 64 ? 0.38 : size <= 128 ? 0.30 : size <= 256 ? 0.15 : 0.12;
   const dotSize = Math.round(size * (isMaskable ? baseRatio * 0.8 : baseRatio));
 
   return new ImageResponse(

--- a/src/web/app/api/ops/pwa/manifest/route.ts
+++ b/src/web/app/api/ops/pwa/manifest/route.ts
@@ -44,6 +44,18 @@ export async function GET() {
     orientation: "portrait-primary" as const,
     icons: [
       {
+        src: "/api/ops/pwa/icon?size=48",
+        sizes: "48x48",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/api/ops/pwa/icon?size=96",
+        sizes: "96x96",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
         src: "/api/ops/pwa/icon?size=192",
         sizes: "192x192",
         type: "image/png",


### PR DESCRIPTION
## Summary
Bug 20: Dot still invisible on desktop taskbar. Root cause: manifest only had 192px/512px icons — browser downscaled 192px to 32px, making the 13% dot (~4px) invisible.

**Fix:** Added 48px and 96px icons to manifest + aggressive dot ratios for small sizes:
- 48px: 38% dot (18px — unmissable on taskbar)
- 96px: 30% dot (29px — clear)
- 192px: 15% dot (29px — slightly larger than before for mobile)
- 512px: 12% dot (61px — refined)

## Test plan
- [ ] Uninstall PWA → reinstall → taskbar icon shows visible gold dot
- [ ] Leitstand sidebar top-left: dot visible
- [ ] Mobile homescreen: dot still looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)