### PR TITLE
fix: P2.1 SMS ≤160 chars + P2.2 termin SMS fallback for voice cases

### DIFF
--- a/src/web/app/api/ops/cases/[id]/notify-melder/route.ts
+++ b/src/web/app/api/ops/cases/[id]/notify-melder/route.ts
@@ -87,7 +87,10 @@ export async function POST(
   }
 
   // ── Send SMS ──────────────────────────────────────────────────────────
-  if (row.contact_phone && smsEnabled && modules.notify_termin_sms !== false) {
+  // If no email was sent (e.g. voice cases without email), SMS is the primary channel
+  // and should send even without the general sms module flag.
+  const smsAsPrimary = !emailSent && !!row.contact_phone;
+  if (row.contact_phone && (smsAsPrimary || (smsEnabled && modules.notify_termin_sms !== false))) {
     const start = new Date(row.scheduled_at);
     const day = start.toLocaleDateString("de-CH", { weekday: "short", timeZone: "Europe/Zurich" }).replace(/\.$/, "");
     const date = start.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", timeZone: "Europe/Zurich" });

--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -156,14 +156,8 @@ export async function POST(
     channel = "sms";
     const smsConfig = await getTenantSmsConfig(row.tenant_id);
     const senderName = smsConfig?.senderName ?? "FlowSight";
-    const smsBody = [
-      `${senderName}: Wie war unser Service?`,
-      ``,
-      `Wir hoffen, Sie waren zufrieden. Über eine kurze Bewertung würden wir uns sehr freuen:`,
-      reviewSurfaceUrl,
-      ``,
-      `Vielen Dank für Ihr Vertrauen — Ihr Service-Team`,
-    ].join("\n");
+    // ≤ 160 chars: warm, direct, professional
+    const smsBody = `${senderName}: Wie war unser Service? Wir freuen uns über Ihre Bewertung:\n${reviewSurfaceUrl}`;
     const smsResult = await sendSms(row.contact_phone, smsBody, senderName);
     sent = smsResult.sent;
   }

--- a/src/web/src/lib/sms/postCallSms.ts
+++ b/src/web/src/lib/sms/postCallSms.ts
@@ -41,25 +41,8 @@ export async function sendPostCallSms(
     ? `${p.street}${p.houseNumber ? ` ${p.houseNumber}` : ""}, ${p.plz} ${p.city}`
     : `${p.plz} ${p.city}`;
 
-  const lines: string[] = [
-    `${p.smsSenderName}: Ihre Meldung (${p.category}) wurde aufgenommen.`,
-    ``,
-  ];
+  // ≤ 160 chars: compact but professional. Correction link is the key element.
+  const body = `${p.smsSenderName}: Meldung ${p.category} erfasst. Daten prüfen & Fotos ergänzen:\n${correctionUrl}`;
 
-  if (p.reporterName) {
-    lines.push(`Name: ${p.reporterName}`);
-  }
-  lines.push(`Adresse: ${addressLine}`);
-  lines.push(``);
-
-  if (!hasStreet || !p.reporterName) {
-    lines.push(`Bitte prüfen und ggf. ergänzen:`);
-  } else {
-    lines.push(`Stimmt alles? Fotos helfen uns:`);
-  }
-  lines.push(correctionUrl);
-  lines.push(``);
-  lines.push(`Ihr Service-Team meldet sich schnellstmöglich.`);
-
-  return sendSms(p.callerPhone, lines.join("\n"), p.smsSenderName);
+  return sendSms(p.callerPhone, body, p.smsSenderName);
 }


### PR DESCRIPTION
## Summary
- **P2.1a:** Post-Call SMS: ~251 → ~120 Chars (Name/Adresse-Echo entfernt, Korrekturlink bleibt)
- **P2.1b:** Review-SMS: ~268 → ~100 Chars (kompakt, warm, professionell)
- **P2.2:** Termin-SMS als Primärkanal bei Voice-Fällen ohne E-Mail (FB10)

Alle 4 SMS-Templates passen jetzt in **eine einzelne SMS** (≤ 160 Zeichen = halbe Kosten).

## Test plan
- [ ] Voice-Fall erstellen → Post-Call SMS prüfen (kurz, mit Korrekturlink)
- [ ] Wizard-Fall erstellen → Post-Call SMS prüfen
- [ ] Fall ohne E-Mail (Voice) → Termin setzen + versenden → SMS muss ankommen
- [ ] Fall mit E-Mail → Termin versenden → E-Mail + SMS
- [ ] Review anfragen (nur Telefon) → SMS mit kurzem Text
- [ ] Zeichenzählung: alle SMS < 160 Chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)