### PR TITLE
feat: Phase 4 Leitzentrale — complete rebuild

### DIFF
--- a/docs/redesign/leitstand/plan_Leitsystem.md
+++ b/docs/redesign/leitstand/plan_Leitsystem.md
@@ -1,7 +1,7 @@
 # Plan Leitsystem — High-End Umsetzung
 
 **Erstellt:** 2026-03-17
-**Letztes Update:** 2026-03-18 (Feedback-Runde 3 umgesetzt — F12-F14)
+**Letztes Update:** 2026-03-18 (Phase 4 — Leitzentrale merged, 6 Systemfluss-Karten)
 **Owner:** Founder + CC
 **Nordstern:** `leitsystem_leitzentrale_super_high_end_plan.md`
 **Referenz:** `leitstand.md` (Grundvertrag), `leitstand_renovation.md` (Implementierungs-Brücke)
@@ -115,7 +115,7 @@ Jede Stufe ist sichtbar, steuerbar, abschliessbar. Die Bewertung (Google-Sterne)
 
 ## Next Steps
 
-**Phase 3 (Rollen & Einstellungen) starten.**
+**Phase 4 DONE.** Leitzentrale + Fallübersicht auf einer Seite. 6 Systemfluss-Karten, Click-to-Filter, Suche, Pagination, Notfall-Markierung.
 
 ---
 
@@ -130,15 +130,15 @@ Jede Stufe ist sichtbar, steuerbar, abschliessbar. Die Bewertung (Google-Sterne)
 | 3.3 | **Einstellungen-UX** | Neue Section "Termine": Kalender-E-Mail + Standard-Termindauer. 6 Benachrichtigungs-Toggles. Mobile-responsive. | **DONE** (PR #266) |
 | 3.4 | **Techniker-Micro-Surface** | `/einsatz/[caseRef]?t=[hmac]` — Adresse + Maps-Navi, Problem, Kunde + Anruf-Link, "Bin vor Ort" + "Erledigt" Buttons. HMAC-gesichert, kein Login. Mobile-first. | **DONE** (PR #267) |
 
-### Phase 4: Leitzentrale (merged)
+### Phase 4: Leitzentrale (merged) — KOMPLETT (18.03.)
 
-| # | Task | Detail | Priorität |
-|---|------|--------|-----------|
-| 4.1 | **Systemfluss-Karten** | ~6 Karten: Eingang → Bei uns → Wartet → Heute → Erledigt → Bewertungen ★ | hoch |
-| 4.2 | **Click-to-Filter** | Klick auf Karte filtert Fallliste darunter | hoch |
-| 4.3 | **Notfälle integriert** | Rote Markierung, zuoberst sortiert | hoch |
-| 4.4 | **Navigation reduzieren** | Nur 2 Punkte: Leitzentrale + Einstellungen | mittel |
-| 4.5 | **Quiet High-End Ästhetik** | Ruhig, klar, hierarchisch, handlungsorientiert | hoch |
+| # | Task | Detail | Status |
+|---|------|--------|--------|
+| 4.1 | **Systemfluss-Karten** | 6 Karten: Eingang → Bei uns → Wartet → Heute → Erledigt → Bewertungen ★. Responsive Grid (2 cols mobile, 6 cols desktop). | **DONE** |
+| 4.2 | **Click-to-Filter** | Klick auf Karte filtert Fallliste darunter. Nochmal klicken = deselect (alle zeigen). | **DONE** |
+| 4.3 | **Notfälle integriert** | Rote border-l-4 + bg-red-50/30 auf Zeile, Notfälle zuoberst sortiert. | **DONE** |
+| 4.4 | **Navigation reduzieren** | Nur 2 Nav-Punkte: Leitzentrale + Einstellungen. Fallübersicht eliminiert. | **DONE** |
+| 4.5 | **Quiet High-End Ästhetik** | Ruhig, klar, hierarchisch. Suche + Tabelle + Pagination. Mobile-first (weniger Spalten). | **DONE** |
 
 ---
 

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -3,8 +3,8 @@ import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
 import { resolveTenantIdentity } from "@/src/lib/tenants/resolveTenantIdentity";
 import { resolveStaffRole } from "@/src/lib/staff/resolveStaffRole";
-import { ZentraleView } from "@/src/components/ops/ZentraleView";
-import type { ZentraleCase, TodayAppointment } from "@/src/components/ops/ZentraleView";
+import { LeitzentraleView } from "@/src/components/ops/LeitzentraleView";
+import type { LeitzentraleCase } from "@/src/components/ops/LeitzentraleView";
 
 // ---------------------------------------------------------------------------
 // Page (Server Component) — Leitsystem
@@ -61,25 +61,7 @@ export default async function OpsCasesPage({
     } catch { /* fallback: no filter */ }
   }
 
-  // ── Query 2: Today's appointments with staff + case join ───────────
-  const todayZurich = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Europe/Zurich",
-  }).format(new Date());
-  const todayStart = `${todayZurich}T00:00:00+00:00`;
-  const todayEnd = `${todayZurich}T23:59:59+00:00`;
-
-  let appointmentsQuery = supabase
-    .from("appointments")
-    .select(
-      "id, scheduled_at, duration_min, status, notes, staff:staff_id(display_name), case_info:case_id(id, seq_number, category, reporter_name, street, house_number, plz, city)"
-    )
-    .gte("scheduled_at", todayStart)
-    .lte("scheduled_at", todayEnd)
-    .in("status", ["scheduled", "confirmed"])
-    .order("scheduled_at", { ascending: true });
-  if (filterTenantId) appointmentsQuery = appointmentsQuery.eq("tenant_id", filterTenantId);
-
-  // ── Query 3: 7-day stats ──────────────────────────────────────────
+  // ── Query 2: 7-day stats ──────────────────────────────────────────
   const sevenDaysAgo = new Date(new Date().getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
   let statsNeueQuery = supabase
     .from("cases")
@@ -120,28 +102,19 @@ export default async function OpsCasesPage({
   // ── Execute all queries in parallel ────────────────────────────────
   const [
     { data: casesRaw },
-    { data: appointmentsRaw },
     { count: neueCount },
     { count: erledigtCount },
     { count: reviewSentCount },
     { count: reviewPendingCount },
   ] = await Promise.all([
     casesQuery,
-    appointmentsQuery,
     statsNeueQuery,
     statsErledigtQuery,
     reviewSentQuery,
     reviewPendingQuery,
   ]);
 
-  const cases = (casesRaw ?? []) as ZentraleCase[];
-
-  // Supabase returns joined relations as arrays — normalize to single objects
-  const todayAppointments: TodayAppointment[] = (appointmentsRaw ?? []).map((a: Record<string, unknown>) => ({
-    ...a,
-    staff: Array.isArray(a.staff) ? (a.staff[0] ?? null) : a.staff,
-    case_info: Array.isArray(a.case_info) ? (a.case_info[0] ?? null) : a.case_info,
-  })) as TodayAppointment[];
+  const cases = (casesRaw ?? []) as LeitzentraleCase[];
 
   // ── Resolve tenant identity for case ID prefix ─────────────────────
   let caseIdPrefix = "FS";
@@ -159,9 +132,8 @@ export default async function OpsCasesPage({
   }
 
   return (
-    <ZentraleView
+    <LeitzentraleView
       cases={cases}
-      todayAppointments={todayAppointments}
       caseIdPrefix={caseIdPrefix}
       weekStats={{
         neue: neueCount ?? 0,

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { CreateCaseModal } from "./CreateCaseModal";
+import { formatCaseId } from "@/src/lib/cases/formatCaseId";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LeitzentraleCase {
+  id: string;
+  seq_number: number | null;
+  created_at: string;
+  updated_at: string;
+  status: string;
+  urgency: string;
+  category: string;
+  description: string;
+  city: string;
+  plz: string;
+  street?: string | null;
+  house_number?: string | null;
+  source: string;
+  assignee_text?: string | null;
+  reporter_name?: string | null;
+  review_sent_at?: string | null;
+  scheduled_at?: string | null;
+}
+
+export interface LeitzentraleProps {
+  cases: LeitzentraleCase[];
+  caseIdPrefix: string;
+  weekStats: { neue: number; erledigt: number };
+  reviewStats: { sent: number; pending: number };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STATUS_LABELS: Record<string, string> = {
+  new: "Neu",
+  scheduled: "Geplant",
+  in_arbeit: "In Arbeit",
+  warten: "Warten",
+  done: "Erledigt",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  new: "bg-blue-100 text-blue-700",
+  scheduled: "bg-violet-100 text-violet-700",
+  in_arbeit: "bg-indigo-100 text-indigo-700",
+  warten: "bg-amber-100 text-amber-700",
+  done: "bg-emerald-100 text-emerald-700",
+};
+
+const URGENCY_DOT: Record<string, string> = {
+  notfall: "bg-red-500",
+  dringend: "bg-amber-500",
+  normal: "bg-gray-400",
+};
+
+const URGENCY_LABEL: Record<string, string> = {
+  notfall: "Hoch",
+  dringend: "Mittel",
+  normal: "Normal",
+};
+
+const PAGE_SIZE = 15;
+
+// ---------------------------------------------------------------------------
+// Filter definitions for Systemfluss cards
+// ---------------------------------------------------------------------------
+
+type FilterKey = "eingang" | "bei_uns" | "wartet" | "heute" | "erledigt" | "bewertungen";
+
+interface FlussCard {
+  key: FilterKey;
+  label: string;
+  accentColor: string;
+  ringColor: string;
+}
+
+const FLUSS_CARDS: FlussCard[] = [
+  { key: "eingang", label: "Eingang", accentColor: "border-blue-500", ringColor: "ring-blue-500" },
+  { key: "bei_uns", label: "Bei uns", accentColor: "border-indigo-500", ringColor: "ring-indigo-500" },
+  { key: "wartet", label: "Wartet", accentColor: "border-amber-500", ringColor: "ring-amber-500" },
+  { key: "heute", label: "Heute", accentColor: "border-violet-500", ringColor: "ring-violet-500" },
+  { key: "erledigt", label: "Erledigt", accentColor: "border-emerald-500", ringColor: "ring-emerald-500" },
+  { key: "bewertungen", label: "Bewertungen", accentColor: "border-amber-400", ringColor: "ring-amber-400" },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getTodayZurich(): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Zurich" }).format(new Date());
+}
+
+function isScheduledToday(scheduledAt: string | null | undefined): boolean {
+  if (!scheduledAt) return false;
+  const dateInZurich = new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Zurich" }).format(new Date(scheduledAt));
+  return dateInZurich === getTodayZurich();
+}
+
+function matchesFilter(c: LeitzentraleCase, filter: FilterKey): boolean {
+  switch (filter) {
+    case "eingang":
+      return c.status === "new";
+    case "bei_uns":
+      return c.status === "scheduled" || c.status === "in_arbeit";
+    case "wartet":
+      return c.status === "warten";
+    case "heute":
+      return isScheduledToday(c.scheduled_at);
+    case "erledigt":
+      return c.status === "done";
+    case "bewertungen":
+      return c.status === "done" && !c.review_sent_at;
+  }
+}
+
+function matchesSearch(c: LeitzentraleCase, query: string): boolean {
+  const q = query.toLowerCase();
+  return (
+    (c.reporter_name ?? "").toLowerCase().includes(q) ||
+    c.city.toLowerCase().includes(q) ||
+    c.category.toLowerCase().includes(q) ||
+    c.description.toLowerCase().includes(q)
+  );
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const todayStr = getTodayZurich();
+  const dateStr = new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Zurich" }).format(d);
+
+  if (dateStr === todayStr) {
+    return "Heute " + d.toLocaleTimeString("de-CH", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" });
+  }
+
+  // Yesterday
+  const yesterday = new Date(now.getTime() - 86400000);
+  const yesterdayStr = new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Zurich" }).format(yesterday);
+  if (dateStr === yesterdayStr) {
+    return "Gestern";
+  }
+
+  return d.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", timeZone: "Europe/Zurich" });
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function LeitzentraleView({ cases, caseIdPrefix, weekStats, reviewStats }: LeitzentraleProps) {
+  const router = useRouter();
+  const [activeFilter, setActiveFilter] = useState<FilterKey | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  // ── Card counts ──────────────────────────────────────────────────────
+  const cardCounts = useMemo(() => {
+    const counts: Record<FilterKey, number> = {
+      eingang: 0,
+      bei_uns: 0,
+      wartet: 0,
+      heute: 0,
+      erledigt: 0,
+      bewertungen: 0,
+    };
+    for (const c of cases) {
+      if (c.status === "new") counts.eingang++;
+      if (c.status === "scheduled" || c.status === "in_arbeit") counts.bei_uns++;
+      if (c.status === "warten") counts.wartet++;
+      if (isScheduledToday(c.scheduled_at)) counts.heute++;
+      if (c.status === "done") counts.erledigt++;
+      if (c.status === "done" && !c.review_sent_at) counts.bewertungen++;
+    }
+    return counts;
+  }, [cases]);
+
+  // ── Filtered + searched cases ────────────────────────────────────────
+  const filteredCases = useMemo(() => {
+    let result = cases;
+
+    // Apply card filter
+    if (activeFilter) {
+      result = result.filter((c) => matchesFilter(c, activeFilter));
+    }
+
+    // Apply search
+    if (searchQuery.trim()) {
+      result = result.filter((c) => matchesSearch(c, searchQuery.trim()));
+    }
+
+    // Sort: Notfälle to top, then by created_at desc
+    const urgencyRank: Record<string, number> = { notfall: 0, dringend: 1, normal: 2 };
+    result = [...result].sort((a, b) => {
+      const ra = urgencyRank[a.urgency] ?? 9;
+      const rb = urgencyRank[b.urgency] ?? 9;
+      if (ra !== rb) return ra - rb;
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    });
+
+    return result;
+  }, [cases, activeFilter, searchQuery]);
+
+  // ── Pagination ───────────────────────────────────────────────────────
+  const totalPages = Math.max(1, Math.ceil(filteredCases.length / PAGE_SIZE));
+  const safePage = Math.min(currentPage, totalPages);
+  const paginatedCases = filteredCases.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  // Reset page when filter/search changes
+  const handleFilterClick = (key: FilterKey) => {
+    setActiveFilter((prev) => (prev === key ? null : key));
+    setCurrentPage(1);
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    setCurrentPage(1);
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* ═══════════════════════════════════════════════════════════════
+          SYSTEMFLUSS-KARTEN
+         ═══════════════════════════════════════════════════════════════ */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+        {FLUSS_CARDS.map((card) => {
+          const isActive = activeFilter === card.key;
+          const count = cardCounts[card.key];
+          return (
+            <button
+              key={card.key}
+              onClick={() => handleFilterClick(card.key)}
+              className={`text-left border-l-4 ${card.accentColor} bg-white rounded-xl p-4 shadow-sm hover:shadow transition border border-gray-200 ${
+                isActive ? `ring-2 ring-offset-2 ${card.ringColor}` : ""
+              }`}
+            >
+              <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-wide">
+                {card.label}
+              </p>
+              <p className={`text-2xl font-bold mt-1 ${count === 0 ? "text-gray-300" : "text-gray-900"}`}>
+                {count}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Active filter or total indicator */}
+      {!activeFilter && (
+        <p className="text-xs text-gray-400">
+          {cases.length} Fälle insgesamt
+          <span className="mx-1.5 text-gray-300">·</span>
+          {weekStats.neue} neu, {weekStats.erledigt} erledigt diese Woche
+          {reviewStats.sent > 0 && (
+            <>
+              <span className="mx-1.5 text-gray-300">·</span>
+              {reviewStats.sent} Bewertungsanfragen (30 Tage)
+            </>
+          )}
+        </p>
+      )}
+
+      {/* ═══════════════════════════════════════════════════════════════
+          SEARCH + NEW CASE
+         ═══════════════════════════════════════════════════════════════ */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+            />
+          </svg>
+          <input
+            type="text"
+            placeholder="Suche nach Kunde, Ort, Kategorie..."
+            value={searchQuery}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="w-full pl-9 pr-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 transition"
+          />
+        </div>
+        <button
+          onClick={() => setModalOpen(true)}
+          className="rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white hover:bg-gray-800 transition-colors flex-shrink-0 whitespace-nowrap"
+        >
+          + Neuer Fall
+        </button>
+      </div>
+
+      {/* ═══════════════════════════════════════════════════════════════
+          CASE TABLE
+         ═══════════════════════════════════════════════════════════════ */}
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        {/* Desktop table */}
+        <div className="hidden md:block overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100">
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                  Nr
+                </th>
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                  Kunde
+                </th>
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                  Kat.
+                </th>
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                  Ort
+                </th>
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                  Priorität
+                </th>
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                  Status
+                </th>
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                  Datum
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {paginatedCases.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="text-center text-gray-400 py-12 text-sm">
+                    Keine Fälle gefunden.
+                  </td>
+                </tr>
+              )}
+              {paginatedCases.map((c) => {
+                const isNotfall = c.urgency === "notfall";
+                return (
+                  <tr
+                    key={c.id}
+                    onClick={() => router.push(`/ops/cases/${c.id}`)}
+                    className={`border-b border-gray-50 hover:bg-gray-50 cursor-pointer transition-colors ${
+                      isNotfall ? "border-l-4 border-l-red-500 bg-red-50/30" : ""
+                    }`}
+                  >
+                    <td className="px-4 py-3 font-mono text-xs text-gray-500 whitespace-nowrap">
+                      {formatCaseId(c.seq_number, caseIdPrefix)}
+                    </td>
+                    <td className="px-4 py-3 text-gray-900 truncate max-w-[180px]">
+                      {c.reporter_name || <span className="text-gray-400">—</span>}
+                    </td>
+                    <td className="px-4 py-3 text-gray-700 truncate max-w-[140px]">{c.category}</td>
+                    <td className="px-4 py-3 text-gray-600 truncate max-w-[120px]">{c.city || "—"}</td>
+                    <td className="px-4 py-3">
+                      <span className="inline-flex items-center gap-1.5">
+                        <span className={`w-2 h-2 rounded-full flex-shrink-0 ${URGENCY_DOT[c.urgency] ?? "bg-gray-400"}`} />
+                        <span className="text-xs text-gray-600">
+                          {URGENCY_LABEL[c.urgency] ?? c.urgency}
+                        </span>
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                          STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-700"
+                        }`}
+                      >
+                        {STATUS_LABELS[c.status] ?? c.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-500 whitespace-nowrap">
+                      {formatDate(c.created_at)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Mobile list */}
+        <div className="md:hidden divide-y divide-gray-50">
+          {paginatedCases.length === 0 && (
+            <div className="text-center text-gray-400 py-12 text-sm">
+              Keine Fälle gefunden.
+            </div>
+          )}
+          {paginatedCases.map((c) => {
+            const isNotfall = c.urgency === "notfall";
+            return (
+              <div
+                key={c.id}
+                onClick={() => router.push(`/ops/cases/${c.id}`)}
+                className={`px-4 py-3.5 hover:bg-gray-50 cursor-pointer transition-colors ${
+                  isNotfall ? "border-l-4 border-l-red-500 bg-red-50/30" : ""
+                }`}
+              >
+                <div className="flex items-center justify-between mb-1.5">
+                  <span className="font-mono text-xs text-gray-400">
+                    {formatCaseId(c.seq_number, caseIdPrefix)}
+                  </span>
+                  <span
+                    className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                      STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-700"
+                    }`}
+                  >
+                    {STATUS_LABELS[c.status] ?? c.status}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-900 font-medium truncate">{c.category}</p>
+                <div className="flex items-center gap-2 mt-1 text-xs text-gray-500">
+                  {c.reporter_name && <span className="truncate max-w-[120px]">{c.reporter_name}</span>}
+                  {c.city && (
+                    <>
+                      <span className="text-gray-300">·</span>
+                      <span>{c.city}</span>
+                    </>
+                  )}
+                  <span className="text-gray-300">·</span>
+                  <span>{formatDate(c.created_at)}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ═══════════════════════════════════════════════════════════════
+          PAGINATION
+         ═══════════════════════════════════════════════════════════════ */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+            disabled={safePage <= 1}
+            className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            &lt;
+          </button>
+          <span className="text-sm text-gray-500">
+            Seite {safePage} von {totalPages}
+          </span>
+          <button
+            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+            disabled={safePage >= totalPages}
+            className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            &gt;
+          </button>
+        </div>
+      )}
+
+      <CreateCaseModal open={modalOpen} onClose={() => setModalOpen(false)} />
+    </div>
+  );
+}

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -28,15 +28,6 @@ const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
-    label: "Fallübersicht",
-    href: "/ops/faelle",
-    icon: (
-      <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
-      </svg>
-    ),
-  },
-  {
     label: "Einstellungen",
     href: "/ops/settings",
     icon: (
@@ -87,12 +78,8 @@ export function OpsShell({
 
   function isNavActive(href: string): boolean {
     if (href === "/ops/cases") {
-      // Leitsystem: only exact match (not case detail pages)
-      return pathname === "/ops/cases" || pathname === "/ops/cases/";
-    }
-    if (href === "/ops/faelle") {
-      // Fallübersicht: /ops/faelle/* AND individual case pages /ops/cases/[id]
-      return pathname.startsWith("/ops/faelle") || (pathname.startsWith("/ops/cases/") && pathname !== "/ops/cases/");
+      // Leitzentrale: exact match + case detail pages /ops/cases/[id]
+      return pathname === "/ops/cases" || pathname === "/ops/cases/" || pathname.startsWith("/ops/cases/");
     }
     return pathname.startsWith(href);
   }


### PR DESCRIPTION
## Summary
Kompletter Neubau der Leitzentrale — High-End, handlungsorientiert, ruhig.

- **6 Systemfluss-Karten:** Eingang → Bei uns → Wartet → Heute → Erledigt → Bewertungen
- **Click-to-Filter:** Karte klicken filtert Fallliste, nochmal klicken = alle
- **Fallliste integriert:** Tabelle mit Suche + Pagination (15/Seite) auf gleicher Seite
- **Notfälle:** Rote Markierung, zuoberst sortiert
- **Navigation:** Nur 2 Punkte (Leitzentrale + Einstellungen)
- **Mobile:** Kompaktes Card-Layout statt Tabelle

## Test plan
- [ ] Leitzentrale öffnen → 6 Karten mit korrekten Zahlen
- [ ] "Eingang" klicken → nur neue Fälle in der Liste
- [ ] Nochmal klicken → alle Fälle wieder sichtbar
- [ ] Suche nach Kundenname → gefilterte Ergebnisse
- [ ] Pagination: Seite 2 → korrekte Fälle
- [ ] Notfall-Fall → rote Markierung, zuoberst
- [ ] Mobile: Karten 2x3, kompakte Fallkarten
- [ ] Navigation: nur Leitzentrale + Einstellungen (keine Fallübersicht)

🤖 Generated with [Claude Code](https://claude.com/claude-code)