### PR TITLE
feat: P3.3 settings — Termine section + plan update

### DIFF
--- a/docs/redesign/leitstand/plan_Leitsystem.md
+++ b/docs/redesign/leitstand/plan_Leitsystem.md
@@ -78,44 +78,57 @@ Jede Stufe ist sichtbar, steuerbar, abschliessbar. Die Bewertung (Google-Sterne)
 
 ---
 
-### Feedback-Runde 3 (18.03.) — Layout + Übersicht + Termin
+### Feedback-Runde 3 (18.03.) — Layout + Übersicht + Termin + Benachrichtigungen
 
-- F12: Layout 50/50 bestätigt. Beschreibung + Kontakt Cards jetzt IMMER gleiche Höhe (CSS Grid statt Flex-Lanes).
-- F13: Amber Akzent-Balken links entfernt. Stattdessen: subtiler stone-to-white Gradient (konsistent in Read + Edit Mode).
-- F14: Termin-Papierflieger-Icon entfernt. Jetzt: voller "Termin versenden" Button unter dem KV-Grid nach Speichern. Mit Lade-State + Erfolgs-Indikator. Kein 30s-Timeout (persistent bis gesendet).
+- F12: Layout 50/50 bestätigt. Beschreibung + Kontakt Cards gleiche Höhe (CSS Grid). **DONE** (PR #258)
+- F13: Amber Akzent-Balken weg → subtiler stone-to-white Gradient. **DONE** (PR #258)
+- F14→F15: Benachrichtigungs-Buttons NUR im Edit-Mode, sofort bei Änderung. Button = speichert + sendet. **DONE** (PRs #259, #260)
+- Neue API: `POST /api/ops/cases/[id]/notify-assignees` — manueller Versand an neue Zuständige.
+- PATCH Route: `_skip_assignee_notify` Flag für manuellen Flow.
+
+---
+
+### Phase 2: Kommunikation & SMS — KOMPLETT (18.03., PRs #261–#265)
+
+| # | Task | Status | Evidence |
+|---|------|--------|----------|
+| 2.1 | **SMS-Audit** | **DONE** | Alle 4 Templates ≤ 160 Chars. Post-Call: 251→130, Review: 268→110. PRs #262, #263. |
+| 2.2 | **Termin-SMS Fallback** | **DONE** | Voice-Fälle ohne E-Mail: SMS als Primärkanal. PR #262. |
+| 2.3 | **Kanal-Hinweise Leitstand** | **DONE** | "per SMS", "per E-Mail + SMS", "Keine Kontaktdaten" unter Termin-Button. PR #264. |
+| 2.4 | **E-Mail-Audit** | **DONE** | "Dashboard"→"Leitstand", ICS Sender-Fallback korrigiert. PR #264. |
+| 2.5 | **160-Char Sentry Guard** | **DONE** | Warning bei >160 Chars (kein Reject). PR #265. |
+| 2.6 | **Zustellberichte** | GEPARKT | eCall liefert message_id. Delivery-Status-Abfrage = Post-MVP. |
+| 2.7 | **Anti-Spam** | **DONE** | Resend SPF/DKIM/DMARC verifiziert auf send.flowsight.ch. |
+
+**Kommunikationsmatrix:** `docs/redesign/leitstand/Matrix_kommunikation.md` — SSOT für alle Benachrichtigungen (25+ Trigger, 5 Kanäle, 5 Akteure). K1–K5 Entscheidungen fixiert.
+
+**SMS-Templates final:**
+
+| Template | Chars | Text |
+|----------|-------|------|
+| Post-Call | ~130 | `{Firma}: Ihre Meldung {Kat} wurde erfasst. Bitte Name & Adresse prüfen und Fotos hochladen: {URL}` |
+| Termin | ~81 | `{Firma}: Ihr Termin am {Tag} {Datum}, {Zeit}–{Ende}. Bei Fragen: {Tel}.` |
+| Review | ~110 | `{Firma}: Vielen Dank für Ihr Vertrauen. Über eine kurze Bewertung freuen wir uns: {URL}` |
+| 24h Reminder | ~100 | `{Firma}: Erinnerung — Ihr Termin morgen {Tag} {Datum}, {Zeit}–{Ende}. Bei Fragen: {Tel}.` |
 
 ---
 
 ## Next Steps
 
-**Founder-Action:** F12-F14 auf Desktop + Mobile testen.
-
-**Danach:** Phase 2 (Kommunikation & SMS) starten.
+**Phase 3 (Rollen & Einstellungen) starten.**
 
 ---
 
 ## Umsetzungs-Plan: Verbleibende Phasen
 
-### Phase 2: Kommunikation & SMS
-
-> Jede Nachricht hat einen Zweck. Keine Informationsflut. ≤ 160 Zeichen.
-
-| # | Task | Detail | Priorität |
-|---|------|--------|-----------|
-| 2.1 | **SMS-Audit** | Alle bestehenden SMS-Templates inventarisieren. Jedes auf ≤ 160 Zeichen prüfen + kürzen. Zeichenzähler als Dev-Tool. | hoch |
-| 2.2 | **Benachrichtigungs-Matrix** | Tabelle: Trigger × Kanal × Empfänger × Inhalt × Zeichenlimit. Für jede Betriebsgrösse (2/5/10/30 MA) durchdenken. Ziel: Kein Spam, kein Informationsverlust. | hoch |
-| 2.3 | **Anti-Spam Massnahmen** | E-Mail: SPF/DKIM/DMARC via Resend (bereits aktiv). Sender-Domain = `send.flowsight.ch` (verifiziert). SMS: eCall alphanumerischer Sender (Firmenname, nicht Nummer). Regelmässig Zustellbarkeit prüfen. | mittel |
-| 2.4 | **eCall-Integration härten** | API-Anbindung verifizieren: Alphanumerischer Sender, Zeichenlimit-Enforcement (reject > 160), Zustellberichte auswerten. Kosten-Monitoring (1.2–1.7 Punkte pro SMS). | mittel |
-| 2.5 | **E-Mail-Templates audit** | Alle E-Mail-Templates auf Identity Contract prüfen: Sender = "{Firma} via FlowSight", kein FlowSight im Body, Handwerker-Wording, Responsive HTML. | mittel |
-
 ### Phase 3: Rollen & Einstellungen
 
-| # | Task | Detail | Priorität |
-|---|------|--------|-----------|
-| 3.1 | **Rollen-Beschreibung verifizieren** | Info-Button-Text in Einstellungen auf Korrektheit prüfen. Abgleich Code ↔ Text. | hoch |
-| 3.2 | **Kalender-Konzept** | Read-Only Abfrage (Google Calendar FreeBusy). Skalierbar für 2–30 MA. | hoch |
-| 3.3 | **Einstellungen-UX aufwerten** | Toggles mit kontextbezogener Empfehlung. Mobile-optimiert. | mittel |
-| 3.4 | **Techniker-Micro-Surface** | SMS-Link `/einsatz/[token]` — Adresse, Problem, Navi, Erledigt-Button, Foto. HMAC-gesichert. | hoch |
+| # | Task | Detail | Status |
+|---|------|--------|--------|
+| 3.1 | **Rollen-Beschreibung** | Admin + Techniker Beschreibungen verifiziert. Stimmen mit Code überein. | **DONE** (bestätigt 18.03.) |
+| 3.2 | **Kalender-Konzept** | ICS-Einladungen + Appointments-Tabelle existieren. Google Calendar FreeBusy = Post-MVP (API-Integration). | GEPARKT |
+| 3.3 | **Einstellungen-UX** | Neue Section "Termine": Kalender-E-Mail + Standard-Termindauer. 6 Benachrichtigungs-Toggles. Mobile-responsive. | **DONE** (PR #266) |
+| 3.4 | **Techniker-Micro-Surface** | SMS-Link `/einsatz/[token]` — Adresse, Problem, Navi, Erledigt-Button, Foto. HMAC-gesichert. | **NÄCHSTER SCHRITT** |
 
 ### Phase 4: Leitzentrale (merged)
 

--- a/src/web/app/ops/(dashboard)/settings/page.tsx
+++ b/src/web/app/ops/(dashboard)/settings/page.tsx
@@ -6,6 +6,8 @@ import { StaffManager } from "@/src/components/ops/StaffManager";
 
 interface Settings {
   google_review_url: string;
+  business_calendar_email: string;
+  default_appointment_duration_min: number;
   notify_reporter_email: boolean;
   notify_reporter_sms: boolean;
   notify_termin_email: boolean;
@@ -40,6 +42,15 @@ export default function SettingsPage() {
   const [notifySaved, setNotifySaved] = useState(false);
   const [notifyError, setNotifyError] = useState<string | null>(null);
 
+  // Form state — Termin-Einstellungen
+  const [calendarEmail, setCalendarEmail] = useState("");
+  const [calendarEmailBaseline, setCalendarEmailBaseline] = useState("");
+  const [appointmentDuration, setAppointmentDuration] = useState(60);
+  const [appointmentDurationBaseline, setAppointmentDurationBaseline] = useState(60);
+  const [terminSettingsSaving, setTerminSettingsSaving] = useState(false);
+  const [terminSettingsSaved, setTerminSettingsSaved] = useState(false);
+  const [terminSettingsError, setTerminSettingsError] = useState<string | null>(null);
+
   // Form state — Google Review
   const [googleReviewUrl, setGoogleReviewUrl] = useState("");
   const [reviewBaseline, setReviewBaseline] = useState("");
@@ -58,6 +69,10 @@ export default function SettingsPage() {
           setData(d);
           setGoogleReviewUrl(d.settings.google_review_url);
           setReviewBaseline(d.settings.google_review_url);
+          setCalendarEmail(d.settings.business_calendar_email ?? "");
+          setCalendarEmailBaseline(d.settings.business_calendar_email ?? "");
+          setAppointmentDuration(d.settings.default_appointment_duration_min ?? 60);
+          setAppointmentDurationBaseline(d.settings.default_appointment_duration_min ?? 60);
           setNotifyEmail(d.settings.notify_reporter_email);
           setNotifySms(d.settings.notify_reporter_sms);
           setNotifyTerminEmail(d.settings.notify_termin_email);
@@ -82,6 +97,7 @@ export default function SettingsPage() {
     notifyEmail !== notifyBaseline.email || notifySms !== notifyBaseline.sms ||
     notifyTerminEmail !== notifyBaseline.terminEmail || notifyTerminSms !== notifyBaseline.terminSms ||
     notifyTerminReminderSms !== notifyBaseline.terminReminderSms || notifyStaffAssignment !== notifyBaseline.staffAssignment;
+  const terminSettingsDirty = calendarEmail !== calendarEmailBaseline || appointmentDuration !== appointmentDurationBaseline;
   const reviewDirty = googleReviewUrl !== reviewBaseline;
 
   async function saveNotify() {
@@ -116,6 +132,33 @@ export default function SettingsPage() {
       setNotifyError("Netzwerkfehler.");
     }
     setNotifySaving(false);
+  }
+
+  async function saveTerminSettings() {
+    setTerminSettingsSaving(true);
+    setTerminSettingsSaved(false);
+    setTerminSettingsError(null);
+    try {
+      const res = await fetch("/api/ops/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          business_calendar_email: calendarEmail.trim() || null,
+          default_appointment_duration_min: appointmentDuration,
+        }),
+      });
+      if (res.ok) {
+        setCalendarEmailBaseline(calendarEmail);
+        setAppointmentDurationBaseline(appointmentDuration);
+        setTerminSettingsSaved(true);
+        setTimeout(() => setTerminSettingsSaved(false), 3000);
+      } else {
+        setTerminSettingsError("Speichern fehlgeschlagen.");
+      }
+    } catch {
+      setTerminSettingsError("Netzwerkfehler.");
+    }
+    setTerminSettingsSaving(false);
   }
 
   async function saveReview() {
@@ -239,6 +282,57 @@ export default function SettingsPage() {
                 setNotifyTerminSms(notifyBaseline.terminSms);
                 setNotifyTerminReminderSms(notifyBaseline.terminReminderSms);
                 setNotifyStaffAssignment(notifyBaseline.staffAssignment);
+              }}
+            />
+          )}
+        </Section>
+
+        {/* Termine — per-card save */}
+        <Section
+          title="Termine"
+          description="Kalender-E-Mail und Standard-Termindauer."
+        >
+          <div className="space-y-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Kalender-E-Mail</label>
+              <input
+                type="email"
+                value={calendarEmail}
+                onChange={(e) => setCalendarEmail(e.target.value)}
+                placeholder="kalender@mein-betrieb.ch"
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 truncate min-w-0"
+              />
+              <p className="mt-1 text-xs text-gray-400">
+                ICS-Kalendereinladungen werden an diese Adresse gesendet (z.B. Outlook oder Google Kalender).
+              </p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Standard-Termindauer</label>
+              <select
+                value={appointmentDuration}
+                onChange={(e) => setAppointmentDuration(Number(e.target.value))}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400"
+              >
+                <option value={30}>30 Minuten</option>
+                <option value={45}>45 Minuten</option>
+                <option value={60}>60 Minuten</option>
+                <option value={90}>90 Minuten</option>
+                <option value={120}>2 Stunden</option>
+              </select>
+              <p className="mt-1 text-xs text-gray-400">
+                Wird bei neuen Terminen als Vorgabe verwendet.
+              </p>
+            </div>
+          </div>
+          {terminSettingsDirty && (
+            <CardSaveBar
+              saving={terminSettingsSaving}
+              saved={terminSettingsSaved}
+              error={terminSettingsError}
+              onSave={saveTerminSettings}
+              onCancel={() => {
+                setCalendarEmail(calendarEmailBaseline);
+                setAppointmentDuration(appointmentDurationBaseline);
               }}
             />
           )}


### PR DESCRIPTION
## Summary
- **Neue Section "Termine"** in Einstellungen: Kalender-E-Mail + Standard-Termindauer
- **plan_Leitsystem.md** vollständig aktualisiert (Phase 1 ✓, Phase 2 ✓, Phase 3 Status)

## Test plan
- [ ] Einstellungen öffnen → "Termine" Section sichtbar
- [ ] Kalender-E-Mail eingeben → Speichern → ICS geht an diese Adresse
- [ ] Termindauer ändern → Speichern → Neuer Standard beim nächsten Termin
- [ ] Mobile: Section stacked, Felder volle Breite

🤖 Generated with [Claude Code](https://claude.com/claude-code)