### PR TITLE
fix: feedback round 4 — tenant isolation, past termin, mobile preview

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -85,8 +85,8 @@ function formatTerminRange(startIso: string, endIso: string | null): string {
   if (sameDay) {
     return `${shortDay(s)} ${fmtDate(s)} · ${fmtTime(s)}–${fmtTime(e)}`;
   }
-  // Multi-day: "Mo 02.03. 11:00 – Fr 06.03. 09:00"
-  return `${shortDay(s)} ${fmtDate(s)} ${fmtTime(s)} – ${shortDay(e)} ${fmtDate(e)} ${fmtTime(e)}`;
+  // Multi-day compact: "Mo 02.03. 11:00 – Fr 06.03. 09:00"
+  return `${shortDay(s)} ${fmtDate(s)} ${fmtTime(s)} –\u00A0${shortDay(e)} ${fmtDate(e)} ${fmtTime(e)}`;
 }
 
 function googleMapsUrl(street: string | null, houseNumber: string | null, plz: string, city: string): string {
@@ -245,6 +245,7 @@ export function CaseDetailForm({
   // ── Live dirty: new assignees + termin changed (for inline notification buttons)
   const liveNewAssignees = selectedAssignees.filter(a => !parseAssignees(baseline.assignee_text).includes(a));
   const liveTerminChanged = (scheduledAt !== baseline.scheduled_at || scheduledEndAt !== baseline.scheduled_end_at) && !!scheduledAt;
+  const terminInPast = !!scheduledAt && new Date(scheduledAt).getTime() < Date.now();
 
   const kontaktDirty =
     street !== baseline.street || houseNumber !== baseline.house_number ||
@@ -369,6 +370,12 @@ export function CaseDetailForm({
 
   /** Save + send termin to all assignees + customer in one step */
   async function handleSaveAndSendTermin() {
+    // Prevent sending appointments in the past
+    if (scheduledAt && new Date(scheduledAt).getTime() < Date.now()) {
+      setTerminSendState("error");
+      setTimeout(() => setTerminSendState("idle"), 4000);
+      return;
+    }
     setTerminSendState("sending");
     const ok = await saveFields({
       status, urgency,
@@ -614,8 +621,12 @@ export function CaseDetailForm({
                     : <span className="text-gray-400">Termin wählen</span>}
                 </button>
 
+                {/* Past termin warning */}
+                {liveTerminChanged && terminInPast && (
+                  <p className="text-xs text-red-600 font-medium mt-2">Termin liegt in der Vergangenheit — Versand nicht möglich</p>
+                )}
                 {/* Termin versenden — sofort bei Änderung */}
-                {liveTerminChanged && terminSendState !== "sent" && (contactEmail.trim() || contactPhone.trim()) && (
+                {liveTerminChanged && !terminInPast && terminSendState !== "sent" && (contactEmail.trim() || contactPhone.trim()) && (
                   <button
                     onClick={handleSaveAndSendTermin}
                     disabled={terminSendState === "sending"}
@@ -781,7 +792,7 @@ export function CaseDetailForm({
                 <p className="text-sm font-semibold text-gray-800 mb-2">{category}</p>
                 {description ? (
                   <div className="overflow-hidden flex-1">
-                    <p className={`text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-words ${!descExpanded ? "line-clamp-2 sm:line-clamp-3" : ""}`}>{description}</p>
+                    <p className={`text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-words ${!descExpanded ? "line-clamp-2 sm:line-clamp-3" : ""}`} style={{ hyphens: "auto" }} lang="de">{description}</p>
                     {(description.split("\n").length > 3 || description.length > 200) && (
                       <button onClick={() => setDescExpanded(p => !p)}
                         className="inline-flex items-center rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 mt-2 transition-colors min-h-[44px] sm:min-h-0">

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -122,11 +122,11 @@ export default async function CaseDetailPage({
       <div className="flex items-center justify-between mb-4">
         <div className="min-w-0">
           <div className="flex items-center gap-3">
-            <Link href="/ops/faelle" className="text-gray-400 hover:text-gray-600 transition-colors flex items-center gap-1 flex-shrink-0">
+            <Link href="/ops/cases" className="text-gray-400 hover:text-gray-600 transition-colors flex items-center gap-1 flex-shrink-0">
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
               </svg>
-              <span className="text-xs hidden sm:inline">Fallübersicht</span>
+              <span className="text-xs hidden sm:inline">Leitzentrale</span>
             </Link>
             <div className="flex items-baseline gap-2 min-w-0">
               <h1 className="text-lg font-bold text-gray-900 truncate">{caseData.category}</h1>

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -21,11 +21,12 @@ export default async function OpsCasesPage({
   const supabase = getServiceClient();
   const scope = await resolveTenantScope();
 
-  // ── Tenant scope ──────────────────────────────────────────────────
+  // ── Tenant scope (ALWAYS filter when tenantId present — even for admins)
+  // Prevents tenant identity leak: Weinberger Leitstand must never show Brunner cases.
   let filterTenantId: string | undefined;
   const filterTenantSlug = params.tenant;
 
-  if (scope && !scope.isAdmin && scope.tenantId) {
+  if (scope?.tenantId) {
     filterTenantId = scope.tenantId;
   } else if (filterTenantSlug) {
     const { data: t } = await supabase

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -69,6 +69,7 @@ export function OpsShell({
     : "LS";
   const color = brandColor ?? "#64748b";
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [mobilePreview, setMobilePreview] = useState(false);
   const pathname = usePathname();
 
   // RBAC: hide Einstellungen for techniker
@@ -281,7 +282,19 @@ export function OpsShell({
       {/* Main content */}
       <main className="md:ml-64 overflow-x-hidden">
         <InstallPrompt />
-        <div className="max-w-6xl mx-auto px-4 py-6 min-w-0">
+        {/* Dev: Mobile Preview Toggle (top-right, desktop only) */}
+        <div className="hidden md:flex justify-end px-4 pt-2">
+          <button
+            onClick={() => setMobilePreview(p => !p)}
+            className={`p-1.5 rounded-md text-xs transition-colors ${mobilePreview ? "bg-gray-900 text-white" : "text-gray-400 hover:text-gray-600 hover:bg-gray-200"}`}
+            title={mobilePreview ? "Desktop-Ansicht" : "Mobile-Vorschau"}
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+            </svg>
+          </button>
+        </div>
+        <div className={`mx-auto px-4 py-6 min-w-0 transition-all duration-300 ${mobilePreview ? "max-w-[390px] border-x border-gray-300 bg-white min-h-screen shadow-lg" : "max-w-6xl"}`}>
           {children}
         </div>
       </main>


### PR DESCRIPTION
## Summary
- **FB2 (KRITISCH):** Tenant-Isolation erzwungen — Admin sieht NUR eigene Fälle
- **FB1b:** Termin in Vergangenheit → Button versteckt, rote Warnung
- **FB4:** Back-Link "Leitzentrale" statt "Fallübersicht" → /ops/cases
- **FB3b:** CSS Silbentrennung (hyphens: auto, lang=de)
- **FB3a:** Multi-Day Termin besseres Wrapping
- **Dev:** Smartphone-Preview Toggle (rechts oben, nur Desktop)

## Test plan
- [ ] Weinberger Leitstand → NUR JW-Fälle sichtbar (keine FS/BH-Fälle)
- [ ] Termin in Vergangenheit setzen → rote Warnung, kein Button
- [ ] Falldetail → "< Leitzentrale" oben links → geht zu /ops/cases
- [ ] Lange Wörter → Silbentrennung aktiv
- [ ] Desktop: Smartphone-Icon rechts oben → 390px Mobile-Vorschau

🤖 Generated with [Claude Code](https://claude.com/claude-code)