### PR TITLE
docs: SSOT update — Leitsystem Phase 1, eCall, OTP auth

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # FlowSight — STATUS (Company SSOT)
 
-**Datum:** 2026-03-14 (QA Sweep Machine + OPS Visual Block: Brand Header, Puls Overhaul, Color Consistency)
+**Datum:** 2026-03-17 (Leitsystem Phase 1 komplett, Login High-End, PWA Auto-Update)
 **Owner:** Founder + CC (Head Ops)
 
 ## Was ist FlowSight?
@@ -15,7 +15,8 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 | Frontend + API | Next.js App Router (Vercel) | Hobby (Free) |
 | Datenbank | Supabase (PostgreSQL + Storage + Auth) | Free |
 | Voice | Retell AI (Dual-Agent DE/INTL) → Twilio SIP → Peoplefone | Pay-as-you-go |
-| Email | Resend (Transaktional) | Free |
+| Email | Resend (Transaktional, Domain: send.flowsight.ch) | Free |
+| SMS | eCall.ch Swiss Gateway (Business Account Typ A, CHF 40/Mo + Punkte) | Pay-as-you-go |
 | Monitoring | Sentry (Error Tracking + Alerts) | Free |
 | Ops Alerts | Telegram + E-Mail (primary), WhatsApp (optional) | GH Actions + Resend |
 
@@ -55,6 +56,7 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 
 ## Aktueller Stand
 
+- **Leitsystem Phase 1 (17.03.):** PRs #238-#256. Login High-End (OTP, Swiss Trust, warm-white). PWA Auto-Update-Prompt. Falldetail komplett: Status vereinfacht (kein Abgeschlossen), Wording Handwerkersprache (17 Dateien), Termin-Validierung (+15min), Multi-Select Staff, Inline Termin-Sende-Icon, Bewertungs-Flow, Layout 50/50, Mobile Overflow gefixt, einheitliche Pill-Badges.
 - **17 Module LIVE.** +1 Kunde: Jul. Weinberger AG (GTM Goldstandard). +1 Modul: Review Surface.
 - **50+ Commits seit 04.03.** (PRs #53–#128).
 - **Architecture Wave (10.03.):** PR #128. RLS Migration applied (tenant isolation at DB level). Tenant scoping in Dashboard + API (`resolveTenantScope.ts`). 3-Tier SMS Routing. Review Surface (Google-style). 15 Demo-Cases seeded (Weinberger). Architecture Document (22 Sections). 3-Modi GTM Logic. Ops Scripts (seed_demo_data, setup_rls_and_admin).

--- a/docs/architecture/zielarchitektur.md
+++ b/docs/architecture/zielarchitektur.md
@@ -1,8 +1,8 @@
 # FlowSight — Zielarchitektur (Business + Produkt + GTM)
 
-**Version:** 1.2 | **Datum:** 2026-03-11
+**Version:** 1.3 | **Datum:** 2026-03-17
 **Autor:** CC (Head Ops) + Founder-Input
-**Status:** v1.2 — D12 ELIMINATED (kein B-Quick, immer B-Full), D16 Trial Machine (11.03.)
+**Status:** v1.3 — D12 ELIMINATED, D16 Trial Machine, D9 OTP-Login (17.03.), eCall Business Account (17.03.)
 **Regel:** Dieses Dokument beschreibt die **Zielarchitektur**. Aktueller Stand → `docs/STATUS.md`. Tasks → `docs/ticketlist.md`.
 **Pfad:** `docs/architecture/zielarchitektur.md` (umgezogen von `docs/gtm/architecture_detail.md`)
 
@@ -20,7 +20,7 @@
 | D6 | Demo-Modi: 3 klar getrennte Welten (Internal/Prospect/Production) | **EMPFOHLEN** | Founder + CC | §8 |
 | D7 | Prospect Experience Layer als eigene Architekturschicht | **EMPFOHLEN** | Founder + CC | §8 |
 | D8 | Tenant-scoped Case List → **RLS** | **ENTSCHIEDEN** ✅ | Founder | §9, §15 |
-| D9 | Demo-Zugang → **Magic-Link via Supabase OTP** | **ENTSCHIEDEN** ✅ | Founder | §11 |
+| D9 | Login → **Custom OTP (6-Digit Code per E-Mail, server-side Session)** | **ENTSCHIEDEN** ✅ | Founder | §11 |
 | D10 | Demo-Dataset → **is_demo Boolean auf Cases** | **ENTSCHIEDEN** ✅ | Founder | §16 |
 | D11 | SMS-Zielrouting → **tenant.demo_sms_target** | **ENTSCHIEDEN** ✅ | Founder | §12 |
 | D12 | ~~G2 B-Quick Agent~~ → **ELIMINATED**. Immer B-Full. Jeder Prospect bekommt eigenen dedizierten Agent. | **ENTSCHIEDEN** ✅ | Founder | §5, operating_model |
@@ -489,8 +489,8 @@ TenantContext ist nicht "ein Feature" — es ist eine **Architekturachse**, die 
 
 #### SMS
 - **Rolle:** Brücke zwischen Voice und Korrektur. Einziger Post-Call-Kontakt zum Melder.
-- **Provider:** eCall.ch (Schweizer SMS-Gateway). Twilio = nur Voice/SIP, kein SMS.
-- **Sender-Logik (2-Tier):** (1) Alphanumerischer Sender pro Tenant (z.B. "Weinberger") — muss im eCall-Portal freigeschaltet sein. (2) Fallback: ECALL_SENDER_NUMBER (FlowSight-Servicenummer, global).
+- **Provider:** eCall.ch (Schweizer SMS-Gateway, Business Account Typ A, CHF 40/Mo + 1.2-1.7 Punkte/SMS, 160 Zeichen). Twilio = nur Voice/SIP, kein SMS.
+- **Sender-Logik (2-Tier):** (1) Alphanumerischer Sender pro Tenant (z.B. "Weinberger", max 11 Zeichen). (2) Fallback: ECALL_SENDER_NUMBER (FlowSight-Servicenummer, global).
 - **Qualitätsanspruch:** Muss von Firmenname kommen (alphanumeric sender). Muss Korrekturlink enthalten. Muss unter 160 Chars (~85 Chars aktuell). Muss auf Handy funktionieren.
 - **Typische Risiken:** Alphanumerischer Sender nicht im eCall-Portal freigeschaltet → 400 → Fallback auf Servicenummer. eCall-Env-Vars nicht gesetzt → SMS-Versand komplett blockiert.
 - **Zielzustand:** Melder erhält SMS innerhalb 10s nach Anruf. Korrekturlink funktioniert. Foto-Upload möglich. Absender = Firmenname (nach eCall-Freischaltung).
@@ -514,33 +514,34 @@ TenantContext ist nicht "ein Feature" — es ist eine **Architekturachse**, die 
 
 ---
 
-## 11. Demo-Zugang / Auth / Sessions
+## 11. Auth / Sessions (Custom OTP seit 17.03.)
+
+### Login-Architektur (Custom OTP)
+
+**Seit PRs #238-#240:** Custom OTP ersetzt Magic-Link. Kein Supabase Auth OTP (Rate Limits), sondern eigener Flow:
+1. User gibt E-Mail ein → `POST /api/ops/auth/send-code` → 6-Digit Code per E-Mail (Resend, Sender: noreply@send.flowsight.ch)
+2. User gibt Code ein → `POST /api/ops/auth/verify-code` → Server-side Session Cookie
+3. Session = httpOnly Cookie, kein JWT im Client. Supabase service-role für DB-Zugriffe.
+
+**Login-UI:** High-End (warm-white, gold CTA, Swiss Trust Footer mit Datenschutz + Impressum).
 
 ### Arten von Zugängen
 
 | Zugangsart | Wer | Wie | Was sichtbar | Schreibrechte |
 |------------|-----|-----|-------------|---------------|
-| **Founder-Login** | Founder | E-Mail + Passwort (Supabase Auth) | Alle Tenants, alle Cases | Voll |
-| **Kunden-Login** | Zahlender Kunde | E-Mail + Passwort, tenant_id in app_metadata | Nur eigener Tenant | Voll (eigene Cases) |
-| **Prospect Demo-Link** | Prospect | Magic-Link oder tokenisierte URL | Nur Demo-Tenant, Demo-Dataset | Read-Only + eigener Test-Call |
+| **Founder-Login** | Founder | OTP per E-Mail (6-Digit Code) | Alle Tenants, alle Cases | Voll |
+| **Kunden-Login** | Zahlender Kunde | OTP per E-Mail, tenant_id in DB | Nur eigener Tenant | Voll (eigene Cases) |
+| **Prospect Demo-Link** | Prospect | OTP per E-Mail (prospect_email aus Trial) | Nur Demo-Tenant, Demo-Dataset | Read-Only + eigener Test-Call |
 | **Review Surface** | Melder (Endkunde) | HMAC-Token in URL (/review/[caseId]?token=xxx) | Nur eine Review-Card | Keine (externer Link) |
 | **SMS Korrekturlink** | Melder (Endkunde) | HMAC-Token in URL (/v/[id]?t=xxx) | Nur ein Case (Korrektur) | Begrenzt (Korrekturfelder) |
 
-### Empfohlene Zielarchitektur für Prospect Demo-Link (D9)
+### Implementierte Auth-Architektur (seit 17.03.)
 
-**Option A: Magic-Link (empfohlen)**
-- Founder sendet Prospect eine URL: `flowsight.ch/demo/weinberger-ag?token=<signed>`
-- Token enthält: tenant_id, expires_at, permissions (read-only)
-- Prospect öffnet Link → sieht Dashboard mit Demo-Dataset + eigenen Test-Cases
-- Kein Passwort nötig. Kein Supabase-User nötig.
-- Ablauf nach 7 Tagen.
-
-**Option B: Temporärer Supabase-User**
-- Founder erstellt Prospect-Account mit read-only Rolle
-- Prospect loggt sich ein wie ein Kunde
-- Aufwändiger, aber natürlicher für "wie fühlt sich das System an"
-
-**Empfehlung:** Option A für MVP. Niedrigerer Aufwand, kein Account-Management, saubere Isolation. Option B erst wenn Kunden-Login ohnehin steht.
+**Custom OTP (implementiert):**
+- Prospect erhält Welcome-Mail mit Login-Link → `/ops` → gibt E-Mail ein → erhält 6-Digit Code → einloggen
+- Server-side Session Cookie (httpOnly, secure). Kein JWT im Client.
+- Tenant-Scope via prospect_email → tenants DB-Lookup
+- Kein Supabase Auth OTP (hatte Rate Limits bei 50+ Tenants). Eigener Code-Generierung + Resend-Versand.
 
 **Risiken beider Optionen:**
 - Token-Leak (Prospect teilt Link) → TTL + Single-Use mitigieren
@@ -570,14 +571,20 @@ Grund: Twilio-SMS via internationale Carrier verursachen Spam-Friktion bei Schwe
 └──────────────────────────────────────────────────┘
 ```
 
-### Sender-Logik (1-Tier, direkt)
+### Account & Kosten (seit 17.03.2026)
+
+**eCall Business Account Typ A** (aktiv):
+- Grundgebühr: CHF 40/Monat
+- SMS-Kosten: 1.2–1.7 Punkte pro SMS (160 Zeichen Limit)
+- Alphanumerischer Sender: max 11 Zeichen (z.B. "Weinberger", "BrunnerHT")
+
+### Sender-Logik (2-Tier)
 
 ```
-ECALL_SENDER_NUMBER = +41766012739 (FlowSight-Servicenummer)
-→ Immer als Absender verwendet (keine alphanumerische Sender-Registrierung nötig)
-→ Empfänger sieht: +41766012739 + Text "Weinberger: Ihre Meldung..."
-→ Firmenname steht im SMS-Text, nicht im Absender-Feld
-→ Skaliert: Ein Sender für alle Tenants, kein Setup pro Betrieb
+Tier 1: Alphanumerischer Sender pro Tenant (z.B. "Weinberger") — max 11 Zeichen
+Tier 2 (Fallback): ECALL_SENDER_NUMBER = +41766012739 (FlowSight-Servicenummer)
+→ Firmenname steht im SMS-Text UND im Absender-Feld (wenn Tier 1 aktiv)
+→ 160-Zeichen-Limit pro SMS (eCall Business Account)
 ```
 
 Bewusste Entscheidung (14.03.): Alphanumerische Sender (z.B. "Weinberger" als Absendername)
@@ -775,7 +782,7 @@ Seed-Script Logik:
 1. Input: tenant_id, tenant_slug, gewerk
 2. Generiere 15 Cases:
    - created_at: heute -1d bis heute -14d (verteilt)
-   - status: 8x done, 4x open, 3x in_progress
+   - status: 8x erledigt, 4x neu, 3x in_arbeit (Kette: Neu → Geplant → In Arbeit → Warten → Erledigt)
    - urgency: 3x emergency, 7x normal, 5x low
    - source: 8x voice, 5x wizard, 2x manual
    - category: gewerk-spezifisch (aus Prospect Card)

--- a/docs/business_briefing.md
+++ b/docs/business_briefing.md
@@ -2,7 +2,7 @@
 
 > Dieses Dokument ist der komplette Kontext für ChatGPT, Claude und externe Partner.
 > Copy-paste als System-Prompt oder ersten Message. Deckt Business, Produkt, Technik und Strategie ab.
-> Letzte Aktualisierung: 2026-03-11
+> Letzte Aktualisierung: 2026-03-17
 
 ---
 
@@ -88,12 +88,12 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 - **Template-System:** Agent-Configs als JSON-Schablone (~20 Min pro Kunde)
 
 ### 3.4 Ops Dashboard
-- Web-App unter /ops (Login via Supabase Auth)
+- Web-App unter /ops (Login via Custom OTP: 6-Digit Code per E-Mail, server-side Session, keine Supabase Rate Limits. Sender: noreply@send.flowsight.ch)
 - **Fallliste:** Alle Fälle mit Status, Quelle (voice/wizard/manual), Datum, seq_number (FS-XXXX)
 - **Filter:** Status, Quelle, Kategorie, Zeitraum, Tenant
 - **Fall-Detailansicht:** Kontaktdaten, Fallbeschreibung, Fotos, Timeline (case_events), Notizen
 - **Aktionen:** Status ändern, Termin senden (E-Mail an Melder), Review anfragen, manueller Fall erstellen
-- **KPI-Cards:** Click-to-Filter (Total→all, Neu→new, In Bearbeitung→default, Erledigt→done)
+- **KPI-Cards:** Click-to-Filter (Total→all, Neu→new, In Bearbeitung→default, Erledigt→done). Status-Kette: Neu → Geplant → In Arbeit → Warten → Erledigt (kein "Abgeschlossen")
 - **CSV-Export** für Buchhaltung/Reporting
 - **Light Theme**, Sidebar-Navigation, responsive
 
@@ -117,7 +117,7 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 - Provider: Resend (SPF/DKIM/DMARC verifiziert)
 
 ### 3.8 SMS Channel
-- Post-call SMS mit Korrekturlink an Melder (Twilio alphanumeric sender)
+- Post-call SMS mit Korrekturlink an Melder (eCall.ch Swiss Gateway, Business Account Typ A)
 - Kurzlink `/v/[caseId]?t=<16hex>` (~85 Zeichen), HMAC-gesichert
 - Foto-Upload via Verify-Seite (Supabase Storage)
 - Akzeptiert sowohl Full-Token (64-hex) als auch Short-Token (16-hex)
@@ -189,7 +189,7 @@ OUTPUT:
   → case_events Eintrag ("Benachrichtigung gesendet")
 
 NACH ERLEDIGUNG:
-  → Status → "resolved" (im Dashboard)
+  → Status → "Erledigt" (im Dashboard). Kette: Neu → Geplant → In Arbeit → Warten → Erledigt
   → Optional: Review-Anfrage per E-Mail
 ```
 
@@ -266,7 +266,7 @@ Phase 5: Delivery      → Nur bei Conversion (Vertrag, Portierung)
 ### Was der Prospect bekommt (Trial, 14 Tage)
 - **Eigene Schweizer Nummer** (Twilio Festnetz)
 - **Lisa (B-Full)** — personalisiert mit seinen Services, PLZ, Firmenname
-- **Dashboard** via Magic-Link (Prospect-View: Status + Review)
+- **Dashboard** via OTP-Login (6-Digit Code per E-Mail, Prospect-View: Status + Review)
 - **15 Demo-Cases** (realistische Schweizer Daten)
 - **SMS-Flow** (Post-Call Korrekturlink)
 - **Review-Surface** (Google-Style mit Firmenname)
@@ -274,7 +274,7 @@ Phase 5: Delivery      → Nur bei Conversion (Vertrag, Portierung)
 ### Trial-Timeline
 | Tag | Was |
 |-----|-----|
-| 0 | Trial Start + Welcome-Mail mit Magic-Link |
+| 0 | Trial Start + Welcome-Mail mit OTP-Login-Link |
 | 0-2 | **First-Call-Moment** (Pflicht) — Founder ruft Prospect-Nummer an |
 | 10 | **Follow-up** (Pflicht) — Founder ruft persönlich an |
 | 14 | **Decision Day** — Convert / Live-Dock / Offboard |


### PR DESCRIPTION
## Summary
- **STATUS.md:** Datum 17.03., Leitsystem Phase 1 bullet (PRs #238-#256), eCall SMS row in Tech Stack
- **business_briefing.md:** OTP login (replaces magic link refs), status chain (Neu→Geplant→In Arbeit→Warten→Erledigt), eCall SMS provider
- **zielarchitektur.md:** v1.3, Custom OTP auth architecture (§11 rewritten), eCall Business Account Typ A details (§12 + touchpoint SMS section), status seed data updated

## Test plan
- [ ] Verify STATUS.md date and new bullet render correctly
- [ ] Verify business_briefing.md auth + status references are consistent
- [ ] Verify zielarchitektur.md §11 and §12 reflect live system

🤖 Generated with [Claude Code](https://claude.com/claude-code)