### PR TITLE
fix: FB7-FB10 compact layout, dynamic hints, independent buttons

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -151,6 +151,7 @@ export function CaseDetailForm({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   currentStaffName,
   staffRole,
+  notifySettings,
 }: {
   initialData: CaseDetail;
   isProspect?: boolean;
@@ -160,7 +161,14 @@ export function CaseDetailForm({
   currentStaffName?: string | null;
   /** Role-based access: "admin" | "techniker" | undefined (full access) */
   staffRole?: "admin" | "techniker";
+  /** Tenant notification settings from modules — controls channel hint text */
+  notifySettings?: {
+    terminEmail: boolean;
+    terminSms: boolean;
+    staffAssignment: boolean;
+  };
 }) {
+  const ns = notifySettings ?? { terminEmail: true, terminSms: true, staffAssignment: true };
   // ── Field state ──────────────────────────────────────────────────────
   const [status, setStatus] = useState(initialData.status);
   const [urgency, setUrgency] = useState(initialData.urgency);
@@ -182,6 +190,9 @@ export function CaseDetailForm({
   // ── Steuerung notification state (edit-mode inline buttons) ────────
   const [assigneeNotifyState, setAssigneeNotifyState] = useState<"idle" | "sending" | "sent" | "error">("idle");
   const [terminSendState, setTerminSendState] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  // FB10: Track pending sends independently — prevents one save from hiding the other button
+  const [terminPendingSend, setTerminPendingSend] = useState(false);
+  const [assigneePendingNotify, setAssigneePendingNotify] = useState(false);
   const [showCloseWarning, setShowCloseWarning] = useState(false);
 
   const [baseline, setBaseline] = useState({
@@ -252,8 +263,11 @@ export function CaseDetailForm({
     scheduledEndAt !== baseline.scheduled_end_at;
 
   // ── Live dirty: new assignees + termin changed (for inline notification buttons)
+  // FB10: Use pending flags so that saving one notification doesn't hide the other button
   const liveNewAssignees = selectedAssignees.filter(a => !parseAssignees(baseline.assignee_text).includes(a));
-  const liveTerminChanged = (scheduledAt !== baseline.scheduled_at || scheduledEndAt !== baseline.scheduled_end_at) && !!scheduledAt;
+  const liveTerminDirty = (scheduledAt !== baseline.scheduled_at || scheduledEndAt !== baseline.scheduled_end_at) && !!scheduledAt;
+  const liveTerminChanged = liveTerminDirty || terminPendingSend;
+  const showAssigneeButton = liveNewAssignees.length > 0 || assigneePendingNotify;
   const terminInPast = !!scheduledAt && new Date(scheduledAt).getTime() < Date.now();
 
   const kontaktDirty =
@@ -347,7 +361,9 @@ export function CaseDetailForm({
 
   /** Save + notify new assignees in one step */
   async function handleSaveAndNotifyAssignees() {
-    const namesToNotify = [...liveNewAssignees]; // capture before save updates baseline
+    const namesToNotify = liveNewAssignees.length > 0 ? [...liveNewAssignees] : [...selectedAssignees]; // capture before save updates baseline
+    // FB10: preserve termin pending state across save
+    if (liveTerminDirty) setTerminPendingSend(true);
     setAssigneeNotifyState("sending");
     const ok = await saveFields({
       status, urgency,
@@ -365,6 +381,7 @@ export function CaseDetailForm({
       });
       if (!res.ok) throw new Error("Benachrichtigung fehlgeschlagen");
       setAssigneeNotifyState("sent");
+      setAssigneePendingNotify(false);
       setTimeout(() => setAssigneeNotifyState("idle"), 3000);
       setLocalEvents(prev => [...prev, {
         id: crypto.randomUUID(), event_type: "assignee_notified",
@@ -379,6 +396,8 @@ export function CaseDetailForm({
 
   /** Save + send termin to all assignees + customer in one step */
   async function handleSaveAndSendTermin() {
+    // FB10: preserve assignee pending state across save
+    if (liveNewAssignees.length > 0) setAssigneePendingNotify(true);
     // Block sending past appointments
     if (scheduledAt && new Date(scheduledAt).getTime() < Date.now()) {
       setTerminSendState("error");
@@ -403,6 +422,7 @@ export function CaseDetailForm({
         if (!melderRes.ok) throw new Error("Kundenbenachrichtigung fehlgeschlagen");
       }
       setTerminSendState("sent");
+      setTerminPendingSend(false);
       setTimeout(() => setTerminSendState("idle"), 3000);
       setLocalEvents(prev => [...prev, {
         id: crypto.randomUUID(), event_type: "termin_versendet",
@@ -579,7 +599,7 @@ export function CaseDetailForm({
                 )}
 
                 {/* Zuständige benachrichtigen — sofort bei Änderung */}
-                {liveNewAssignees.length > 0 && assigneeNotifyState !== "sent" && (
+                {showAssigneeButton && assigneeNotifyState !== "sent" && (
                   <button
                     onClick={handleSaveAndNotifyAssignees}
                     disabled={assigneeNotifyState === "sending"}
@@ -603,8 +623,11 @@ export function CaseDetailForm({
                     )}
                   </button>
                 )}
-                {liveNewAssignees.length > 0 && assigneeNotifyState === "idle" && (
-                  <p className="text-xs text-gray-500 mt-1">Neu: {liveNewAssignees.join(", ")}</p>
+                {showAssigneeButton && assigneeNotifyState === "idle" && (
+                  <p className="text-xs text-gray-500 mt-1">
+                    {liveNewAssignees.length > 0 ? `Neu: ${liveNewAssignees.join(", ")}` : "Benachrichtigung ausstehend"}
+                    {ns.staffAssignment ? " — wird per E-Mail benachrichtigt" : ""}
+                  </p>
                 )}
                 {assigneeNotifyState === "sent" && (
                   <div className="flex items-center gap-1.5 mt-2">
@@ -659,17 +682,16 @@ export function CaseDetailForm({
                     )}
                   </button>
                 )}
-                {/* Channel hint: what channel will be used for customer notification */}
+                {/* Channel hint: dynamic based on contact data + tenant notification settings */}
                 {liveTerminChanged && terminSendState === "idle" && (
                   <p className="text-xs text-gray-500 mt-1">
-                    {!contactEmail.trim() && !contactPhone.trim()
-                      ? "Keine Kontaktdaten — Kunde wird nicht benachrichtigt"
-                      : !contactEmail.trim()
-                        ? "Kunde wird per SMS benachrichtigt"
-                        : contactPhone.trim()
-                          ? "Kunde wird per E-Mail + SMS benachrichtigt"
-                          : "Kunde wird per E-Mail benachrichtigt"
-                    }
+                    {(() => {
+                      const hasEmail = !!contactEmail.trim() && ns.terminEmail;
+                      const hasSms = !!contactPhone.trim() && ns.terminSms;
+                      if (!hasEmail && !hasSms) return "Kunde wird nicht benachrichtigt";
+                      const channels = [hasEmail && "E-Mail", hasSms && "SMS"].filter(Boolean).join(" + ");
+                      return `Kunde wird per ${channels} benachrichtigt`;
+                    })()}
                   </p>
                 )}
                 {/* No contact warning — shown instead of button */}

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -93,6 +93,14 @@ export default async function CaseDetailPage({
   const isProspect = scope?.isProspect ?? false;
   const brandColor = identity?.primaryColor ?? "#64748b";
 
+  // Load tenant modules for notification settings (channel hints)
+  const { data: tenantRow } = await supabase
+    .from("tenants")
+    .select("modules")
+    .eq("id", caseData.tenant_id)
+    .single();
+  const tenantModules = (tenantRow?.modules ?? {}) as Record<string, unknown>;
+
   // Resolve logged-in user for self-send guard + RBAC
   const authClient = await getAuthClient();
   const { data: { user } } = await authClient.auth.getUser();
@@ -155,6 +163,11 @@ export default async function CaseDetailPage({
         brandColor={brandColor}
         currentStaffName={currentStaffName}
         staffRole={staffRole}
+        notifySettings={{
+          terminEmail: tenantModules.notify_termin_email !== false,
+          terminSms: tenantModules.notify_termin_sms !== false,
+          staffAssignment: tenantModules.notify_staff_assignment !== false,
+        }}
       />
 
     </>

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -228,11 +228,11 @@ export function LeitzentraleView({ cases, caseIdPrefix, weekStats, reviewStats }
   };
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-3">
       {/* ═══════════════════════════════════════════════════════════════
           SYSTEMFLUSS-KARTEN
          ═══════════════════════════════════════════════════════════════ */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2">
         {FLUSS_CARDS.map((card) => {
           const isActive = activeFilter === card.key;
           const count = cardCounts[card.key];
@@ -240,14 +240,14 @@ export function LeitzentraleView({ cases, caseIdPrefix, weekStats, reviewStats }
             <button
               key={card.key}
               onClick={() => handleFilterClick(card.key)}
-              className={`text-left border-l-4 ${card.accentColor} bg-white rounded-xl p-4 shadow-sm hover:shadow transition border border-gray-200 ${
+              className={`text-left border-l-4 ${card.accentColor} bg-white rounded-xl px-3 py-2.5 shadow-sm hover:shadow transition border border-gray-200 ${
                 isActive ? `ring-2 ring-offset-2 ${card.ringColor}` : ""
               }`}
             >
-              <p className="text-[11px] font-semibold text-gray-500 uppercase tracking-wide">
+              <p className="text-[10px] font-semibold text-gray-500 uppercase tracking-wide">
                 {card.label}
               </p>
-              <p className={`text-2xl font-bold mt-1 ${count === 0 ? "text-gray-300" : "text-gray-900"}`}>
+              <p className={`text-xl font-bold mt-0.5 ${count === 0 ? "text-gray-300" : "text-gray-900"}`}>
                 {count}
               </p>
             </button>
@@ -313,25 +313,25 @@ export function LeitzentraleView({ cases, caseIdPrefix, weekStats, reviewStats }
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-gray-100">
-                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">
                   Nr
                 </th>
-                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">
                   Kunde
                 </th>
-                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">
                   Kat.
                 </th>
-                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">
                   Ort
                 </th>
-                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">
                   Priorität
                 </th>
-                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">
                   Status
                 </th>
-                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-4 py-3">
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">
                   Datum
                 </th>
               </tr>
@@ -354,15 +354,15 @@ export function LeitzentraleView({ cases, caseIdPrefix, weekStats, reviewStats }
                       isNotfall ? "border-l-4 border-l-red-500 bg-red-50/30" : ""
                     }`}
                   >
-                    <td className="px-4 py-3 font-mono text-xs text-gray-500 whitespace-nowrap">
+                    <td className="px-3 py-2 font-mono text-xs text-gray-500 whitespace-nowrap">
                       {formatCaseId(c.seq_number, caseIdPrefix)}
                     </td>
-                    <td className="px-4 py-3 text-gray-900 truncate max-w-[180px]">
+                    <td className="px-3 py-2 text-gray-900 truncate max-w-[180px]">
                       {c.reporter_name || <span className="text-gray-400">—</span>}
                     </td>
-                    <td className="px-4 py-3 text-gray-700 truncate max-w-[140px]">{c.category}</td>
-                    <td className="px-4 py-3 text-gray-600 truncate max-w-[120px]">{c.city || "—"}</td>
-                    <td className="px-4 py-3">
+                    <td className="px-3 py-2 text-gray-700 truncate max-w-[140px]">{c.category}</td>
+                    <td className="px-3 py-2 text-gray-600 truncate max-w-[120px]">{c.city || "—"}</td>
+                    <td className="px-3 py-2">
                       <span className="inline-flex items-center gap-1.5">
                         <span className={`w-2 h-2 rounded-full flex-shrink-0 ${URGENCY_DOT[c.urgency] ?? "bg-gray-400"}`} />
                         <span className="text-xs text-gray-600">
@@ -370,7 +370,7 @@ export function LeitzentraleView({ cases, caseIdPrefix, weekStats, reviewStats }
                         </span>
                       </span>
                     </td>
-                    <td className="px-4 py-3">
+                    <td className="px-3 py-2">
                       <span
                         className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${
                           STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-700"
@@ -379,7 +379,7 @@ export function LeitzentraleView({ cases, caseIdPrefix, weekStats, reviewStats }
                         {STATUS_LABELS[c.status] ?? c.status}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-xs text-gray-500 whitespace-nowrap">
+                    <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
                       {formatDate(c.created_at)}
                     </td>
                   </tr>

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -310,7 +310,7 @@ export function OpsShell({
             </div>
           </div>
         ) : (
-          <div className="max-w-6xl mx-auto px-4 py-6 min-w-0">
+          <div className="max-w-6xl mx-auto px-4 py-4 min-w-0">
             {children}
           </div>
         )}


### PR DESCRIPTION
## Summary
- **FB7:** Leitzentrale fits on 100% zoom — compact cards (p-2.5, gap-2), tighter table rows (py-2), reduced spacing
- **FB8:** Channel hint text dynamically reflects Einstellungen (E-Mail/SMS toggles). If SMS disabled → no "SMS" in hint.
- **FB9:** (Compliment — no changes needed)
- **FB10:** "Benachrichtigen" and "Termin versenden" buttons work independently — clicking one no longer hides the other

## Test plan
- [ ] Open Leitzentrale at 100% zoom → cards + 15-row table + pagination should fit without scrolling
- [ ] Disable "SMS-Terminbestätigung" in Einstellungen → hint should say "per E-Mail" (not "E-Mail + SMS")
- [ ] Assign staff + set termin → click "Benachrichtigen" → verify "Termin versenden" button remains
- [ ] Assign staff + set termin → click "Termin versenden" → verify "Benachrichtigen" button remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)