### PR TITLE
feat: termin validation (1.2) + mobile overflow fix (1.8)

### DIFF
--- a/src/web/app/api/ops/cases/[id]/route.ts
+++ b/src/web/app/api/ops/cases/[id]/route.ts
@@ -202,6 +202,23 @@ export async function PATCH(
     );
   }
 
+  // Validate appointment: scheduled_end_at must be > scheduled_at + 15min
+  if ("scheduled_at" in update && "scheduled_end_at" in update && update.scheduled_at && update.scheduled_end_at) {
+    const startMs = new Date(update.scheduled_at as string).getTime();
+    const endMs = new Date(update.scheduled_end_at as string).getTime();
+    if (isNaN(startMs) || isNaN(endMs)) {
+      return NextResponse.json(
+        { error: "Ungültige Termin-Daten." },
+        { status: 400 }
+      );
+    }
+    if (endMs - startMs < 15 * 60 * 1000) {
+      return NextResponse.json(
+        { error: "Bis-Zeitpunkt muss mindestens 15 Minuten nach Von liegen." },
+        { status: 400 }
+      );
+    }
+  }
 
   try {
     const supabase = getServiceClient();

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -594,7 +594,7 @@ export function CaseDetailForm({
         ) : (
           <div className="bg-gray-50 -mx-5 -my-4 px-5 py-5 rounded-t-2xl border-b border-gray-200/60">
             <SectionHead title="Übersicht" onEdit={() => startEdit("steuerung")} canEdit={canEditSection("steuerung")} />
-            <div className="grid grid-cols-2 md:grid-cols-[1fr_1fr_1fr_1.5fr] gap-x-6 gap-y-3">
+            <div className="grid grid-cols-2 md:grid-cols-[1fr_1fr_1fr_1.5fr] gap-x-6 gap-y-3 min-w-0">
               <KV label="Status">
                 <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold ${STATUS_COLORS[status] ?? "bg-gray-100 text-gray-500"}`}>
                   {STATUS_LABELS[status] ?? status}
@@ -614,14 +614,14 @@ export function CaseDetailForm({
               </KV>
               <KV label="Termin">
                 {scheduledAt
-                  ? <span className="text-[15px] font-semibold text-gray-900 whitespace-nowrap">{formatTerminRange(scheduledAt, scheduledEndAt || null)}</span>
+                  ? <span className="text-[15px] font-semibold text-gray-900 sm:whitespace-nowrap break-words">{formatTerminRange(scheduledAt, scheduledEndAt || null)}</span>
                   : <span className="text-sm text-gray-500">Offen</span>}
               </KV>
             </div>
 
             {/* Quick actions (read-only view) */}
             {scheduledAt && (contactEmail || contactPhone) && (
-              <div className="flex items-center gap-2 mt-3 pt-2 border-t border-gray-200/40 print:hidden">
+              <div className="flex flex-wrap items-center gap-2 mt-3 pt-2 border-t border-gray-200/40 print:hidden">
                 <button onClick={handleNotifyMelder} disabled={melderNotifyState === "sending"}
                   className="text-xs text-gray-500 hover:text-gray-700 transition-colors"
                 >{melderNotifyState === "sending" ? "Sende…" : melderNotifyState === "sent" ? "Kunde benachrichtigt ✓" : "Kunden über Termin benachrichtigen"}</button>
@@ -665,7 +665,7 @@ export function CaseDetailForm({
                 <p className="text-sm font-semibold text-gray-800 mb-2">{category}</p>
                 {description ? (
                   <div className="overflow-hidden">
-                    <p className={`text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-all ${!descExpanded ? "line-clamp-2 sm:line-clamp-3" : ""}`}>{description}</p>
+                    <p className={`text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-words ${!descExpanded ? "line-clamp-2 sm:line-clamp-3" : ""}`}>{description}</p>
                     {(description.split("\n").length > 3 || description.length > 200) && (
                       <button onClick={() => setDescExpanded(p => !p)}
                         className="inline-flex items-center rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 mt-2 transition-colors min-h-[44px] sm:min-h-0">
@@ -704,7 +704,7 @@ export function CaseDetailForm({
         </div>
 
         {/* ── RIGHT RAIL: Kontakt + Notizen + Anhänge ────────────── */}
-        <div className="border-t border-gray-100 md:border-t-0 md:w-80 lg:w-[340px] flex-shrink-0 bg-gray-50/40 md:rounded-br-2xl p-3 space-y-3 print:bg-white">
+        <div className="border-t border-gray-100 md:border-t-0 md:w-80 lg:w-[340px] flex-shrink-0 bg-gray-50/40 md:rounded-br-2xl p-3 space-y-3 print:bg-white min-w-0 overflow-hidden">
 
           {/* Kontakt mini-card */}
           <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
@@ -836,9 +836,9 @@ function SectionHead({
 /** Key-value display pair */
 function KV({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div>
+    <div className="min-w-0">
       <span className="text-gray-500 text-[11px] font-medium uppercase tracking-wide">{label}</span>
-      <div className="mt-0.5">{children}</div>
+      <div className="mt-0.5 min-w-0 break-words">{children}</div>
     </div>
   );
 }

--- a/src/web/app/ops/(dashboard)/settings/page.tsx
+++ b/src/web/app/ops/(dashboard)/settings/page.tsx
@@ -146,11 +146,11 @@ export default function SettingsPage() {
   }
 
   return (
-    <div>
+    <div className="overflow-x-hidden min-w-0">
       <div className="mb-8">
         <h2 className="text-lg font-bold text-gray-900">Einstellungen</h2>
         {data?.tenant_name && (
-          <p className="text-sm text-gray-500">{data.tenant_name}</p>
+          <p className="text-sm text-gray-500 break-words">{data.tenant_name}</p>
         )}
       </div>
 
@@ -254,7 +254,7 @@ export default function SettingsPage() {
             value={googleReviewUrl}
             onChange={(e) => setGoogleReviewUrl(e.target.value)}
             placeholder="https://g.page/r/..."
-            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400"
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 truncate min-w-0"
           />
           <p className="mt-1.5 text-xs text-gray-400">
             Suchen Sie Ihren Betrieb auf Google Maps &rarr; &quot;Rezension
@@ -289,9 +289,9 @@ function Section({
   children: React.ReactNode;
 }) {
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-5">
+    <div className="bg-white border border-gray-200 rounded-xl p-5 min-w-0 overflow-hidden">
       <h3 className="text-sm font-semibold text-gray-900 mb-0.5">{title}</h3>
-      <p className="text-xs text-gray-400 mb-4">{description}</p>
+      <p className="text-xs text-gray-400 mb-4 break-words">{description}</p>
       {children}
     </div>
   );
@@ -348,8 +348,8 @@ function Toggle({
   description: string;
 }) {
   return (
-    <label className="flex items-start gap-3 cursor-pointer">
-      <div className="pt-0.5">
+    <label className="flex items-start gap-3 cursor-pointer min-w-0">
+      <div className="pt-0.5 flex-shrink-0">
         <button
           type="button"
           role="switch"
@@ -366,9 +366,9 @@ function Toggle({
           />
         </button>
       </div>
-      <div>
-        <p className="text-sm font-medium text-gray-700">{label}</p>
-        <p className="text-xs text-gray-400">{description}</p>
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-700 break-words">{label}</p>
+        <p className="text-xs text-gray-400 break-words">{description}</p>
       </div>
     </label>
   );

--- a/src/web/src/components/ops/AppointmentPicker.tsx
+++ b/src/web/src/components/ops/AppointmentPicker.tsx
@@ -90,9 +90,13 @@ export function AppointmentPicker({
 
   // Date click state machine
   function handleDateClick(dateStr: string) {
+    setValidationError(null);
     if (!startDate) {
       setStartDate(dateStr);
       setEndDate(null);
+      // Same day: ensure endTime >= startTime + 15
+      const minEnd = bumpTime(startTime, 15);
+      if (endTime < minEnd) setEndTime(minEnd);
     } else if (!endDate) {
       if (dateStr === startDate) {
         setStartDate(null);
@@ -105,23 +109,52 @@ export function AppointmentPicker({
     } else {
       setStartDate(dateStr);
       setEndDate(null);
+      // Reset to same-day: ensure endTime >= startTime + 15
+      const minEnd = bumpTime(startTime, 15);
+      if (endTime < minEnd) setEndTime(minEnd);
     }
   }
 
-  // Time validation: single day → endTime must be > startTime
+  // Validation error message
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  // Compute minimum "Bis" time: Von + 15 min on the same day
+  const minEndTime = (() => {
+    if (!startDate) return undefined;
+    const effEndDate = endDate ?? startDate;
+    // Only constrain when same day
+    if (effEndDate === startDate) {
+      return bumpTime(startTime, 15);
+    }
+    return undefined;
+  })();
+
+  // Time validation: single day → endTime must be >= startTime + 15min
   function handleStartTimeChange(t: string) {
     setStartTime(t);
-    if (startDate && !endDate && t >= endTime) {
-      setEndTime(bumpTime(t, 15));
+    setValidationError(null);
+    const effEndDate = endDate ?? startDate;
+    // Auto-adjust "Bis" if it would be before Von + 15min
+    if (startDate && effEndDate === startDate) {
+      const minEnd = bumpTime(t, 15);
+      if (endTime < minEnd) {
+        setEndTime(minEnd);
+      }
     }
   }
 
   function handleEndTimeChange(t: string) {
-    if (startDate && !endDate && t <= startTime) {
-      setEndTime(bumpTime(startTime, 15));
-    } else {
-      setEndTime(t);
+    setValidationError(null);
+    const effEndDate = endDate ?? startDate;
+    if (startDate && effEndDate === startDate) {
+      const minEnd = bumpTime(startTime, 15);
+      if (t < minEnd) {
+        // Auto-correct to minimum
+        setEndTime(minEnd);
+        return;
+      }
     }
+    setEndTime(t);
   }
 
   // Confirm
@@ -129,7 +162,17 @@ export function AppointmentPicker({
   const handleConfirm = () => {
     if (!startDate) return;
     const effEndDate = endDate ?? startDate;
-    onConfirm(toIso(startDate, startTime), toIso(effEndDate, endTime));
+    const startIso = toIso(startDate, startTime);
+    const endIso = toIso(effEndDate, endTime);
+    // Final validation: end must be > start + 15min
+    const startMs = new Date(startIso).getTime();
+    const endMs = new Date(endIso).getTime();
+    if (endMs - startMs < 15 * 60 * 1000) {
+      setValidationError("Bis-Zeitpunkt muss nach Von + 15 Min. liegen");
+      return;
+    }
+    setValidationError(null);
+    onConfirm(startIso, endIso);
   };
 
   return (
@@ -165,23 +208,29 @@ export function AppointmentPicker({
               value={endTime}
               brandColor={brandColor}
               onChange={handleEndTimeChange}
+              minTime={minEndTime}
             />
           </div>
         </div>
       </div>
 
+      {/* Validation error */}
+      {validationError && (
+        <p className="mt-2 text-xs text-red-600 font-medium">{validationError}</p>
+      )}
+
       {/* Summary + Actions */}
-      <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-100">
-        <div className="text-sm text-gray-600">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between mt-4 pt-3 border-t border-gray-100 gap-2">
+        <div className="text-sm text-gray-600 min-w-0">
           {startDate ? (
-            <span className="font-medium text-gray-800">
+            <span className="font-medium text-gray-800 break-words">
               {formatPickerSummary(startDate, endDate, startTime, endTime)}
             </span>
           ) : (
             <span className="text-gray-400">Tag wählen</span>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-shrink-0">
           <button
             type="button"
             onClick={onCancel}

--- a/src/web/src/components/ops/CaseListClient.tsx
+++ b/src/web/src/components/ops/CaseListClient.tsx
@@ -172,10 +172,10 @@ export function CaseListClient({
   return (
     <>
       {/* Action bar */}
-      <div className="flex items-center justify-between mb-4 gap-3">
-        <div className="flex items-center gap-3">
-          <form onSubmit={handleSearch} className="flex items-center gap-2">
-            <div className="relative">
+      <div className="flex flex-wrap items-center justify-between mb-4 gap-3 min-w-0">
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <form onSubmit={handleSearch} className="flex items-center gap-2 min-w-0 flex-1 sm:flex-initial">
+            <div className="relative min-w-0 flex-1 sm:flex-initial">
               <svg className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400 pointer-events-none" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
               </svg>
@@ -184,7 +184,7 @@ export function CaseListClient({
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Name, Adresse, Kategorie…"
-                className="rounded-lg border border-gray-300 bg-white pl-8 pr-3 py-2 text-xs text-gray-700 placeholder:text-gray-400 w-52 focus:outline-none focus:ring-2 focus:ring-slate-400/30 focus:border-slate-400"
+                className="rounded-lg border border-gray-300 bg-white pl-8 pr-3 py-2 text-xs text-gray-700 placeholder:text-gray-400 w-full sm:w-52 focus:outline-none focus:ring-2 focus:ring-slate-400/30 focus:border-slate-400"
               />
             </div>
             {search !== searchQuery && (
@@ -212,10 +212,10 @@ export function CaseListClient({
             {totalCount} {totalCount === 1 ? "Fall" : "Fälle"}
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-shrink-0">
           <button
             onClick={() => exportCsv(rows, caseIdPrefix, tenantShortName)}
-            className="rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50 shadow-sm transition-colors"
+            className="rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50 shadow-sm transition-colors hidden sm:block"
           >
             Exportieren
           </button>
@@ -326,10 +326,10 @@ export function CaseListClient({
               <Link
                 key={c.id}
                 href={`/ops/cases/${c.id}`}
-                className="block bg-white rounded-xl border border-gray-200 p-4 hover:border-gray-300 hover:shadow-sm transition-colors"
+                className="block bg-white rounded-xl border border-gray-200 p-4 hover:border-gray-300 hover:shadow-sm transition-colors overflow-hidden"
               >
-                <div className="flex items-start justify-between mb-2">
-                  <div>
+                <div className="flex items-start justify-between mb-2 gap-2">
+                  <div className="min-w-0 truncate">
                     <span className="text-slate-700 font-medium text-sm">
                       {formatCaseId(c.seq_number, caseIdPrefix)}
                     </span>
@@ -338,13 +338,16 @@ export function CaseListClient({
                     )}
                   </div>
                   <span
-                    className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-500"}`}
+                    className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-500"}`}
                   >
                     {STATUS_LABELS[c.status] ?? c.status}
                   </span>
                 </div>
-                <p className="text-gray-900 text-sm font-medium mb-1">
+                <p className="text-gray-900 text-sm font-medium mb-1 truncate">
                   {c.category} — {truncate(c.description, 60)}
+                </p>
+                <p className="text-gray-500 text-xs mb-1 truncate">
+                  {formatAddress(c)}
                 </p>
                 <div className="flex items-center gap-3 text-xs text-gray-500">
                   <span className="inline-flex items-center gap-1">

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -292,9 +292,9 @@ export function OpsShell({
       )}
 
       {/* Main content */}
-      <main className="md:ml-64">
+      <main className="md:ml-64 overflow-x-hidden">
         <InstallPrompt />
-        <div className="max-w-6xl mx-auto px-4 py-6">
+        <div className="max-w-6xl mx-auto px-4 py-6 min-w-0">
           {children}
         </div>
       </main>

--- a/src/web/src/components/ops/StaffManager.tsx
+++ b/src/web/src/components/ops/StaffManager.tsx
@@ -269,43 +269,45 @@ export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
         </div>
       ) : (
         <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-200 bg-slate-50/80">
-                <th className="px-4 py-3 font-medium">Name</th>
-                <th className="px-4 py-3 font-medium">Rolle</th>
-                <th className="px-4 py-3 font-medium hidden sm:table-cell">E-Mail</th>
-                <th className="px-4 py-3 font-medium hidden sm:table-cell">Telefon</th>
-                <th className="px-4 py-3 font-medium w-24"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {staff.map((s) => (
-                <tr key={s.id} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
-                  <td className="px-4 py-3 font-medium text-gray-900">{s.display_name}</td>
-                  <td className="px-4 py-3 text-gray-600">{ROLE_LABELS[s.role] ?? s.role}</td>
-                  <td className="px-4 py-3 text-gray-500 hidden sm:table-cell">{s.email ?? "—"}</td>
-                  <td className="px-4 py-3 text-gray-500 hidden sm:table-cell">{s.phone ?? "—"}</td>
-                  <td className="px-4 py-3">
-                    <div className="flex gap-1">
-                      <button
-                        onClick={() => startEdit(s)}
-                        className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                      >
-                        Bearbeiten
-                      </button>
-                      <button
-                        onClick={() => handleDeactivate(s.id)}
-                        className="text-xs text-red-400 hover:text-red-600 transition-colors ml-2"
-                      >
-                        Entfernen
-                      </button>
-                    </div>
-                  </td>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-200 bg-slate-50/80">
+                  <th className="px-4 py-3 font-medium">Name</th>
+                  <th className="px-4 py-3 font-medium">Rolle</th>
+                  <th className="px-4 py-3 font-medium hidden sm:table-cell">E-Mail</th>
+                  <th className="px-4 py-3 font-medium hidden sm:table-cell">Telefon</th>
+                  <th className="px-4 py-3 font-medium w-24"></th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {staff.map((s) => (
+                  <tr key={s.id} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-3 font-medium text-gray-900 max-w-[140px] truncate">{s.display_name}</td>
+                    <td className="px-4 py-3 text-gray-600">{ROLE_LABELS[s.role] ?? s.role}</td>
+                    <td className="px-4 py-3 text-gray-500 hidden sm:table-cell max-w-[180px] truncate">{s.email ?? "—"}</td>
+                    <td className="px-4 py-3 text-gray-500 hidden sm:table-cell max-w-[140px] truncate">{s.phone ?? "—"}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex gap-1">
+                        <button
+                          onClick={() => startEdit(s)}
+                          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                        >
+                          Bearbeiten
+                        </button>
+                        <button
+                          onClick={() => handleDeactivate(s.id)}
+                          className="text-xs text-red-400 hover:text-red-600 transition-colors ml-2"
+                        >
+                          Entfernen
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </div>

--- a/src/web/src/components/ops/TimeSlotSelector.tsx
+++ b/src/web/src/components/ops/TimeSlotSelector.tsx
@@ -11,6 +11,8 @@ export interface TimeSlotSelectorProps {
   value: string; // "15:00"
   brandColor: string;
   onChange: (time: string) => void;
+  /** Minimum selectable time slot (inclusive). Slots before this are greyed out and disabled. */
+  minTime?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -28,7 +30,7 @@ for (let h = 6; h <= 20; h++) {
 // Component
 // ---------------------------------------------------------------------------
 
-export function TimeSlotSelector({ label, value, brandColor, onChange }: TimeSlotSelectorProps) {
+export function TimeSlotSelector({ label, value, brandColor, onChange, minTime }: TimeSlotSelectorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLButtonElement>(null);
 
@@ -53,23 +55,27 @@ export function TimeSlotSelector({ label, value, brandColor, onChange }: TimeSlo
       >
         {SLOTS.map(slot => {
           const isSelected = slot === value;
+          const isDisabled = !!minTime && slot < minTime;
           return (
             <button
               key={slot}
               ref={isSelected ? selectedRef : undefined}
               type="button"
-              onClick={() => onChange(slot)}
+              disabled={isDisabled}
+              onClick={() => { if (!isDisabled) onChange(slot); }}
               className="w-full px-3 py-1.5 text-xs font-medium text-left transition-colors"
               style={{
                 backgroundColor: isSelected ? brandColor : undefined,
-                color: isSelected ? "#fff" : "#374151",
+                color: isDisabled ? "#d1d5db" : isSelected ? "#fff" : "#374151",
                 borderRadius: isSelected ? "0.5rem" : undefined,
+                cursor: isDisabled ? "not-allowed" : "pointer",
+                opacity: isDisabled ? 0.5 : 1,
               }}
               onMouseEnter={(e) => {
-                if (!isSelected) e.currentTarget.style.backgroundColor = `${brandColor}14`;
+                if (!isSelected && !isDisabled) e.currentTarget.style.backgroundColor = `${brandColor}14`;
               }}
               onMouseLeave={(e) => {
-                if (!isSelected) e.currentTarget.style.backgroundColor = "";
+                if (!isSelected && !isDisabled) e.currentTarget.style.backgroundColor = "";
               }}
             >
               {slot}


### PR DESCRIPTION
## Summary
- **Task 1.2 — Termin-Validierung:** "Bis" time slots before "Von" + 15 min are greyed out and disabled in the TimeSlotSelector. Auto-adjusts "Bis" when "Von" changes. Shows inline German error on confirm if constraint violated. Server-side PATCH validation returns 400 if `scheduled_end_at` < `scheduled_at` + 15 min.
- **Task 1.8 — Mobile Overflow Fix:** Prevents horizontal scroll across the entire OPS dashboard. Fixes Settings page, StaffManager table, CaseDetailForm (Termin display, KV grid, description), and CaseListClient (mobile cards, action bar). All text elements properly truncate or wrap on 390px viewports.

## Changes (8 files)
| File | What |
|------|------|
| `AppointmentPicker.tsx` | Validation state, minEndTime calculation, auto-adjust logic, error display |
| `TimeSlotSelector.tsx` | `minTime` prop — disables & greys out slots below threshold |
| `route.ts` (cases/[id]) | Server-side 400 if end < start + 15min |
| `OpsShell.tsx` | `overflow-x-hidden` + `min-w-0` on main content |
| `settings/page.tsx` | `overflow-hidden`, `break-words`, `min-w-0` on sections/inputs |
| `StaffManager.tsx` | `overflow-x-auto` wrapper, `truncate` on email/phone cells |
| `CaseDetailForm.tsx` | `whitespace-nowrap` → `sm:whitespace-nowrap`, `min-w-0` on KV/grid, `flex-wrap` on actions |
| `CaseListClient.tsx` | Mobile cards: `truncate`, address row, responsive action bar |

## Test plan
- [ ] Open AppointmentPicker, set "Von" to 14:00 → verify "Bis" slots before 14:15 are greyed out
- [ ] Change "Von" to 16:00 when "Bis" is 14:30 → verify "Bis" auto-adjusts to 16:15
- [ ] Try to confirm with end < start + 15min → verify inline German error
- [ ] PATCH API with `scheduled_end_at` < `scheduled_at` + 15min → verify 400 response
- [ ] Open Settings page on 390px viewport → no horizontal scroll
- [ ] Open StaffManager with long emails → no overflow, truncated
- [ ] Open CaseDetail with long Termin range on mobile → wraps properly
- [ ] Open Fallübersicht mobile cards → all text truncated, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)