### PR TITLE
fix: tenant isolation hardening — mismatch warning + R4

### DIFF
--- a/src/web/app/api/ops/cases/[id]/send-invite/route.ts
+++ b/src/web/app/api/ops/cases/[id]/send-invite/route.ts
@@ -221,9 +221,11 @@ export async function POST(
     ? new Date(row.scheduled_end_at)
     : new Date(dtStart.getTime() + 60 * 60 * 1000);
 
-  const fromEnvValue = process.env.MAIL_FROM;
-  const from = fromEnvValue ?? "noreply@send.flowsight.ch";
-  const organizerEmail = from;
+  // R4: tenant-branded sender — tenant name in From header
+  const addr = process.env.MAIL_FROM ?? "noreply@send.flowsight.ch";
+  const safeTenantName = tenantName.replace(/[<>"]/g, "");
+  const from = `${safeTenantName} <${addr}>`;
+  const organizerEmail = addr;
 
   const baseUrl =
     process.env.APP_URL ??

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -92,6 +92,8 @@ export default async function CaseDetailPage({
   const caseId = formatCaseId(caseData.seq_number, identity?.caseIdPrefix);
   const isProspect = scope?.isProspect ?? false;
   const brandColor = identity?.primaryColor ?? "#64748b";
+  // Tenant mismatch detection — admin viewing another tenant's case
+  const isForeignTenant = scope?.isAdmin && scope.tenantId && caseData.tenant_id !== scope.tenantId;
 
   // Load tenant modules for notification settings (channel hints)
   const { data: tenantRow } = await supabase
@@ -154,6 +156,13 @@ export default async function CaseDetailPage({
           </span>
         </div>
       </div>
+
+      {/* Tenant mismatch warning — prevents accidentally emailing from wrong tenant */}
+      {isForeignTenant && identity && (
+        <div className="mb-3 px-4 py-3 rounded-xl bg-amber-50 border border-amber-200 text-amber-800 text-sm font-medium">
+          ⚠️ Dieser Fall gehört zu <strong>{identity.displayName}</strong>, nicht zum aktuell eingeloggten Betrieb. E-Mails werden im Namen von {identity.displayName} versendet.
+        </div>
+      )}
 
       {/* Case surface */}
       <CaseDetailForm

--- a/src/web/src/lib/tenants/resolveTenantIdentity.ts
+++ b/src/web/src/lib/tenants/resolveTenantIdentity.ts
@@ -102,34 +102,9 @@ export async function resolveTenantIdentity(
       }
     }
 
-    // Fallback: pick first tenant (admin without tenant_id, or single-tenant MVP).
-    // Admin sees all cases via RLS anyway — this just provides branding context.
-    const { data: tenants } = await supabase
-      .from("tenants")
-      .select("id, name, slug, case_id_prefix, modules")
-      .order("created_at", { ascending: true })
-      .limit(1);
-
-    if (tenants && tenants.length === 1) {
-      const t = tenants[0];
-      const modules = t.modules as Record<string, unknown> | null;
-      const shortName =
-        typeof modules?.sms_sender_name === "string"
-          ? modules.sms_sender_name
-          : t.name;
-      return {
-        tenantId: t.id,
-        displayName: t.name,
-        shortName,
-        leitsystemName: deriveLeitsystemName(modules, shortName),
-        caseIdPrefix: t.case_id_prefix ?? "FS",
-        primaryColor:
-          typeof modules?.primary_color === "string"
-            ? modules.primary_color
-            : FALLBACK.primaryColor,
-      };
-    }
-
+    // SAFETY: No fallback to "first tenant" — this caused Brunner HT to leak
+    // into Weinberger contexts. Admin without tenant_id gets neutral branding.
+    // Email routes use resolveTenantIdentityById(case.tenant_id) which is always correct.
     return null;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

**Root Cause Analysis:**
Case FS-0034 genuinely belongs to Brunner HT (demo tenant). All email routes correctly use `resolveTenantIdentityById(case.tenant_id)` — the emails showed "Brunner HT" because the case IS a Brunner case. The admin was viewing demo-tenant cases alongside Weinberger cases without visual distinction.

**Fixes:**
- **send-invite:** Add tenant display name to `From:` header (was naked email address)
- **resolveTenantIdentity:** Remove dangerous admin fallback that picked oldest tenant (Brunner HT). Admin now gets neutral "Leitsystem" branding.
- **Case detail:** Amber warning banner when viewing a foreign tenant's case: "Dieser Fall gehört zu [X], nicht zum eingeloggten Betrieb"

## Test plan
- [ ] Open a Brunner HT case as admin → see amber tenant mismatch warning
- [ ] Open a Weinberger case as admin → no warning (same tenant)
- [ ] Send termin from Weinberger case → email From shows "Weinberger AG"
- [ ] Sidebar shows "Leitsystem" if no tenant context (fallback removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)