### PR TITLE
feat: layout rebalance — 1/3 left, 2/3 right

### DIFF
--- a/docs/redesign/leitstand/plan_Leitsystem.md
+++ b/docs/redesign/leitstand/plan_Leitsystem.md
@@ -46,13 +46,13 @@ Jede Stufe ist sichtbar, steuerbar, abschliessbar. Die Bewertung (Google-Sterne)
 | # | Task | Detail | Priorität |
 |---|------|--------|-----------|
 | 1.1 | **Status vereinfachen** | "Abgeschlossen" entfernen. Status-Kette: Neu → Geplant → In Arbeit → Warten → Erledigt. Dropdown + Badges + Farben anpassen. | **DONE** (PR #246) |
-| 1.2 | **Termin-Validierung** | Ende muss nach Start liegen. Client-side + Server-side Validierung. | hoch |
+| 1.2 | **Termin-Validierung** | "Bis"-Zeitpunkt frühestens "Von" + 15min. Alles davor ausgegraut/nicht wählbar. Server-side Validierung zusätzlich. | **DONE** (PR #248) |
 | 1.3 | **"Zuständig" = Multi-Select aus Staff** | Freitext-Feld ersetzen durch Dropdown der aktiven Mitarbeiter (aus staff-Tabelle). Mehrfachauswahl möglich (Chips-UI). Bei Zuweisung: optionale E-Mail an zugewiesene(n) Mitarbeiter (gesteuert via Einstellungen). | hoch |
 | 1.4 | **Termin-Benachrichtigung neu** | Buttons "Meldenden benachrichtigen" + "Termin an Mitarbeiter senden" ELIMINIEREN. Stattdessen: Nach Termin-Eingabe → "Übernehmen" klicken → dann erscheint EIN Button "Termin versenden" → sendet an BEIDE (Kunde + zugewiesene Mitarbeiter). Bestätigung im Verlauf sichtbar, nicht als separater Status. | hoch |
 | 1.5 | **Layout-Rebalance Falldetail** | Links (Beschreibung + Verlauf): ca. 1/3 Breite. Rechts (Übersicht/Kontakt/Notizen/Anhänge): ca. 2/3 Breite. Beschreibung + Verlauf visuell aufwerten auf Niveau der rechten Sektionen (gleiche Card-Qualität, gleiche Typografie-Hierarchie). | mittel |
 | 1.6 | **Bewertungs-Flow** | "Bewertung anfragen"-Button nur sichtbar wenn Status = Erledigt. Verlauf zeigt den Fluss: Erstellt → ... → Erledigt → Bewertung angefragt → ★ Bewertung erhalten. Wenn Kunde nicht reagiert = egal, Fall bleibt "Erledigt". Kein Nachhaken-Zwang. | hoch |
 | 1.7 | **Wording-Sweep Falldetail** | Durchgehend Handwerkersprache: "Meldende/n" → "Kunde", "Dringlichkeit" → "Priorität", "Einsatz abgeschlossen" → "Arbeit erledigt", "Zuweisung" → "Vergabe", "Quelle" → "Herkunft". | **DONE** (PR #246, 17 Dateien, 30+ Edits) |
-| 1.8 | **Mobile Overflow fixen** | M8-Bug: Zahlen/Text gehen rechts aus dem Viewport raus. Responsive Checks auf allen Sektionen (Einstellungen, Falldetail, Termine). Truncation + Wrapping sicherstellen. | hoch |
+| 1.8 | **Mobile Overflow fixen** | M8-Bug: Zahlen/Text gehen rechts aus dem Viewport raus. Responsive Checks auf allen Sektionen (Einstellungen, Falldetail, Termine). Truncation + Wrapping sicherstellen. | **DONE** (PR #248) |
 
 **Definition of Done Phase 1:** Falldetail ist auf Desktop UND Mobile High-End. Jeder Handwerker versteht sofort: Was ist das Problem? Wo? Wer kümmert sich? Wann? Was ist der nächste Schritt?
 

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -644,14 +644,14 @@ export function CaseDetailForm({
       </div>
 
       {/* ── 2-LANE BODY ──────────────────────────────────────────── */}
-      <div className="md:flex print:block">
+      <div className="flex flex-col-reverse md:flex-row print:block">
 
         {/* ── LEFT LANE: Beschreibung + Verlauf ──────────────────── */}
-        <div className="flex-1 min-w-0 md:border-r md:border-gray-100">
-          {/* Beschreibung */}
-          <div className={sectionPad}>
+        <div className="md:w-1/3 min-w-0 md:border-r md:border-gray-100 p-3 space-y-3">
+          {/* Beschreibung card */}
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
             {editingSection === "beschreibung" ? (
-              <div className="bg-gray-50 -mx-5 -my-4 px-5 py-4">
+              <div className="bg-gray-50 -m-4 p-4 rounded-xl">
                 <SectionHead title="Beschreibung" editing onClose={cancelEdit} />
                 <div className="space-y-3">
                   <div><label className={lbl}>Kategorie</label><input type="text" value={category} onChange={e => setCategory(e.target.value)} className={inp} /></div>
@@ -680,8 +680,8 @@ export function CaseDetailForm({
             )}
           </div>
 
-          {/* Verlauf + Bewertung */}
-          <div className={`${sectionPad} border-t border-gray-100`}>
+          {/* Verlauf + Bewertung card */}
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
             <h3 className={`${sectionTitle} mb-3`}>Verlauf</h3>
             <CompactTimeline
               events={localEvents}
@@ -704,7 +704,7 @@ export function CaseDetailForm({
         </div>
 
         {/* ── RIGHT RAIL: Kontakt + Notizen + Anhänge ────────────── */}
-        <div className="border-t border-gray-100 md:border-t-0 md:w-80 lg:w-[340px] flex-shrink-0 bg-gray-50/40 md:rounded-br-2xl p-3 space-y-3 print:bg-white min-w-0 overflow-hidden">
+        <div className="md:w-2/3 border-t border-gray-100 md:border-t-0 bg-gray-50/40 md:rounded-br-2xl p-3 space-y-3 print:bg-white min-w-0 overflow-hidden">
 
           {/* Kontakt mini-card */}
           <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">


### PR DESCRIPTION
## Summary
Task 1.5: Case detail layout rebalance.
- Left lane (Beschreibung/Verlauf): 1/3 width, card-wrapped
- Right rail (Kontakt/Notizen/Anhänge): 2/3 width (was fixed 320-340px)
- Mobile: flex-col-reverse (important info first)
- Plan updated: Task 1.2 + 1.8 marked DONE

🤖 Generated with [Claude Code](https://claude.com/claude-code)