### PR TITLE
fix: P2.3 channel hints + P2.4 email wording audit

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -615,7 +615,7 @@ export function CaseDetailForm({
                 </button>
 
                 {/* Termin versenden — sofort bei Änderung */}
-                {liveTerminChanged && terminSendState !== "sent" && (
+                {liveTerminChanged && terminSendState !== "sent" && (contactEmail.trim() || contactPhone.trim()) && (
                   <button
                     onClick={handleSaveAndSendTermin}
                     disabled={terminSendState === "sending"}
@@ -638,6 +638,23 @@ export function CaseDetailForm({
                       </>
                     )}
                   </button>
+                )}
+                {/* Channel hint: what channel will be used for customer notification */}
+                {liveTerminChanged && terminSendState === "idle" && (
+                  <p className="text-xs text-gray-500 mt-1">
+                    {!contactEmail.trim() && !contactPhone.trim()
+                      ? "Keine Kontaktdaten — Kunde wird nicht benachrichtigt"
+                      : !contactEmail.trim()
+                        ? "Kunde wird per SMS benachrichtigt"
+                        : contactPhone.trim()
+                          ? "Kunde wird per E-Mail + SMS benachrichtigt"
+                          : "Kunde wird per E-Mail benachrichtigt"
+                    }
+                  </p>
+                )}
+                {/* No contact warning — shown instead of button */}
+                {liveTerminChanged && !contactEmail.trim() && !contactPhone.trim() && terminSendState !== "sent" && (
+                  <p className="text-xs text-amber-600 mt-1 font-medium">Termin wird nur an Zuständige gesendet</p>
                 )}
                 {terminSendState === "sent" && (
                   <div className="flex items-center gap-1.5 mt-2">

--- a/src/web/src/lib/email/resend.ts
+++ b/src/web/src/lib/email/resend.ts
@@ -148,7 +148,7 @@ function buildOpsNotificationHtml(p: CaseEmailPayload, deepLink: string): string
 </td></tr>
 <!-- CTA button -->
 <tr><td style="padding:24px 24px 8px" align="center">
-  <a href="${escapeHtml(deepLink)}" target="_blank" style="display:inline-block;background:#d4a853;color:#0b1120;font-size:15px;font-weight:700;text-decoration:none;padding:12px 32px;border-radius:6px">Fall im Dashboard &ouml;ffnen</a>
+  <a href="${escapeHtml(deepLink)}" target="_blank" style="display:inline-block;background:#d4a853;color:#0b1120;font-size:15px;font-weight:700;text-decoration:none;padding:12px 32px;border-radius:6px">Fall im Leitstand &ouml;ffnen</a>
 </td></tr>
 <!-- Footer -->
 <tr><td style="padding:20px 24px;border-top:1px solid #1e293b;margin-top:16px">
@@ -871,7 +871,7 @@ interface AppointmentEmailPayload {
 }
 
 export async function sendAppointmentIcsEmail(payload: AppointmentEmailPayload): Promise<boolean> {
-  const from = `${payload.tenantDisplayName ?? "Leitstand"} <${process.env.RESEND_FROM ?? "noreply@flowsight.ch"}>`;
+  const from = `${payload.tenantDisplayName ?? "Ihr Servicebetrieb"} <${process.env.RESEND_FROM ?? "noreply@flowsight.ch"}>`;
   const recipientEmail = payload.staffEmail || process.env.MAIL_REPLY_TO;
   if (!recipientEmail) return false;
 


### PR DESCRIPTION
## Summary
- **P2.3:** Kanal-Hinweis unter Termin-Button: zeigt ob E-Mail, SMS, beides oder nichts
- **P2.4:** E-Mail-Audit: "Dashboard" → "Leitstand", ICS Sender-Fallback korrigiert

## Test plan
- [ ] Fall ohne E-Mail (Voice) → Termin ändern → Hinweis "per SMS benachrichtigt"
- [ ] Fall mit E-Mail + Telefon → Hinweis "per E-Mail + SMS"
- [ ] Fall ohne Kontaktdaten → Amber-Warnung + kein Button
- [ ] Fall-Notification E-Mail → CTA Button zeigt "Leitstand" (nicht "Dashboard")

🤖 Generated with [Claude Code](https://claude.com/claude-code)