### PR TITLE
fix: mobile preview iframe + brand color sync

### DIFF
--- a/scripts/_ops/onboard_tenant.mjs
+++ b/scripts/_ops/onboard_tenant.mjs
@@ -41,6 +41,7 @@ const name = getArg("--name")[0];
 const slug = getArg("--slug")[0];
 const phones = getArg("--phone");
 const modulesArg = getArg("--modules")[0] ?? "voice,website_wizard,ops,reviews";
+const colorArg = getArg("--color")[0]; // e.g. "#004994"
 const dryRun = getFlag("--dry-run");
 
 if (!name || !slug) {
@@ -55,6 +56,7 @@ Required:
 Optional:
   --phone    Phone number (E.164), repeatable
   --modules  Comma-separated: voice,website_wizard,ops,reviews (default: all)
+  --color    Brand color hex (e.g. "#004994") — used in Leitsystem calendar, buttons, etc.
   --dry-run  Preview without DB writes
 `);
   process.exit(1);
@@ -80,6 +82,8 @@ const modules = {};
 for (const m of ALL_MODULES) {
   modules[m] = modulesArg.split(",").map((s) => s.trim()).includes(m);
 }
+// Brand color → stored in modules.primary_color
+if (colorArg) modules.primary_color = colorArg;
 
 // ── Env ─────────────────────────────────────────────────────────────────
 const url = process.env.SUPABASE_URL;

--- a/scripts/_ops/sync_brand_colors.mjs
+++ b/scripts/_ops/sync_brand_colors.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Sync brand colors from CustomerSite configs into tenant DB (modules.primary_color).
+ *
+ * This ensures the Leitsystem calendar, buttons, and accents use the correct tenant color.
+ * Run once after onboarding, or whenever colors change.
+ *
+ * Usage:
+ *   node --env-file=src/web/.env.local scripts/_ops/sync_brand_colors.mjs [--dry-run]
+ */
+
+const BRAND_COLORS = {
+  "weinberger-ag": "#004994",
+  "doerfler-ag": "#2b6cb0",
+  "walter-leuthold": "#203784",
+  "orlandini": "#1a5276",
+  "widmer-sanitaer": "#1a4b8c",
+  "brunner-haustechnik": "#0d7377",
+};
+
+const dryRun = process.argv.includes("--dry-run");
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error("FATAL: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set.");
+  process.exit(1);
+}
+
+const REST = `${url}/rest/v1`;
+const HEADERS = {
+  apikey: key,
+  Authorization: `Bearer ${key}`,
+  "Content-Type": "application/json",
+  Prefer: "return=representation",
+};
+
+console.log("\n🎨 Sync Brand Colors → DB\n");
+
+for (const [slug, color] of Object.entries(BRAND_COLORS)) {
+  // Fetch tenant
+  const res = await fetch(`${REST}/tenants?slug=eq.${slug}&select=id,name,slug,modules`, {
+    headers: HEADERS,
+  });
+  const tenants = await res.json();
+
+  if (!tenants?.length) {
+    console.log(`  ⏭  ${slug} — not found in DB, skipping`);
+    continue;
+  }
+
+  const tenant = tenants[0];
+  const modules = tenant.modules ?? {};
+
+  if (modules.primary_color === color) {
+    console.log(`  ✅ ${slug} — already ${color}`);
+    continue;
+  }
+
+  const oldColor = modules.primary_color ?? "(not set)";
+
+  if (dryRun) {
+    console.log(`  🔍 ${slug} — would set ${oldColor} → ${color}`);
+    continue;
+  }
+
+  // Update modules.primary_color
+  const updated = { ...modules, primary_color: color };
+  const patchRes = await fetch(`${REST}/tenants?id=eq.${tenant.id}`, {
+    method: "PATCH",
+    headers: HEADERS,
+    body: JSON.stringify({ modules: updated }),
+  });
+
+  if (patchRes.ok) {
+    console.log(`  ✅ ${slug} — ${oldColor} → ${color}`);
+  } else {
+    const err = await patchRes.text();
+    console.error(`  ❌ ${slug} — FAILED: ${err}`);
+  }
+}
+
+console.log("\nDone.\n");

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -295,9 +295,25 @@ export function OpsShell({
             </svg>
           </button>
         </div>
-        <div className={`mx-auto px-4 py-6 min-w-0 transition-all duration-300 ${mobilePreview ? "max-w-[390px] border-x border-gray-300 bg-white min-h-screen shadow-lg" : "max-w-6xl"}`}>
-          {children}
-        </div>
+        {mobilePreview ? (
+          <div className="flex justify-center py-6 bg-gray-200 min-h-screen">
+            <div className="relative">
+              {/* Phone frame */}
+              <div className="w-[410px] h-[820px] bg-gray-900 rounded-[3rem] p-[10px] shadow-2xl">
+                <iframe
+                  src={pathname}
+                  className="w-[390px] h-[800px] rounded-[2.4rem] bg-white"
+                  style={{ border: "none" }}
+                  title="Mobile-Vorschau"
+                />
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="max-w-6xl mx-auto px-4 py-6 min-w-0">
+            {children}
+          </div>
+        )}
       </main>
       <ServiceWorkerRegistration />
       <UpdatePrompt />


### PR DESCRIPTION
## Summary
- **Mobile Preview:** Replace `max-w` constraint with real `<iframe>` (390px width) — CSS media queries now fire correctly, so the preview looks identical to a real smartphone
- **Brand Colors DB Fix:** Brunner HT had wrong color (#2d6a4f→#0d7377), Doerfler had Weinberger's color (#004994→#2b6cb0) — both fixed via sync script
- **New:** `sync_brand_colors.mjs` — syncs CustomerSite brandColor into DB `modules.primary_color`
- **New:** `--color` flag on `onboard_tenant.mjs` for future tenant provisioning

## Test plan
- [ ] Click smartphone icon top-right → verify iframe shows real mobile layout (identical to phone)
- [ ] Open Weinberger case → calendar should show navy blue (#004994), not green
- [ ] Open Brunner case → calendar should show teal (#0d7377)

🤖 Generated with [Claude Code](https://claude.com/claude-code)