### PR TITLE
fix: SMS templates — precise wording for max functionality

### DIFF
--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -156,8 +156,8 @@ export async function POST(
     channel = "sms";
     const smsConfig = await getTenantSmsConfig(row.tenant_id);
     const senderName = smsConfig?.senderName ?? "FlowSight";
-    // ≤ 160 chars: warm, direct, professional
-    const smsBody = `${senderName}: Wie war unser Service? Wir freuen uns über Ihre Bewertung:\n${reviewSurfaceUrl}`;
+    // ≤ 160 chars: personal thanks + clear CTA
+    const smsBody = `${senderName}: Vielen Dank für Ihr Vertrauen. Über eine kurze Bewertung freuen wir uns:\n${reviewSurfaceUrl}`;
     const smsResult = await sendSms(row.contact_phone, smsBody, senderName);
     sent = smsResult.sent;
   }

--- a/src/web/src/lib/sms/postCallSms.ts
+++ b/src/web/src/lib/sms/postCallSms.ts
@@ -35,14 +35,8 @@ export async function sendPostCallSms(
   const caseRef = `${p.caseIdPrefix}-${p.seqNumber}`;
   const correctionUrl = `${baseUrl}/v/${caseRef}?t=${shortToken}`;
 
-  const hasStreet = p.street && p.street.length > 0;
-
-  const addressLine = hasStreet
-    ? `${p.street}${p.houseNumber ? ` ${p.houseNumber}` : ""}, ${p.plz} ${p.city}`
-    : `${p.plz} ${p.city}`;
-
-  // ≤ 160 chars: compact but professional. Correction link is the key element.
-  const body = `${p.smsSenderName}: Meldung ${p.category} erfasst. Daten prüfen & Fotos ergänzen:\n${correctionUrl}`;
+  // ≤ 160 chars: explicit about what the customer can do (correct voice-agent errors + upload photos)
+  const body = `${p.smsSenderName}: Ihre Meldung ${p.category} wurde erfasst. Bitte Name & Adresse prüfen und Fotos hochladen:\n${correctionUrl}`;
 
   return sendSms(p.callerPhone, body, p.smsSenderName);
 }


### PR DESCRIPTION
## Summary
- **Post-Call SMS:** Explizit "Name & Adresse prüfen und Fotos hochladen" (Voice-Agent-Fehler korrigieren)
- **Review SMS:** Persönlicher Dank + klarer CTA statt generisch
- **Termin + Reminder:** Unverändert (bereits optimal)
- Cleanup: ungenutzte Variablen entfernt

## Alle 4 SMS-Templates final

| Template | Text | ~Chars |
|----------|------|--------|
| **Post-Call** | `{Firma}: Ihre Meldung {Kat} wurde erfasst. Bitte Name & Adresse prüfen und Fotos hochladen: {URL}` | ~130 |
| **Termin** | `{Firma}: Ihr Termin am {Tag} {Datum}, {Zeit}–{Ende}. Bei Fragen: {Tel}.` | ~81 |
| **Review** | `{Firma}: Vielen Dank für Ihr Vertrauen. Über eine kurze Bewertung freuen wir uns: {URL}` | ~110 |
| **24h Reminder** | `{Firma}: Erinnerung — Ihr Termin morgen {Tag} {Datum}, {Zeit}–{Ende}. Bei Fragen: {Tel}.` | ~100 |

## Test plan
- [ ] Voice-Testanruf → SMS mit "Name & Adresse prüfen und Fotos hochladen"
- [ ] Korrekturlink öffnen → Name/Adresse editierbar + Foto-Upload
- [ ] Review anfragen (nur Telefon) → SMS mit "Vielen Dank für Ihr Vertrauen"

🤖 Generated with [Claude Code](https://claude.com/claude-code)