### PR TITLE
fix: Phase 1.1 + 1.7 — remove archived status + wording sweep

### DIFF
--- a/src/web/app/api/cases/route.ts
+++ b/src/web/app/api/cases/route.ts
@@ -310,7 +310,7 @@ export async function POST(request: NextRequest) {
       await supabase.from("case_events").insert({
         case_id: row.id,
         event_type: "reporter_confirmation_sent",
-        title: "Bestätigung an Melder gesendet",
+        title: "Bestätigung an Kunden gesendet",
       }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
     }
 
@@ -336,7 +336,7 @@ export async function POST(request: NextRequest) {
           await supabase.from("case_events").insert({
             case_id: row.id,
             event_type: "sms_sent",
-            title: "Bestätigungs-SMS an Melder gesendet",
+            title: "Bestätigungs-SMS an Kunden gesendet",
             metadata: { to: data.contact_phone, message_sid: smsResult.messageSid },
           }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
         }

--- a/src/web/app/api/lifecycle/tick/route.ts
+++ b/src/web/app/api/lifecycle/tick/route.ts
@@ -355,7 +355,7 @@ async function processTerminReminders(
     await supabase.from("case_events").insert({
       case_id: c.id,
       event_type: "termin_reminder_sent",
-      title: "24h-Erinnerung an Meldende/n gesendet",
+      title: "24h-Erinnerung an Kunden gesendet",
       metadata: { sms_sent: smsResult.sent, reason: smsResult.reason ?? null },
     });
 

--- a/src/web/app/api/ops/cases/[id]/notify-melder/route.ts
+++ b/src/web/app/api/ops/cases/[id]/notify-melder/route.ts
@@ -110,7 +110,7 @@ export async function POST(
   await supabase.from("case_events").insert({
     case_id: id,
     event_type: "melder_termin_notified",
-    title: "Terminbestätigung an Meldende/n gesendet",
+    title: "Terminbestätigung an Kunden gesendet",
     metadata: { email_sent: emailSent, sms_sent: smsSent, user_id: user.id },
   }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
 

--- a/src/web/app/api/ops/cases/[id]/route.ts
+++ b/src/web/app/api/ops/cases/[id]/route.ts
@@ -12,7 +12,7 @@ import { resolveStaffRole } from "@/src/lib/staff/resolveStaffRole";
 // Allowed values for ops fields
 // ---------------------------------------------------------------------------
 
-const VALID_STATUSES = ["new", "scheduled", "in_arbeit", "warten", "done", "archived"] as const;
+const VALID_STATUSES = ["new", "scheduled", "in_arbeit", "warten", "done"] as const;
 
 const STATUS_LABELS: Record<string, string> = {
   new: "Neu",
@@ -20,7 +20,6 @@ const STATUS_LABELS: Record<string, string> = {
   in_arbeit: "In Arbeit",
   warten: "Warten",
   done: "Erledigt",
-  archived: "Abgeschlossen",
 };
 
 const FIELD_LABELS: Record<string, string> = {
@@ -37,7 +36,7 @@ const FIELD_LABELS: Record<string, string> = {
   internal_notes: "Notizen",
   contact_email: "E-Mail",
   contact_phone: "Telefon",
-  reporter_name: "Melder",
+  reporter_name: "Kunde",
 };
 
 const VALID_URGENCIES = ["notfall", "dringend", "normal"] as const;

--- a/src/web/app/api/ops/metrics/route.ts
+++ b/src/web/app/api/ops/metrics/route.ts
@@ -18,7 +18,6 @@ export async function GET() {
     .from("cases")
     .select("id, status, urgency, source, created_at, updated_at")
     .eq("is_demo", false)
-    .neq("status", "archived")
     .limit(5000);
 
   if (scope.tenantId) query = query.eq("tenant_id", scope.tenantId);

--- a/src/web/app/api/retell/webhook/route.ts
+++ b/src/web/app/api/retell/webhook/route.ts
@@ -578,7 +578,7 @@ export async function POST(req: Request) {
           await supabase.from("case_events").insert({
             case_id: caseId,
             event_type: "sms_verification_sent",
-            title: "SMS-Bestätigung an Melder gesendet",
+            title: "SMS-Bestätigung an Kunden gesendet",
             metadata: { sms_sid: smsResult.messageSid },
           }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
         } else {

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -17,7 +17,6 @@ const STATUSES = [
   { value: "in_arbeit", label: "In Arbeit" },
   { value: "warten", label: "Warten" },
   { value: "done", label: "Erledigt" },
-  { value: "archived", label: "Abgeschlossen" },
 ] as const;
 
 const STATUS_LABELS: Record<string, string> = Object.fromEntries(STATUSES.map(s => [s.value, s.label]));
@@ -28,7 +27,6 @@ const STATUS_COLORS: Record<string, string> = {
   in_arbeit: "bg-indigo-100 text-indigo-700",
   warten: "bg-amber-100 text-amber-700",
   done: "bg-emerald-100 text-emerald-700",
-  archived: "bg-gray-100 text-gray-500",
 };
 
 const URGENCIES = [
@@ -42,7 +40,7 @@ const URGENCY_LABELS: Record<string, string> = Object.fromEntries(URGENCIES.map(
 const NEXT_STEP: Record<string, string> = {
   new: "Sichten und einordnen",
   scheduled: "Einsatz durchführen",
-  in_arbeit: "Einsatz abschliessen",
+  in_arbeit: "Arbeit erledigen",
   warten: "Rückmeldung prüfen",
 };
 
@@ -101,7 +99,7 @@ const LEGACY_FIELD_MAP: Record<string, string> = {
   urgency: "Priorität", category: "Kategorie", description: "Beschreibung",
   plz: "PLZ", city: "Ort", street: "Strasse", house_number: "Hausnummer",
   assignee_text: "Zuständig", scheduled_at: "Termin", internal_notes: "Notizen",
-  contact_email: "E-Mail", contact_phone: "Telefon", reporter_name: "Melder",
+  contact_email: "E-Mail", contact_phone: "Telefon", reporter_name: "Kunde",
 };
 
 function humanizeTitle(title: string): string {
@@ -371,7 +369,7 @@ export function CaseDetailForm({
       setMelderNotifyState("sent");
       setLocalEvents(prev => [...prev, {
         id: crypto.randomUUID(), event_type: "melder_termin_notified",
-        title: "Terminbestätigung an Meldende/n gesendet", created_at: new Date().toISOString(),
+        title: "Terminbestätigung an Kunden gesendet", created_at: new Date().toISOString(),
       }]);
       setTimeout(() => setMelderNotifyState("idle"), 3000);
     } catch {
@@ -571,7 +569,7 @@ export function CaseDetailForm({
 
             {/* Status feedback for melder notification */}
             {melderNotifyState === "sent" && (
-              <p className="text-xs text-emerald-600 text-right mt-1">Meldende/r benachrichtigt ✓</p>
+              <p className="text-xs text-emerald-600 text-right mt-1">Kunde benachrichtigt ✓</p>
             )}
             {melderNotifyState === "error" && (
               <p className="text-xs text-red-600 text-right mt-1">Benachrichtigung fehlgeschlagen.</p>
@@ -626,7 +624,7 @@ export function CaseDetailForm({
               <div className="flex items-center gap-2 mt-3 pt-2 border-t border-gray-200/40 print:hidden">
                 <button onClick={handleNotifyMelder} disabled={melderNotifyState === "sending"}
                   className="text-xs text-gray-500 hover:text-gray-700 transition-colors"
-                >{melderNotifyState === "sending" ? "Sende…" : melderNotifyState === "sent" ? "Meldende/r benachrichtigt ✓" : "Meldende/n über Termin benachrichtigen"}</button>
+                >{melderNotifyState === "sending" ? "Sende…" : melderNotifyState === "sent" ? "Kunde benachrichtigt ✓" : "Kunden über Termin benachrichtigen"}</button>
                 <span className="text-gray-300">|</span>
                 <button onClick={handleSendInvite} disabled={inviteState === "sending"}
                   className="text-xs text-gray-500 hover:text-gray-700 transition-colors"
@@ -714,7 +712,7 @@ export function CaseDetailForm({
               <>
                 <SectionHead title="Kontakt" editing onClose={cancelEdit} />
                 <div className="space-y-3">
-                  <div><label className={lbl}>Melder</label><input type="text" value={reporterName} onChange={e => setReporterName(e.target.value)} placeholder="Hans Müller" className={inp} /></div>
+                  <div><label className={lbl}>Kunde</label><input type="text" value={reporterName} onChange={e => setReporterName(e.target.value)} placeholder="Hans Müller" className={inp} /></div>
                   <div><label className={lbl}>Telefon</label><input type="tel" value={contactPhone} onChange={e => setContactPhone(e.target.value)} placeholder="+41 79..." className={inp} /></div>
                   <div><label className={lbl}>E-Mail</label><input type="email" value={contactEmail} onChange={e => setContactEmail(e.target.value)} placeholder="name@beispiel.ch" className={inp} /></div>
                   <div className="grid grid-cols-3 gap-2">
@@ -977,7 +975,7 @@ function BewertungEndCap({
   brandColor: string;
   hasEvents: boolean;
 }) {
-  const isActive = status === "done" || status === "archived";
+  const isActive = status === "done";
   const reviewSent = reviewInfo.status === "angefragt" || reviewInfo.status === "geoeffnet" || reviewInfo.status === "geklickt";
   const starsMuted = !isActive; // muted when case not yet done
 
@@ -990,8 +988,6 @@ function BewertungEndCap({
   } else if (reviewInfo.status === "kein_kontakt") {
     label = "Kein Kontakt hinterlegt";
   } else if (reviewInfo.status === "uebersprungen") {
-    label = "Keine Bewertung angefragt";
-  } else if (status === "archived" && !reviewSent) {
     label = "Keine Bewertung angefragt";
   } else if (isActive) {
     label = "Bewertung möglich";

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -43,7 +43,6 @@ export default async function OpsCasesPage({
       "id, seq_number, created_at, updated_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, review_sent_at, scheduled_at"
     )
     .eq("is_demo", showDemo)
-    .neq("status", "archived")
     .order("created_at", { ascending: false })
     .limit(200);
   if (filterTenantId) casesQuery = casesQuery.eq("tenant_id", filterTenantId);

--- a/src/web/app/ops/(dashboard)/faelle/page.tsx
+++ b/src/web/app/ops/(dashboard)/faelle/page.tsx
@@ -18,7 +18,6 @@ const STATUS_FILTERS = [
   { value: "in_arbeit", label: "In Arbeit" },
   { value: "warten", label: "Warten" },
   { value: "done", label: "Erledigt" },
-  { value: "archived", label: "Abgeschlossen" },
 ] as const;
 
 const URGENCY_FILTERS = [

--- a/src/web/app/ops/(dashboard)/settings/page.tsx
+++ b/src/web/app/ops/(dashboard)/settings/page.tsx
@@ -158,7 +158,7 @@ export default function SettingsPage() {
         {/* Team — StaffManager handles its own save */}
         <Section
           title="Team"
-          description="Mitarbeiter verwalten. Die E-Mail-Adresse wird für Kalendereinladungen bei Terminzuweisung verwendet."
+          description="Mitarbeiter verwalten. Die E-Mail-Adresse wird für Kalendereinladungen bei Terminvergabe verwendet."
         >
           <StaffManager tenantId={data?.tenant_id} embedded />
         </Section>
@@ -166,7 +166,7 @@ export default function SettingsPage() {
         {/* Benachrichtigungen — per-card save */}
         <Section
           title="Benachrichtigungen"
-          description="Automatische Benachrichtigungen an Meldende und Mitarbeiter."
+          description="Automatische Benachrichtigungen an Kunden und Mitarbeiter."
         >
           <div className="space-y-5">
             {/* Sub-section: Bei Fallerfassung */}
@@ -176,38 +176,38 @@ export default function SettingsPage() {
                 <Toggle
                   checked={notifyEmail}
                   onChange={setNotifyEmail}
-                  label="E-Mail-Bestätigung an Meldende"
-                  description="Meldende erhalten eine E-Mail mit Fallnummer und Zusammenfassung"
+                  label="E-Mail-Bestätigung an Kunden"
+                  description="Kunden erhalten eine E-Mail mit Fallnummer und Zusammenfassung"
                 />
                 <Toggle
                   checked={notifySms}
                   onChange={setNotifySms}
-                  label="SMS-Bestätigung an Meldende"
-                  description="Meldende erhalten eine SMS-Bestätigung nach der Meldung"
+                  label="SMS-Bestätigung an Kunden"
+                  description="Kunden erhalten eine SMS-Bestätigung nach der Meldung"
                 />
               </div>
             </div>
 
-            {/* Sub-section: Bei Terminzuweisung */}
+            {/* Sub-section: Bei Terminvergabe */}
             <div>
-              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Bei Terminzuweisung</p>
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Bei Terminvergabe</p>
               <div className="space-y-3">
                 <Toggle
                   checked={notifyTerminEmail}
                   onChange={setNotifyTerminEmail}
-                  label="E-Mail-Terminbestätigung an Meldende"
-                  description="Meldende erhalten eine E-Mail wenn ein Termin eingeplant wird"
+                  label="E-Mail-Terminbestätigung an Kunden"
+                  description="Kunden erhalten eine E-Mail wenn ein Termin eingeplant wird"
                 />
                 <Toggle
                   checked={notifyTerminSms}
                   onChange={setNotifyTerminSms}
-                  label="SMS-Terminbestätigung an Meldende"
-                  description="Meldende erhalten eine SMS mit den Termindetails"
+                  label="SMS-Terminbestätigung an Kunden"
+                  description="Kunden erhalten eine SMS mit den Termindetails"
                 />
                 <Toggle
                   checked={notifyStaffAssignment}
                   onChange={setNotifyStaffAssignment}
-                  label="E-Mail an Mitarbeiter bei Zuweisung"
+                  label="E-Mail an Mitarbeiter bei Vergabe"
                   description="Mitarbeiter erhalten eine E-Mail wenn ihnen ein Fall zugewiesen wird"
                 />
               </div>
@@ -220,8 +220,8 @@ export default function SettingsPage() {
                 <Toggle
                   checked={notifyTerminReminderSms}
                   onChange={setNotifyTerminReminderSms}
-                  label="24h-Erinnerung an Meldende per SMS"
-                  description="Meldende erhalten am Vortag eine SMS-Erinnerung an den Termin"
+                  label="24h-Erinnerung an Kunden per SMS"
+                  description="Kunden erhalten am Vortag eine SMS-Erinnerung an den Termin"
                 />
               </div>
             </div>

--- a/src/web/src/components/ops/CaseListClient.tsx
+++ b/src/web/src/components/ops/CaseListClient.tsx
@@ -38,7 +38,6 @@ const STATUS_LABELS: Record<string, string> = {
   in_arbeit: "In Arbeit",
   warten: "Warten",
   done: "Erledigt",
-  archived: "Abgeschlossen",
 };
 
 const STATUS_COLORS: Record<string, string> = {
@@ -47,7 +46,6 @@ const STATUS_COLORS: Record<string, string> = {
   in_arbeit: "bg-indigo-100 text-indigo-700",
   warten: "bg-amber-100 text-amber-700",
   done: "bg-emerald-100 text-emerald-700",
-  archived: "bg-gray-100 text-gray-500",
 };
 
 const URGENCY_DOT: Record<string, string> = {
@@ -98,7 +96,7 @@ function truncate(s: string, max: number): string {
 }
 
 function exportCsv(rows: CaseRow[], prefix: string, tenantName?: string) {
-  const headers = ["Fall-ID", "Kunde", "Adresse", "Kategorie", "Beschreibung", "Quelle", "Dringlichkeit", "Status", "Erstellt"];
+  const headers = ["Fall-ID", "Kunde", "Adresse", "Kategorie", "Beschreibung", "Herkunft", "Priorität", "Status", "Erstellt"];
   const lines = rows.map((r) => [
     formatCaseId(r.seq_number, prefix),
     r.reporter_name ?? "",
@@ -246,8 +244,8 @@ export function CaseListClient({
                   <th className="px-4 py-3 font-medium">Kunde</th>
                   <th className="px-4 py-3 font-medium">Adresse</th>
                   <th className="px-4 py-3 font-medium">Problem</th>
-                  <th className="px-4 py-3 font-medium">Quelle</th>
-                  <th className="px-4 py-3 font-medium">Dringlichkeit</th>
+                  <th className="px-4 py-3 font-medium">Herkunft</th>
+                  <th className="px-4 py-3 font-medium">Priorität</th>
                   <th className="px-4 py-3 font-medium">Status</th>
                   <th className="px-4 py-3 font-medium">Erstellt</th>
                 </tr>

--- a/src/web/src/components/ops/CaseTimeline.tsx
+++ b/src/web/src/components/ops/CaseTimeline.tsx
@@ -13,7 +13,7 @@ export interface CaseEvent {
 const NEXT_STEP: Record<string, string> = {
   new: "Sichten und einordnen",
   scheduled: "Einsatz durchführen",
-  in_arbeit: "Einsatz abschliessen",
+  in_arbeit: "Arbeit erledigen",
   warten: "Rückmeldung prüfen",
 };
 

--- a/src/web/src/components/ops/CreateCaseModal.tsx
+++ b/src/web/src/components/ops/CreateCaseModal.tsx
@@ -122,7 +122,7 @@ export function CreateCaseModal({
         <form id="create-case-form" onSubmit={handleSubmit} className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
           {/* Reporter name */}
           <div>
-            <label htmlFor="mc-name" className={labelClasses}>Name des Melders</label>
+            <label htmlFor="mc-name" className={labelClasses}>Name des Kunden</label>
             <input
               id="mc-name"
               type="text"
@@ -151,7 +151,7 @@ export function CreateCaseModal({
 
             {/* Urgency */}
             <div>
-              <label htmlFor="mc-urg" className={labelClasses}>Dringlichkeit</label>
+              <label htmlFor="mc-urg" className={labelClasses}>Priorität</label>
               <select
                 id="mc-urg"
                 value={urgency}

--- a/src/web/src/components/ops/PulsView.tsx
+++ b/src/web/src/components/ops/PulsView.tsx
@@ -30,7 +30,6 @@ const STATUS_LABELS: Record<string, string> = {
   in_arbeit: "In Arbeit",
   warten: "Warten",
   done: "Erledigt",
-  archived: "Abgeschlossen",
 };
 
 const URGENCY_DOT: Record<string, string> = {
@@ -83,6 +82,7 @@ function groupCases(cases: CaseRow[]): PulsGroup[] {
   const abschluss: CaseRow[] = [];
 
   for (const c of cases) {
+    // "archived" status eliminated — skip for safety if still in DB
     if (c.status === "archived") continue;
 
     // Achtung: Notfälle (any status except done) + stuck >48h

--- a/src/web/src/components/ops/StaffManager.tsx
+++ b/src/web/src/components/ops/StaffManager.tsx
@@ -131,7 +131,7 @@ export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
         <div className="flex items-center justify-between mb-4">
           <div>
             <h2 className="text-lg font-bold text-gray-900">Team</h2>
-            <p className="text-sm text-gray-500">Team verwalten — für Fall-Zuweisung und Einsatzplanung</p>
+            <p className="text-sm text-gray-500">Team verwalten — für Fall-Vergabe und Einsatzplanung</p>
           </div>
           {!showForm && (
             <button
@@ -205,7 +205,7 @@ export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
                         <li>Sieht alle Fälle im Betrieb</li>
                         <li>Kann Fälle zuweisen und Mitarbeiter verwalten</li>
                         <li>Zugriff auf Einstellungen und Benachrichtigungen</li>
-                        <li>Kann Termine versenden und Meldende benachrichtigen</li>
+                        <li>Kann Termine versenden und Kunden benachrichtigen</li>
                       </ul>
                     </div>
                     <div className="p-2.5 bg-slate-50 rounded-lg">
@@ -230,7 +230,7 @@ export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
                 placeholder="max@firma.ch"
                 className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400/30"
               />
-              <p className="mt-1 text-[11px] text-gray-400">Für Kalendereinladungen bei Terminzuweisung</p>
+              <p className="mt-1 text-[11px] text-gray-400">Für Kalendereinladungen bei Terminvergabe</p>
             </div>
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Telefon</label>

--- a/src/web/src/components/ops/ZentraleView.tsx
+++ b/src/web/src/components/ops/ZentraleView.tsx
@@ -82,10 +82,10 @@ function formatTime(iso: string): string {
 function computeNextStep(c: ZentraleCase): string {
   if (c.status === "new") return "Sichten und einordnen";
   if (c.status === "scheduled") return "Einsatz durchführen";
-  if (c.status === "in_arbeit") return "Einsatz abschliessen";
+  if (c.status === "in_arbeit") return "Arbeit erledigen";
   if (c.status === "warten") return "Rückmeldung prüfen";
   if (c.status === "done" && !c.review_sent_at) return "Review anfragen";
-  if (c.status === "done") return "Abgeschlossen";
+  if (c.status === "done") return "Erledigt";
   return "";
 }
 
@@ -116,8 +116,9 @@ function groupForLeitsystem(cases: ZentraleCase[]): LeitsystemGroups {
   const abschluss: ZentraleCase[] = [];
 
   for (const c of cases) {
+    // "archived" status eliminated — skip for safety if still in DB
     if (c.status === "archived") continue;
-    const isActive = c.status !== "done" && c.status !== "archived";
+    const isActive = c.status !== "done";
 
     if (isActive) {
       aktive++;

--- a/src/web/src/lib/email/resend.ts
+++ b/src/web/src/lib/email/resend.ts
@@ -95,13 +95,13 @@ function buildOpsNotificationHtml(p: CaseEmailPayload, deepLink: string): string
 
   // Data rows
   const rows: [string, string][] = [
-    ["Quelle", sourceLabel],
+    ["Herkunft", sourceLabel],
     ["Kategorie", p.category],
-    ["Dringlichkeit", p.urgency.charAt(0).toUpperCase() + p.urgency.slice(1)],
+    ["Priorität", p.urgency.charAt(0).toUpperCase() + p.urgency.slice(1)],
     ["PLZ / Ort", `${p.plz} ${p.city}`],
   ];
   if (addressParts.length > 0) rows.push(["Adresse", addressParts[0]]);
-  if (p.reporterName) rows.push(["Melder", p.reporterName]);
+  if (p.reporterName) rows.push(["Kunde", p.reporterName]);
   if (p.contactPhone) rows.push(["Telefon", p.contactPhone]);
   if (p.contactEmail) rows.push(["E-Mail", p.contactEmail]);
 
@@ -287,12 +287,12 @@ export async function sendCaseNotification(
         `Neuer Fall erstellt`,
         `──────────────────────`,
         `Fall-Nr:   ${formatCaseLabel(payload.caseId, payload.seqNumber, payload.caseIdPrefix)}`,
-        `Quelle:    ${sourceLabel}`,
+        `Herkunft:  ${sourceLabel}`,
         `Kategorie: ${payload.category}`,
-        `Dringend:  ${payload.urgency}`,
+        `Priorität: ${payload.urgency}`,
         `PLZ/Ort:   ${payload.plz} ${payload.city}`,
         ...(addressLine ? [addressLine] : []),
-        ...(payload.reporterName ? [`Melder:    ${payload.reporterName}`] : []),
+        ...(payload.reporterName ? [`Kunde:     ${payload.reporterName}`] : []),
         ...(contactLines.length > 0 ? contactLines : []),
         `──────────────────────`,
         `Beschreibung:`,
@@ -731,7 +731,7 @@ export async function sendAssignmentNotification(
         `Fall-Nr:     ${payload.caseLabel}`,
         `Kategorie:   ${payload.category}`,
         `Ort:         ${payload.city}`,
-        `Dringlichkeit: ${urgencyLabel}`,
+        `Priorität:   ${urgencyLabel}`,
         `──────────────────────`,
         `Beschreibung:`,
         payload.description,


### PR DESCRIPTION
## Summary
- **Task 1.1 (Status vereinfachen):** Remove "Abgeschlossen" (archived) status from entire OPS dashboard. Status chain is now: Neu → Geplant → In Arbeit → Warten → Erledigt. Safety guards kept in PulsView/ZentraleView for legacy DB rows.
- **Task 1.7 (Wording Sweep):** Replace SaaS terminology with Handwerker-Sprache across all OPS-facing UI:
  - Meldende/Melder → Kunde/Kunden
  - Dringlichkeit → Priorität
  - Quelle → Herkunft
  - Einsatz abschliessen → Arbeit erledigen
  - Terminzuweisung/Zuweisung → Terminvergabe/Vergabe

**17 files changed** across: CaseDetailForm, CaseListClient, CaseTimeline, CreateCaseModal, PulsView, ZentraleView, StaffManager, Settings, API routes (cases, ops/cases, metrics, notify-melder, lifecycle/tick, retell/webhook), email templates (resend.ts).

Code identifiers (`reporter_name`, `assignee_text`, etc.) unchanged — only user-visible strings modified.

## Test plan
- [ ] Verify OPS dashboard shows no "Abgeschlossen" status option in dropdowns or filters
- [ ] Verify case list headers show "Priorität" and "Herkunft" instead of "Dringlichkeit" and "Quelle"
- [ ] Verify CSV export uses new headers
- [ ] Verify settings page shows "Kunden" instead of "Meldende", "Terminvergabe" instead of "Terminzuweisung"
- [ ] Verify case detail form label shows "Kunde" instead of "Melder"
- [ ] Verify timeline shows "Arbeit erledigen" instead of "Einsatz abschliessen"
- [ ] Verify BewertungEndCap only triggers on `status === "done"` (not archived)

🤖 Generated with [Claude Code](https://claude.com/claude-code)