### PR TITLE
fix: FB11-FB14 button style, search, termin, PWA deep links

### DIFF
--- a/src/web/app/api/ops/pwa/manifest/route.ts
+++ b/src/web/app/api/ops/pwa/manifest/route.ts
@@ -36,9 +36,12 @@ export async function GET() {
     short_name: shortName,
     description: "Fälle, Termine und Team auf einen Blick.",
     start_url: "/ops/cases",
-    scope: "/ops/",
+    scope: "/",
     display: "standalone" as const,
     display_override: ["standalone"],
+    // Deep linking: prefer opening links in installed PWA instead of browser
+    handle_links: "preferred",
+    launch_handler: { client_mode: "focus-existing" },
     background_color: "#1a2744",
     theme_color: "#1a2744",
     orientation: "portrait-primary" as const,

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -782,8 +782,8 @@ export function CaseDetailForm({
               </KV>
               <KV label="Termin">
                 {scheduledAt ? (
-                  <span className="inline-block px-2.5 py-0.5 rounded-full bg-gray-100 text-sm font-medium text-gray-700 text-center leading-snug">
-                    {(() => { const r = formatTerminRange(scheduledAt, scheduledEndAt || null); return r.line2 ? <>{r.line1}<br className="sm:hidden" /><span className="hidden sm:inline"> </span>{r.line2}</> : r.line1; })()}
+                  <span className="inline-block px-2.5 py-0.5 rounded-full bg-gray-100 text-[11px] sm:text-sm font-medium text-gray-700 leading-tight sm:leading-snug max-w-full">
+                    {(() => { const r = formatTerminRange(scheduledAt, scheduledEndAt || null); return r.line2 ? <>{r.line1}<br />{r.line2}</> : r.line1; })()}
                   </span>
                 ) : (
                   <span className="inline-block px-2.5 py-0.5 rounded-full bg-gray-100 text-sm font-medium text-gray-500">Offen</span>
@@ -828,7 +828,7 @@ export function CaseDetailForm({
                     <p className={`text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-words ${!descExpanded ? "line-clamp-2 sm:line-clamp-3" : ""}`} style={{ hyphens: "auto", WebkitHyphens: "auto" }} lang="de">{description}</p>
                     {(description.split("\n").length > 2 || description.length > 80) && (
                       <button onClick={() => setDescExpanded(p => !p)}
-                        className="inline-flex items-center rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 mt-2 transition-colors min-h-[44px] sm:min-h-0">
+                        className="text-xs text-gray-400 hover:text-gray-600 mt-1 transition-colors min-h-[44px] sm:min-h-0 flex items-center">
                         {descExpanded ? "Weniger" : "Alles anzeigen"}
                       </button>
                     )}

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -125,12 +125,30 @@ function matchesFilter(c: LeitzentraleCase, filter: FilterKey): boolean {
 
 function matchesSearch(c: LeitzentraleCase, query: string): boolean {
   const q = query.toLowerCase();
-  return (
-    (c.reporter_name ?? "").toLowerCase().includes(q) ||
-    c.city.toLowerCase().includes(q) ||
-    c.category.toLowerCase().includes(q) ||
-    c.description.toLowerCase().includes(q)
-  );
+  // Search across ALL visible fields — scalable, comprehensive
+  const fields = [
+    c.reporter_name,
+    c.city,
+    c.plz,
+    c.street,
+    c.house_number,
+    c.category,
+    c.description,
+    c.assignee_text,
+    c.source,
+    // Labels (so users can search "dringend", "notfall", "erledigt", etc.)
+    STATUS_LABELS[c.status],
+    c.status,
+    URGENCY_LABEL[c.urgency],
+    c.urgency,
+    // Case ID
+    c.seq_number != null ? String(c.seq_number) : null,
+    // Date (multiple formats: "14.03", "14.03.2026", "März")
+    new Date(c.created_at).toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", timeZone: "Europe/Zurich" }),
+    new Date(c.created_at).toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", timeZone: "Europe/Zurich" }),
+    new Date(c.created_at).toLocaleDateString("de-CH", { day: "numeric", month: "long", timeZone: "Europe/Zurich" }),
+  ];
+  return fields.some(f => f && f.toLowerCase().includes(q));
 }
 
 function formatDate(iso: string): string {
@@ -290,7 +308,7 @@ export function LeitzentraleView({ cases, caseIdPrefix, weekStats, reviewStats }
           </svg>
           <input
             type="text"
-            placeholder="Suche nach Kunde, Ort, Kategorie..."
+            placeholder="Suche nach Kunde, Ort, Datum, Status..."
             value={searchQuery}
             onChange={(e) => handleSearchChange(e.target.value)}
             className="w-full pl-9 pr-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 transition"


### PR DESCRIPTION
## Summary
- **FB11:** "Alles anzeigen" button — plain text link style (matches Interne Notizen), no border pill
- **FB12:** Termin pill on mobile — `text-[11px]` + `leading-tight`, always 2-line break for multi-day ranges
- **FB13:** Full-field search — now searches date, status/priority labels, PLZ, street, house number, assignee, case ID, source. Placeholder updated.
- **FB14:** PWA deep linking — `scope: "/"` (was `/ops/`), `handle_links: "preferred"`, `launch_handler: focus-existing`. E-Mail links should now open in installed PWA on supported devices.

## Test plan
- [ ] Description "Alles anzeigen" — no border, plain text like Notizen section
- [ ] Multi-day termin on mobile — should be 2 lines, smaller font
- [ ] Search "14.03" → should find cases from that date
- [ ] Search "dringend" → should find urgent cases
- [ ] Search "8800" (PLZ) → should find matching cases
- [ ] Click link from notification email on phone with PWA installed → should open in PWA

🤖 Generated with [Claude Code](https://claude.com/claude-code)