### PR TITLE
fix: feedback round 3 — equal-height cards, overview bg, termin button

### DIFF
--- a/docs/redesign/leitstand/plan_Leitsystem.md
+++ b/docs/redesign/leitstand/plan_Leitsystem.md
@@ -1,6 +1,7 @@
 # Plan Leitsystem — High-End Umsetzung
 
 **Erstellt:** 2026-03-17
+**Letztes Update:** 2026-03-18 (Feedback-Runde 3 umgesetzt — F12-F14)
 **Owner:** Founder + CC
 **Nordstern:** `leitsystem_leitzentrale_super_high_end_plan.md`
 **Referenz:** `leitstand.md` (Grundvertrag), `leitstand_renovation.md` (Implementierungs-Brücke)
@@ -27,36 +28,73 @@ Jede Stufe ist sichtbar, steuerbar, abschliessbar. Die Bewertung (Google-Sterne)
 | **E1** | Status "Abgeschlossen" eliminiert. Nur: Neu → Geplant → In Arbeit → Warten → Erledigt | Einfacher. Erledigt = Arbeit getan. Danach optional Bewertung anfragen. |
 | **E2** | Leitzentrale + Fallübersicht = EINE Seite (nur 2 Nav-Punkte: Leitzentrale + Einstellungen) | Oben: Systemfluss-KPIs (klickbar). Unten: gefilterte Fallliste. Kein Hin-und-Her. |
 | **E3** | Notfälle NICHT separat, sondern integriert in Gesamtliste mit roter Prioritäts-Markierung | Kein eigener Banner, keine eigene Seite. Höchste Priorität = oben in der Liste. |
-| **E4** | Termin-Benachrichtigungen: EIN Button "Termin versenden" (an Kunde + Mitarbeiter). Erst sichtbar nach "Übernehmen". | Kein versehentliches Senden. Keine getrennten Buttons für Kunde/Mitarbeiter. |
+| **E4** | Termin-Sende-Icon nur nach Edit-Save sichtbar (30s Timeout). Sendet an Kunde + Mitarbeiter. | Kein versehentliches Senden. Papierflieger-Icon inline neben Termin-Badge. |
 | **E5** | SMS immer ≤ 160 Zeichen (eCall: ab 161 = doppelter Preis) | Kosten + Zustellbarkeit. Jedes Template wird auf 160 Zeichen geprüft. |
 | **E6** | Kalender-Sync nötig (Read-Only: Outlook/Google) beim Zuweisen | Keine Termin-Überschneidungen. Skalierbar für 2–30 MA. |
 | **E7** | "Zuständig" = Multi-Select-Dropdown aus Staff-Tabelle (nicht Freitext) | Grössere Projekte haben mehrere Mitarbeiter. |
 | **E8** | Bewertungs-Button erst sichtbar wenn Status = Erledigt | Logischer Fluss: Erst Arbeit, dann Lohn. |
-| **E9** | Beschreibung/Verlauf schmaler (ca. 1/3), Kontakt/Notizen/Anhänge breiter (ca. 2/3) | Übersicht zuerst, Details bei Bedarf. Klare Abgrenzung zum Scan-Kopf oben. |
+| **E9** | Layout aktuell 50/50 (Founder testet). Beschreibung/Verlauf links, Kontakt/Notizen rechts. | Feedback-Runde 2: 50/50 zum Testen deployed. Founder entscheidet ob final. |
 | **E10** | Verlauf-Struktur bleibt: Schritt 1 → nächster Schritt → komprimiert → letzter Schritt → Zieleinlauf (Bewertung) | Bewährt, logisch, platzsparend. |
+| **E11** | Übersicht-Bereich: weisser Hintergrund + Shadow + goldener Akzent-Balken links | Stärkste visuelle Präsenz für die wichtigste Area. Einheitliche Pill-Badges für alle 4 Werte. |
 
 ---
 
-## Umsetzungs-Plan: Bottom-Up in 4 Phasen
+## Session 17.03. — Was wurde gemacht
 
-### Phase 1: Der Fall (Basis)
+### Vor Phase 1: Login + PWA Fixes (PRs #238–#245)
+- **Login-Bug gefixt:** Session-Cookies server-side gesetzt (Re-Login nach Logout funktioniert)
+- **Spam-Fix:** E-Mail-Sender auf `send.flowsight.ch` (verifizierte Resend-Domain)
+- **Login High-End Redesign:** Brand-System-konform (warm-white, gold CTA, Signal Dot, Swiss Trust Footer)
+- **PWA Icon:** Signal Dot (goldener Punkt auf Navy), responsiv pro Grösse
+- **PWA Update-Prompt:** "Neue Version verfügbar" Banner für automatische Updates (kritisch für 50+ Betriebe)
+- **PWA Titel:** Nur "Leitsystem" (kein doppeltes "Leitsystem - Weinberger Leitsystem")
 
-> Ohne sauberes Falldetail macht die Leitzentrale keinen Sinn.
+### Phase 1: Der Fall — KOMPLETT (8/8 Tasks, PRs #246–#252)
 
-| # | Task | Detail | Priorität |
-|---|------|--------|-----------|
-| 1.1 | **Status vereinfachen** | "Abgeschlossen" entfernen. Status-Kette: Neu → Geplant → In Arbeit → Warten → Erledigt. Dropdown + Badges + Farben anpassen. | **DONE** (PR #246) |
-| 1.2 | **Termin-Validierung** | "Bis"-Zeitpunkt frühestens "Von" + 15min. Alles davor ausgegraut/nicht wählbar. Server-side Validierung zusätzlich. | **DONE** (PR #248) |
-| 1.3 | **"Zuständig" = Multi-Select aus Staff** | Freitext-Feld ersetzen durch Dropdown der aktiven Mitarbeiter (aus staff-Tabelle). Mehrfachauswahl möglich (Chips-UI). Bei Zuweisung: optionale E-Mail an zugewiesene(n) Mitarbeiter (gesteuert via Einstellungen). | hoch |
-| 1.4 | **Termin-Benachrichtigung neu** | Buttons "Meldenden benachrichtigen" + "Termin an Mitarbeiter senden" ELIMINIEREN. Stattdessen: Nach Termin-Eingabe → "Übernehmen" klicken → dann erscheint EIN Button "Termin versenden" → sendet an BEIDE (Kunde + zugewiesene Mitarbeiter). Bestätigung im Verlauf sichtbar, nicht als separater Status. | hoch |
-| 1.5 | **Layout-Rebalance Falldetail** | Links (Beschreibung + Verlauf): ca. 1/3 Breite. Rechts (Übersicht/Kontakt/Notizen/Anhänge): ca. 2/3 Breite. Beschreibung + Verlauf visuell aufwerten auf Niveau der rechten Sektionen (gleiche Card-Qualität, gleiche Typografie-Hierarchie). | mittel |
-| 1.6 | **Bewertungs-Flow** | "Bewertung anfragen"-Button nur sichtbar wenn Status = Erledigt. Verlauf zeigt den Fluss: Erstellt → ... → Erledigt → Bewertung angefragt → ★ Bewertung erhalten. Wenn Kunde nicht reagiert = egal, Fall bleibt "Erledigt". Kein Nachhaken-Zwang. | hoch |
-| 1.7 | **Wording-Sweep Falldetail** | Durchgehend Handwerkersprache: "Meldende/n" → "Kunde", "Dringlichkeit" → "Priorität", "Einsatz abgeschlossen" → "Arbeit erledigt", "Zuweisung" → "Vergabe", "Quelle" → "Herkunft". | **DONE** (PR #246, 17 Dateien, 30+ Edits) |
-| 1.8 | **Mobile Overflow fixen** | M8-Bug: Zahlen/Text gehen rechts aus dem Viewport raus. Responsive Checks auf allen Sektionen (Einstellungen, Falldetail, Termine). Truncation + Wrapping sicherstellen. | **DONE** (PR #248) |
+| # | Task | PR | Highlights |
+|---|------|----|------------|
+| 1.1 | Status vereinfachen | #246 | "Abgeschlossen" entfernt. Kette: Neu → Geplant → In Arbeit → Warten → Erledigt. |
+| 1.2 | Termin-Validierung | #248 | "Bis" frühestens "Von" + 15min. Ausgegraute Slots. Server-Validierung. |
+| 1.3 | Multi-Select Staff | #252 | Chips-UI mit Suchfilter + Initialen-Avatar. Diff-basierte E-Mail-Benachrichtigung. |
+| 1.4 | Termin-Benachrichtigung | #251 | 2 Buttons → 1 inline Papierflieger-Icon. -62 Zeilen netto. |
+| 1.5 | Layout-Rebalance | #250 | Card-wrapped Sections. Mobile: wichtige Info zuerst. |
+| 1.6 | Bewertungs-Flow | #251 | Nur bei Status=Erledigt. Labels: "Bewertung möglich", "Nicht anfragen". |
+| 1.7 | Wording-Sweep | #246 | 17 Dateien, 30+ Edits. Meldende→Kunde, Dringlichkeit→Priorität, etc. |
+| 1.8 | Mobile Overflow | #248 | overflow-x-hidden global, truncate, break-words, min-w-0. |
 
-**Definition of Done Phase 1:** Falldetail ist auf Desktop UND Mobile High-End. Jeder Handwerker versteht sofort: Was ist das Problem? Wo? Wer kümmert sich? Wann? Was ist der nächste Schritt?
+### Feedback-Runde 1 (PR #254) — nach Phase 1
+- F1+F2: "Termin versenden" von Standalone-Button zu inline Papierflieger-Icon neben Termin-Badge
+- F3: Layout getauscht (Beschreibung links gross, Kontakt rechts klein)
+- F4: Übergang Übersicht → Content geglättet (kein harter Border mehr)
+- F5: Einheitliche Pill-Badges für Status, Priorität, Zuständig, Termin
+- F6: Mobile-Reihenfolge: Beschreibung vor Notizen
+
+### Feedback-Runde 2 (PR #256) — Feinschliff
+- F7: Termin-Icon NUR sichtbar nach Edit-Save (terminJustSaved Gate, 30s Timeout)
+- F8: Übersicht visuell stärker (bg-white, shadow-sm, amber Akzent-Balken links)
+- F9: Notizen-Overflow gefixt (break-words + overflowWrap: anywhere)
+- F10: Trennlinien zwischen Right-Rail Cards entfernt
+- F11: Layout auf 50/50 gesetzt (Founder testet)
 
 ---
+
+### Feedback-Runde 3 (18.03.) — Layout + Übersicht + Termin
+
+- F12: Layout 50/50 bestätigt. Beschreibung + Kontakt Cards jetzt IMMER gleiche Höhe (CSS Grid statt Flex-Lanes).
+- F13: Amber Akzent-Balken links entfernt. Stattdessen: subtiler stone-to-white Gradient (konsistent in Read + Edit Mode).
+- F14: Termin-Papierflieger-Icon entfernt. Jetzt: voller "Termin versenden" Button unter dem KV-Grid nach Speichern. Mit Lade-State + Erfolgs-Indikator. Kein 30s-Timeout (persistent bis gesendet).
+
+---
+
+## Next Steps
+
+**Founder-Action:** F12-F14 auf Desktop + Mobile testen.
+
+**Danach:** Phase 2 (Kommunikation & SMS) starten.
+
+---
+
+## Umsetzungs-Plan: Verbleibende Phasen
 
 ### Phase 2: Kommunikation & SMS
 
@@ -70,38 +108,24 @@ Jede Stufe ist sichtbar, steuerbar, abschliessbar. Die Bewertung (Google-Sterne)
 | 2.4 | **eCall-Integration härten** | API-Anbindung verifizieren: Alphanumerischer Sender, Zeichenlimit-Enforcement (reject > 160), Zustellberichte auswerten. Kosten-Monitoring (1.2–1.7 Punkte pro SMS). | mittel |
 | 2.5 | **E-Mail-Templates audit** | Alle E-Mail-Templates auf Identity Contract prüfen: Sender = "{Firma} via FlowSight", kein FlowSight im Body, Handwerker-Wording, Responsive HTML. | mittel |
 
-**Definition of Done Phase 2:** Jede ausgehende Nachricht (SMS + E-Mail) hat einen klar definierten Trigger, Empfänger, Inhalt. Alles ≤ 160 Zeichen (SMS). Kein Spam. Matrix dokumentiert.
-
----
-
 ### Phase 3: Rollen & Einstellungen
-
-> Admin und Techniker haben klar getrennte Welten.
 
 | # | Task | Detail | Priorität |
 |---|------|--------|-----------|
-| 3.1 | **Rollen-Beschreibung verifizieren** | Info-Button-Text in Einstellungen auf Korrektheit prüfen. Stimmt die Beschreibung mit der tatsächlichen Implementierung überein? Abgleich Code ↔ Text. | hoch |
-| 3.2 | **Kalender-Konzept** | Read-Only Abfrage: Beim Termin-Setzen zeigen, ob Mitarbeiter frei/belegt ist. MVP: Google Calendar API (FreeBusy). Später: Outlook/Exchange. Skalierbar für 2–30 MA. Kein Schreib-Zugriff nötig (nur Lesen). | hoch |
-| 3.3 | **Einstellungen-UX aufwerten** | Toggles mit kontextbezogener Empfehlung ("Empfohlen für Betriebe ab 5 MA"). Mobile Overflow fixen (M8-Bug). Sections klar trennen mit visueller Hierarchie. | mittel |
-| 3.4 | **Techniker-Micro-Surface** | SMS-Link post-Zuweisung: `/einsatz/[token]` — Adresse, Problem, Navigation (1-Tap Maps), Status-Button ("Erledigt"), Foto-Upload. Kein Login, kein Account. HMAC-gesichert. | hoch (Post-Phase-1) |
-
-**Definition of Done Phase 3:** Jede Rolle hat genau die Rechte und Informationen, die sie braucht. Kalender-Konflikte werden beim Zuweisen sichtbar. Techniker brauchen keinen Login.
-
----
+| 3.1 | **Rollen-Beschreibung verifizieren** | Info-Button-Text in Einstellungen auf Korrektheit prüfen. Abgleich Code ↔ Text. | hoch |
+| 3.2 | **Kalender-Konzept** | Read-Only Abfrage (Google Calendar FreeBusy). Skalierbar für 2–30 MA. | hoch |
+| 3.3 | **Einstellungen-UX aufwerten** | Toggles mit kontextbezogener Empfehlung. Mobile-optimiert. | mittel |
+| 3.4 | **Techniker-Micro-Surface** | SMS-Link `/einsatz/[token]` — Adresse, Problem, Navi, Erledigt-Button, Foto. HMAC-gesichert. | hoch |
 
 ### Phase 4: Leitzentrale (merged)
 
-> Eine Seite zeigt den ganzen Systemfluss — von Eingang bis Bewertung.
-
 | # | Task | Detail | Priorität |
 |---|------|--------|-----------|
-| 4.1 | **Systemfluss-Karten** | ~6 Karten in logischer Reihenfolge: Eingang (Neu) → Bei uns (In Arbeit/Geplant) → Wartet (auf Rückmeldung) → Heute (Termine) → Erledigt → Bewertungen ★. Jede Karte = KPI-Zahl + Kurzinfo. | hoch |
-| 4.2 | **Click-to-Filter** | Klick auf Karte filtert die Fallliste darunter. Aktive Karte visuell hervorgehoben. "Alle" als Reset. | hoch |
-| 4.3 | **Notfälle integriert** | Rote Markierung in der Gesamtliste (Priorität = Notfall → rote Zeile/Badge). Kein separater Banner. Notfälle immer zuoberst sortiert. | hoch |
-| 4.4 | **Navigation reduzieren** | Nur 2 Punkte: Leitzentrale (Systemfluss + Fallliste) + Einstellungen. Sidebar vereinfachen. | mittel |
-| 4.5 | **Quiet High-End Ästhetik** | Nicht "Dashboard". Nicht "viele bunte Karten". Ruhig, klar, hierarchisch. Handlungsorientiert, nicht analytisch. Nordstern: `leitsystem_leitzentrale_super_high_end_plan.md` §11. | hoch |
-
-**Definition of Done Phase 4:** Ein Handwerker öffnet morgens die App und sieht in 3 Sekunden: Was ist neu? Was muss ich heute tun? Wo stehe ich insgesamt? Der Systemfluss von Eingang bis Bewertung ist auf einen Blick sichtbar.
+| 4.1 | **Systemfluss-Karten** | ~6 Karten: Eingang → Bei uns → Wartet → Heute → Erledigt → Bewertungen ★ | hoch |
+| 4.2 | **Click-to-Filter** | Klick auf Karte filtert Fallliste darunter | hoch |
+| 4.3 | **Notfälle integriert** | Rote Markierung, zuoberst sortiert | hoch |
+| 4.4 | **Navigation reduzieren** | Nur 2 Punkte: Leitzentrale + Einstellungen | mittel |
+| 4.5 | **Quiet High-End Ästhetik** | Ruhig, klar, hierarchisch, handlungsorientiert | hoch |
 
 ---
 
@@ -116,19 +140,17 @@ Jede Stufe ist sichtbar, steuerbar, abschliessbar. Die Bewertung (Google-Sterne)
 | Einsatzplan | Nicht nötig | Nice-to-have | Wichtig | Zwingend |
 | Bewertungen | Meister fragt persönlich | Systematisch per System | Systematisch per System | Systematisch per System |
 
-**Design-Regel:** Alles muss für 2 MA funktionieren (einfachster Fall). Features für 10+ MA dürfen die UX für 2 MA nicht verkomplizieren (progressive disclosure).
-
 ---
 
 ## SMS-Constraint (eCall)
 
 | Regel | Detail |
 |-------|--------|
-| **Max 160 Zeichen** | Ab 161 = 2 SMS = doppelter Preis (2.4–3.4 Punkte statt 1.2–1.7) |
-| **Sender** | Alphanumerisch (max 11 Zeichen): z.B. "Weinberger", "BrunnerHT" |
-| **Fallback** | Wenn Firmenname > 11 Zeichen → eCall-Servicenummer als Sender |
-| **Kosten** | CHF 0.096–0.136 pro SMS (Swisscom/Sunrise vs. Salt) |
-| **API** | REST + HTTPS, bereits integriert via `sendSmsEcall.ts` |
+| **Max 160 Zeichen** | Ab 161 = 2 SMS = doppelter Preis |
+| **Sender** | Alphanumerisch (max 11 Zeichen) |
+| **Kosten** | CHF 0.096–0.136 pro SMS |
+| **API** | REST + HTTPS via `sendSmsEcall.ts` |
+| **Vertrag** | Business Account Typ A, CHF 40/Monat Basis + Punkte |
 
 ---
 
@@ -136,36 +158,11 @@ Jede Stufe ist sichtbar, steuerbar, abschliessbar. Die Bewertung (Google-Sterne)
 
 | Idee | Warum geparkt |
 |------|---------------|
-| Tages-Briefing SMS (07:00) | Gute Idee, aber erst wenn Basis steht |
+| Tages-Briefing SMS (07:00) | Gute Idee, erst wenn Basis steht |
 | Einsatz-SMS an Techniker | Abhängig von Micro-Surface (Phase 3.4) |
 | Einsatzplan als 3. Nav-Punkt | Erst ab Kunde 5+ relevant |
 | Offline-Cache für Falldaten | PWA-Shell steht, Daten-Cache = Phase 5 |
 | Wochenübersicht (30 MA) | Erst nach Einsatzplan-Grundlage |
-
----
-
-## Reihenfolge der Umsetzung
-
-```
-Phase 1: Der Fall ← JETZT
-  └── 1.1 Status vereinfachen
-  └── 1.2 Termin-Validierung
-  └── 1.3 Zuständig = Multi-Select Staff
-  └── 1.4 Termin-Benachrichtigung (1 Button)
-  └── 1.5 Layout-Rebalance (1/3 : 2/3)
-  └── 1.6 Bewertungs-Flow
-  └── 1.7 Wording-Sweep
-  └── 1.8 Mobile Overflow fixen
-
-Phase 2: Kommunikation ← nach Phase 1
-  └── 2.1–2.5
-
-Phase 3: Rollen & Einstellungen ← parallel möglich
-  └── 3.1–3.4
-
-Phase 4: Leitzentrale ← wenn Basis steht
-  └── 4.1–4.5
-```
 
 ---
 
@@ -179,3 +176,5 @@ Phase 4: Leitzentrale ← wenn Basis steht
 | `identity_contract.md` | Branding-Regeln (R1–R7, FlowSight unsichtbar) |
 | `brand_system.md` | Farben, Typografie, Logo (Signal Dot) |
 | `case_contract.md` | Datenmodell (Pflichtfelder, Lifecycle) |
+| `docs/gtm/gold_contact.md` | GTM Nordstern (5-Stufen-Kaufpsychologie, 7 WOW-Momente) |
+| `docs/gtm/operating_model.md` | Trial-Lifecycle (14 Tage, 5 Phasen) |

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -300,16 +300,17 @@ export function CaseDetailForm({
   }
 
   async function saveSteuerung() {
-    await saveFields({
+    const ok = await saveFields({
       status, urgency,
       assignee_text: assigneeText || null,
       scheduled_at: scheduledAt || null,
       scheduled_end_at: scheduledEndAt || null,
     });
-    // F7: Show termin send icon only after saving a termin
-    if (scheduledAt) {
+    // Show "Termin versenden" button after saving (persistent until sent)
+    if (ok && scheduledAt) {
       setTerminJustSaved(true);
-      setTimeout(() => setTerminJustSaved(false), 30_000);
+      setTerminSentForCurrent(false);
+      setTerminSendState("idle");
     }
   }
 
@@ -470,7 +471,7 @@ export function CaseDetailForm({
       {/* ── ÜBERSICHT (full width top band) ─────────────────────── */}
       <div className={sectionPad}>
         {editingSection === "steuerung" ? (
-          <div className="bg-gray-50 -mx-5 -my-4 px-5 py-4 rounded-t-2xl">
+          <div className="bg-gradient-to-b from-stone-50/80 to-gray-50/50 -mx-5 -my-4 px-5 py-4 rounded-t-2xl">
             <SectionHead title="Übersicht" editing onClose={cancelEdit} />
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 mb-3">
               <div>
@@ -541,7 +542,7 @@ export function CaseDetailForm({
             />
           </div>
         ) : (
-          <div className="bg-white shadow-sm border-l-4 border-l-amber-400 -mx-5 -my-4 px-6 py-5 rounded-t-2xl">
+          <div className="bg-gradient-to-b from-stone-50/80 to-white -mx-5 -my-4 px-6 py-5 rounded-t-2xl">
             <SectionHead title="Übersicht" onEdit={() => startEdit("steuerung")} canEdit={canEditSection("steuerung")} />
             <div className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 min-w-0">
               <KV label="Status">
@@ -571,38 +572,53 @@ export function CaseDetailForm({
               </KV>
               <KV label="Termin">
                 {scheduledAt ? (
-                  <div className="flex items-center gap-2">
-                    <span className="inline-block px-2.5 py-0.5 rounded-full bg-gray-100 text-sm font-medium text-gray-700">{formatTerminRange(scheduledAt, scheduledEndAt || null)}</span>
-                    {scheduledAt && terminJustSaved && !terminSentForCurrent && terminSendState !== "sent" && (
-                      <button
-                        onClick={handleSendTermin}
-                        disabled={terminSendState === "sending"}
-                        className="w-7 h-7 rounded-full text-gray-400 hover:text-gray-700 hover:bg-gray-200 transition-colors print:hidden inline-flex items-center justify-center flex-shrink-0"
-                        title="Termin versenden"
-                      >
-                        {terminSendState === "sending" ? (
-                          <svg className="animate-spin w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                          </svg>
-                        ) : (
-                          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
-                          </svg>
-                        )}
-                      </button>
-                    )}
-                    {(terminSentForCurrent || terminSendState === "sent") && (
-                      <svg className="w-5 h-5 text-emerald-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-                      </svg>
-                    )}
-                  </div>
+                  <span className="inline-block px-2.5 py-0.5 rounded-full bg-gray-100 text-sm font-medium text-gray-700">{formatTerminRange(scheduledAt, scheduledEndAt || null)}</span>
                 ) : (
                   <span className="inline-block px-2.5 py-0.5 rounded-full bg-gray-100 text-sm font-medium text-gray-500">Offen</span>
                 )}
               </KV>
             </div>
+
+            {/* Termin versenden — appears after save */}
+            {scheduledAt && terminJustSaved && !terminSentForCurrent && terminSendState !== "sent" && (
+              <div className="flex justify-end mt-4 print:hidden">
+                <button
+                  onClick={handleSendTermin}
+                  disabled={terminSendState === "sending"}
+                  className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-gray-800 disabled:opacity-60 transition-colors"
+                >
+                  {terminSendState === "sending" ? (
+                    <>
+                      <svg className="animate-spin w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                      </svg>
+                      <span>Wird versendet…</span>
+                    </>
+                  ) : (
+                    <>
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
+                      </svg>
+                      <span>Termin versenden</span>
+                    </>
+                  )}
+                </button>
+              </div>
+            )}
+            {scheduledAt && (terminSentForCurrent || terminSendState === "sent") && (
+              <div className="flex items-center justify-end gap-2 mt-3 print:hidden">
+                <svg className="w-5 h-5 text-emerald-600" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
+                <span className="text-sm text-emerald-700 font-medium">Termin versendet</span>
+              </div>
+            )}
+            {terminSendState === "error" && (
+              <div className="flex items-center justify-end gap-2 mt-3 print:hidden">
+                <span className="text-sm text-red-600 font-medium">Versand fehlgeschlagen — bitte erneut versuchen</span>
+              </div>
+            )}
 
             {/* Save state feedback */}
             {(saveState === "saved" || saveState === "error") && (
@@ -616,14 +632,15 @@ export function CaseDetailForm({
       </div>
 
       {/* ── 2-LANE BODY ──────────────────────────────────────────── */}
-      <div className="flex flex-col md:flex-row print:block">
+      {/* ── BODY ──────────────────────────────────────────────── */}
+      <div className="p-3 space-y-3 print:block">
 
-        {/* ── LEFT LANE: Beschreibung + Verlauf ──────────────────── */}
-        <div className="md:w-1/2 min-w-0 md:border-r md:border-gray-100/60 p-3 space-y-3">
+        {/* ── Row 1: Beschreibung + Kontakt (equal height) ───────── */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {/* Beschreibung card */}
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 flex flex-col">
             {editingSection === "beschreibung" ? (
-              <div className="bg-gray-50 -m-4 p-4 rounded-xl">
+              <div className="bg-gray-50 -m-4 p-4 rounded-xl flex-1">
                 <SectionHead title="Beschreibung" editing onClose={cancelEdit} />
                 <div className="space-y-3">
                   <div><label className={lbl}>Kategorie</label><input type="text" value={category} onChange={e => setCategory(e.target.value)} className={inp} /></div>
@@ -632,11 +649,11 @@ export function CaseDetailForm({
                 <EditActions onSave={saveBeschreibung} onCancel={cancelEdit} saving={saveState === "saving"} dirty={beschreibungDirty} error={saveState === "error" ? errorMsg : ""} />
               </div>
             ) : (
-              <>
+              <div className="flex-1 flex flex-col">
                 <SectionHead title="Beschreibung" onEdit={() => startEdit("beschreibung")} canEdit={canEditSection("beschreibung")} />
                 <p className="text-sm font-semibold text-gray-800 mb-2">{category}</p>
                 {description ? (
-                  <div className="overflow-hidden">
+                  <div className="overflow-hidden flex-1">
                     <p className={`text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-words ${!descExpanded ? "line-clamp-2 sm:line-clamp-3" : ""}`}>{description}</p>
                     {(description.split("\n").length > 3 || description.length > 200) && (
                       <button onClick={() => setDescExpanded(p => !p)}
@@ -646,42 +663,16 @@ export function CaseDetailForm({
                     )}
                   </div>
                 ) : (
-                  <p className="text-sm text-gray-400">—</p>
+                  <p className="text-sm text-gray-400 flex-1">—</p>
                 )}
-              </>
+              </div>
             )}
           </div>
 
-          {/* Verlauf + Bewertung card */}
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-            <h3 className={`${sectionTitle} mb-3`}>Verlauf</h3>
-            <CompactTimeline
-              events={localEvents}
-              status={status}
-              expanded={timelineExpanded}
-              onToggle={() => setTimelineExpanded(p => !p)}
-            />
-            <BewertungEndCap
-              status={status}
-              reviewInfo={reviewInfo}
-              canRequestReview={canRequestReview}
-              reviewState={reviewState}
-              reviewMsg={reviewMsg}
-              onRequest={handleRequestReview}
-              onSkip={handleSkipReview}
-              brandColor={brandColor}
-              hasEvents={localEvents.length > 0}
-            />
-          </div>
-        </div>
-
-        {/* ── RIGHT RAIL: Kontakt + Notizen + Anhänge ────────────── */}
-        <div className="md:w-1/2 bg-gray-50/40 md:rounded-br-2xl p-3 space-y-3 print:bg-white min-w-0 overflow-hidden">
-
-          {/* Kontakt mini-card */}
-          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+          {/* Kontakt card */}
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 flex flex-col">
             {editingSection === "kontakt" ? (
-              <>
+              <div className="flex-1">
                 <SectionHead title="Kontakt" editing onClose={cancelEdit} />
                 <div className="space-y-3">
                   <div><label className={lbl}>Kunde</label><input type="text" value={reporterName} onChange={e => setReporterName(e.target.value)} placeholder="Hans Müller" className={inp} /></div>
@@ -697,11 +688,11 @@ export function CaseDetailForm({
                   </div>
                 </div>
                 <EditActions onSave={saveKontakt} onCancel={cancelEdit} saving={saveState === "saving"} dirty={kontaktDirty} error={saveState === "error" ? errorMsg : ""} />
-              </>
+              </div>
             ) : (
-              <>
+              <div className="flex-1 flex flex-col">
                 <SectionHead title="Kontakt" onEdit={() => startEdit("kontakt")} canEdit={canEditSection("kontakt")} />
-                <div className="space-y-1 text-sm">
+                <div className="space-y-1 text-sm flex-1">
                   {reporterName && <p className="font-medium text-gray-900">{reporterName}</p>}
                   {contactPhone && (
                     <a href={`tel:${contactPhone}`} className="block text-blue-600 hover:underline min-h-[44px] sm:min-h-0 flex items-center">{contactPhone}</a>
@@ -726,44 +717,72 @@ export function CaseDetailForm({
                     </a>
                   </div>
                 </div>
-              </>
+              </div>
             )}
           </div>
+        </div>
 
-          {/* Interne Notizen mini-card */}
+        {/* ── Row 2: Verlauf + Notizen/Anhänge ───────────────────── */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {/* Verlauf + Bewertung card */}
           <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-            {editingSection === "notizen" ? (
-              <>
-                <SectionHead title="Interne Notizen" editing onClose={cancelEdit} />
-                <textarea rows={4} value={internalNotes} onChange={e => setInternalNotes(e.target.value)} placeholder="Nur intern sichtbar…" className={`${inp} max-h-40 overflow-y-auto`} />
-                <EditActions onSave={saveNotizen} onCancel={cancelEdit} saving={saveState === "saving"} dirty={notizenDirty} error={saveState === "error" ? errorMsg : ""} />
-              </>
-            ) : (
-              <>
-                <SectionHead title="Interne Notizen" onEdit={() => startEdit("notizen")} canEdit={canEditSection("notizen")} />
-                {internalNotes ? (
-                  <div>
-                    <p className={`text-sm text-gray-600 whitespace-pre-wrap break-words ${!notesExpanded ? "line-clamp-2" : ""}`} style={{ overflowWrap: "anywhere" }}>{internalNotes}</p>
-                    {(internalNotes.includes("\n") || internalNotes.length > 80) && (
-                      <button onClick={() => setNotesExpanded(p => !p)}
-                        className="text-xs text-gray-400 hover:text-gray-600 mt-1 transition-colors min-h-[44px] sm:min-h-0 flex items-center">
-                        {notesExpanded ? "Weniger" : "Alles anzeigen"}
-                      </button>
-                    )}
-                  </div>
-                ) : (
-                  <p className="text-sm text-gray-400">Keine Notizen</p>
-                )}
-              </>
-            )}
+            <h3 className={`${sectionTitle} mb-3`}>Verlauf</h3>
+            <CompactTimeline
+              events={localEvents}
+              status={status}
+              expanded={timelineExpanded}
+              onToggle={() => setTimelineExpanded(p => !p)}
+            />
+            <BewertungEndCap
+              status={status}
+              reviewInfo={reviewInfo}
+              canRequestReview={canRequestReview}
+              reviewState={reviewState}
+              reviewMsg={reviewMsg}
+              onRequest={handleRequestReview}
+              onSkip={handleSkipReview}
+              brandColor={brandColor}
+              hasEvents={localEvents.length > 0}
+            />
           </div>
 
-          {/* Anhänge mini-card */}
-          {!isProspect && (
+          {/* Notizen + Anhänge */}
+          <div className="space-y-3">
+            {/* Interne Notizen card */}
             <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-              <AttachmentsSection caseId={initialData.id} />
+              {editingSection === "notizen" ? (
+                <>
+                  <SectionHead title="Interne Notizen" editing onClose={cancelEdit} />
+                  <textarea rows={4} value={internalNotes} onChange={e => setInternalNotes(e.target.value)} placeholder="Nur intern sichtbar…" className={`${inp} max-h-40 overflow-y-auto`} />
+                  <EditActions onSave={saveNotizen} onCancel={cancelEdit} saving={saveState === "saving"} dirty={notizenDirty} error={saveState === "error" ? errorMsg : ""} />
+                </>
+              ) : (
+                <>
+                  <SectionHead title="Interne Notizen" onEdit={() => startEdit("notizen")} canEdit={canEditSection("notizen")} />
+                  {internalNotes ? (
+                    <div>
+                      <p className={`text-sm text-gray-600 whitespace-pre-wrap break-words ${!notesExpanded ? "line-clamp-2" : ""}`} style={{ overflowWrap: "anywhere" }}>{internalNotes}</p>
+                      {(internalNotes.includes("\n") || internalNotes.length > 80) && (
+                        <button onClick={() => setNotesExpanded(p => !p)}
+                          className="text-xs text-gray-400 hover:text-gray-600 mt-1 transition-colors min-h-[44px] sm:min-h-0 flex items-center">
+                          {notesExpanded ? "Weniger" : "Alles anzeigen"}
+                        </button>
+                      )}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-400">Keine Notizen</p>
+                  )}
+                </>
+              )}
             </div>
-          )}
+
+            {/* Anhänge card */}
+            {!isProspect && (
+              <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+                <AttachmentsSection caseId={initialData.id} />
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **F12:** Beschreibung + Kontakt Cards immer gleiche Höhe (CSS Grid statt Flex-Lanes)
- **F13:** Amber Akzent-Balken links entfernt → subtiler stone-to-white Gradient (konsistent Read + Edit)
- **F14:** Papierflieger-Icon → voller "Termin versenden" Button unter KV-Grid (persistent, mit Lade-State + Erfolg)

## Test plan
- [ ] Desktop: Falldetail öffnen — Beschreibung + Kontakt gleiche Höhe?
- [ ] Desktop: Übersicht — kein amber Balken mehr, subtiler Hintergrund?
- [ ] Desktop: Übersicht bearbeiten — gleicher Hintergrund in Edit-Mode?
- [ ] Desktop: Termin setzen + Speichern → "Termin versenden" Button erscheint?
- [ ] Desktop: Button klicken → Lade-Animation → Erfolg (Checkmark + Text)?
- [ ] Mobile: Layout stacked, Cards volle Breite?

🤖 Generated with [Claude Code](https://claude.com/claude-code)