### PR TITLE
fix: case detail feedback round 1 — layout, badges, termin icons

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -592,45 +592,69 @@ export function CaseDetailForm({
             />
           </div>
         ) : (
-          <div className="bg-gray-50 -mx-5 -my-4 px-5 py-5 rounded-t-2xl border-b border-gray-200/60">
+          <div className="bg-gray-50/80 -mx-5 -my-4 px-5 py-5 rounded-t-2xl">
             <SectionHead title="Übersicht" onEdit={() => startEdit("steuerung")} canEdit={canEditSection("steuerung")} />
             <div className="grid grid-cols-2 md:grid-cols-[1fr_1fr_1fr_1.5fr] gap-x-6 gap-y-3 min-w-0">
               <KV label="Status">
-                <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold ${STATUS_COLORS[status] ?? "bg-gray-100 text-gray-500"}`}>
+                <span className={`inline-block px-2.5 py-0.5 rounded-full text-sm font-medium ${STATUS_COLORS[status] ?? "bg-gray-100 text-gray-500"}`}>
                   {STATUS_LABELS[status] ?? status}
                 </span>
               </KV>
               <KV label="Priorität">
-                <span className={`text-[15px] font-semibold ${
-                  urgency === "notfall" ? "text-red-600" :
-                  urgency === "dringend" ? "text-amber-600" :
-                  "text-gray-900"
+                <span className={`inline-block px-2.5 py-0.5 rounded-full text-sm font-medium ${
+                  urgency === "notfall" ? "bg-red-100 text-red-700" :
+                  urgency === "dringend" ? "bg-amber-100 text-amber-700" :
+                  "bg-gray-100 text-gray-600"
                 }`}>{URGENCY_LABELS[urgency] ?? urgency}</span>
               </KV>
               <KV label="Zuständig">
                 {assigneeText
-                  ? <span className="text-[15px] font-medium text-gray-900">{assigneeText}</span>
-                  : <span className="text-sm text-gray-500">Nicht zugewiesen</span>}
+                  ? <span className="inline-block px-2.5 py-0.5 rounded-full text-sm font-medium bg-gray-100 text-gray-700">{assigneeText}</span>
+                  : <span className="text-sm text-gray-400">Nicht zugewiesen</span>}
               </KV>
               <KV label="Termin">
-                {scheduledAt
-                  ? <span className="text-[15px] font-semibold text-gray-900 sm:whitespace-nowrap break-words">{formatTerminRange(scheduledAt, scheduledEndAt || null)}</span>
-                  : <span className="text-sm text-gray-500">Offen</span>}
+                <div className="flex items-center gap-1.5 min-w-0">
+                  {scheduledAt
+                    ? <span className="inline-block px-2.5 py-0.5 rounded-full text-sm font-medium bg-gray-100 text-gray-700 sm:whitespace-nowrap break-words">{formatTerminRange(scheduledAt, scheduledEndAt || null)}</span>
+                    : <span className="text-sm text-gray-400">Offen</span>}
+                  {/* Inline send icons — subtle, only when termin exists */}
+                  {scheduledAt && !terminSentForCurrent && (
+                    <span className="inline-flex items-center gap-1 print:hidden flex-shrink-0">
+                      {/* Send to staff */}
+                      {inviteState === "sending" ? (
+                        <span className="w-4 h-4 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+                      ) : inviteState === "sent" ? (
+                        <svg className="w-4 h-4 text-emerald-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+                      ) : (
+                        <button onClick={handleSendInvite} title="Termin an Mitarbeiter senden"
+                          className="p-0.5 rounded text-gray-400 hover:text-gray-600 transition-colors">
+                          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
+                          </svg>
+                        </button>
+                      )}
+                      {/* Notify melder */}
+                      {(contactEmail || contactPhone) && (
+                        <>
+                          {melderNotifyState === "sending" ? (
+                            <span className="w-4 h-4 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+                          ) : melderNotifyState === "sent" ? (
+                            <svg className="w-4 h-4 text-emerald-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+                          ) : (
+                            <button onClick={handleNotifyMelder} title="Kunden über Termin benachrichtigen"
+                              className="p-0.5 rounded text-gray-400 hover:text-gray-600 transition-colors">
+                              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+                              </svg>
+                            </button>
+                          )}
+                        </>
+                      )}
+                    </span>
+                  )}
+                </div>
               </KV>
             </div>
-
-            {/* Quick actions (read-only view) */}
-            {scheduledAt && (contactEmail || contactPhone) && (
-              <div className="flex flex-wrap items-center gap-2 mt-3 pt-2 border-t border-gray-200/40 print:hidden">
-                <button onClick={handleNotifyMelder} disabled={melderNotifyState === "sending"}
-                  className="text-xs text-gray-500 hover:text-gray-700 transition-colors"
-                >{melderNotifyState === "sending" ? "Sende…" : melderNotifyState === "sent" ? "Kunde benachrichtigt ✓" : "Kunden über Termin benachrichtigen"}</button>
-                <span className="text-gray-300">|</span>
-                <button onClick={handleSendInvite} disabled={inviteState === "sending"}
-                  className="text-xs text-gray-500 hover:text-gray-700 transition-colors"
-                >{inviteState === "sending" ? "Sende…" : inviteState === "sent" ? "Termin gesendet ✓" : "Termin an Mitarbeiter senden"}</button>
-              </div>
-            )}
 
             {/* Save state feedback */}
             {(saveState === "saved" || saveState === "error") && (
@@ -644,10 +668,10 @@ export function CaseDetailForm({
       </div>
 
       {/* ── 2-LANE BODY ──────────────────────────────────────────── */}
-      <div className="flex flex-col-reverse md:flex-row print:block">
+      <div className="flex flex-col md:flex-row print:block mt-1">
 
         {/* ── LEFT LANE: Beschreibung + Verlauf ──────────────────── */}
-        <div className="md:w-1/3 min-w-0 md:border-r md:border-gray-100 p-3 space-y-3">
+        <div className="md:w-2/3 min-w-0 md:border-r md:border-gray-100/60 p-3 space-y-3">
           {/* Beschreibung card */}
           <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
             {editingSection === "beschreibung" ? (
@@ -704,7 +728,7 @@ export function CaseDetailForm({
         </div>
 
         {/* ── RIGHT RAIL: Kontakt + Notizen + Anhänge ────────────── */}
-        <div className="md:w-2/3 border-t border-gray-100 md:border-t-0 bg-gray-50/40 md:rounded-br-2xl p-3 space-y-3 print:bg-white min-w-0 overflow-hidden">
+        <div className="md:w-1/3 border-t border-gray-100/40 md:border-t-0 bg-gray-50/30 md:rounded-br-2xl p-3 space-y-3 print:bg-white min-w-0 overflow-hidden">
 
           {/* Kontakt mini-card */}
           <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
@@ -837,8 +861,8 @@ function SectionHead({
 function KV({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="min-w-0">
-      <span className="text-gray-500 text-[11px] font-medium uppercase tracking-wide">{label}</span>
-      <div className="mt-0.5 min-w-0 break-words">{children}</div>
+      <span className="text-gray-400 text-[11px] font-medium uppercase tracking-wide">{label}</span>
+      <div className="mt-1 min-w-0 break-words">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **F1+F2**: Replace standalone "Termin versenden" button with subtle inline send icons (paper plane for staff, envelope for customer) next to the termin badge in read-only view. Shows spinner while sending, green checkmark on success, then disappears.
- **F3**: Swap 2-lane layout widths — Beschreibung/Verlauf now gets 2/3 width, Kontakt/Notizen/Anhänge gets 1/3 (was inverted).
- **F4**: Remove hard `border-b` between Übersicht band and content body. Uses subtle spacing and softer background for a seamless premium transition.
- **F5**: Unified badge/pill styling for all 4 Übersicht values — Status (colored), Priorität (colored: red/amber/gray), Zuständig (gray pill), Termin (gray pill). All same `text-sm font-medium`, all with `rounded-full` background.
- **F6**: Remove `flex-col-reverse` so mobile order is natural: Beschreibung/Verlauf first, then Kontakt/Notizen/Anhänge.

## Test plan
- [ ] Open a case with a scheduled termin — verify small send icons appear next to the termin badge
- [ ] Click paper plane icon — verify spinner, then green checkmark
- [ ] Click envelope icon (when contact exists) — verify Kunde notification works
- [ ] Verify Übersicht shows all 4 values as consistent badge/pills
- [ ] Verify 2-lane layout: left (Beschreibung) is wider than right (Kontakt)
- [ ] Verify mobile: Beschreibung comes BEFORE Interne Notizen when scrolling
- [ ] Verify no hard border line between Übersicht and content area

🤖 Generated with [Claude Code](https://claude.com/claude-code)