### PR TITLE
fix: FB19-FB21 tenant scope, staff, nav

### DIFF
--- a/src/web/app/ops/(dashboard)/settings/page.tsx
+++ b/src/web/app/ops/(dashboard)/settings/page.tsx
@@ -287,57 +287,6 @@ export default function SettingsPage() {
           )}
         </Section>
 
-        {/* Termine — per-card save */}
-        <Section
-          title="Termine"
-          description="Kalender-E-Mail und Standard-Termindauer."
-        >
-          <div className="space-y-3">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Kalender-E-Mail</label>
-              <input
-                type="email"
-                value={calendarEmail}
-                onChange={(e) => setCalendarEmail(e.target.value)}
-                placeholder="kalender@mein-betrieb.ch"
-                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 truncate min-w-0"
-              />
-              <p className="mt-1 text-xs text-gray-400">
-                ICS-Kalendereinladungen werden an diese Adresse gesendet (z.B. Outlook oder Google Kalender).
-              </p>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Standard-Termindauer</label>
-              <select
-                value={appointmentDuration}
-                onChange={(e) => setAppointmentDuration(Number(e.target.value))}
-                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400"
-              >
-                <option value={30}>30 Minuten</option>
-                <option value={45}>45 Minuten</option>
-                <option value={60}>60 Minuten</option>
-                <option value={90}>90 Minuten</option>
-                <option value={120}>2 Stunden</option>
-              </select>
-              <p className="mt-1 text-xs text-gray-400">
-                Wird bei neuen Terminen als Vorgabe verwendet.
-              </p>
-            </div>
-          </div>
-          {terminSettingsDirty && (
-            <CardSaveBar
-              saving={terminSettingsSaving}
-              saved={terminSettingsSaved}
-              error={terminSettingsError}
-              onSave={saveTerminSettings}
-              onCancel={() => {
-                setCalendarEmail(calendarEmailBaseline);
-                setAppointmentDuration(appointmentDurationBaseline);
-              }}
-            />
-          )}
-        </Section>
-
         {/* Google Review — per-card save */}
         <Section
           title="Google-Bewertungen"

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -15,6 +15,7 @@ interface NavItem {
   label: string;
   href: string;
   icon: React.ReactNode;
+  disabled?: boolean;
 }
 
 const NAV_ITEMS: NavItem[] = [
@@ -24,6 +25,16 @@ const NAV_ITEMS: NavItem[] = [
     icon: (
       <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />
+      </svg>
+    ),
+  },
+  {
+    label: "Einsatzplanung",
+    href: "#",
+    disabled: true,
+    icon: (
+      <svg className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
       </svg>
     ),
   },
@@ -116,6 +127,18 @@ export function OpsShell({
     <nav className="flex-1 px-3 py-5">
       <div className="space-y-1">
         {visibleNavItems.map((item) => {
+          if (item.disabled) {
+            return (
+              <div
+                key={item.label}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-gray-600 cursor-default opacity-50"
+              >
+                {item.icon}
+                <span>{item.label}</span>
+                <span className="ml-auto text-[10px] text-gray-600 bg-gray-800 px-1.5 py-0.5 rounded">Bald</span>
+              </div>
+            );
+          }
           const active = isNavActive(item.href);
           return (
             <Link

--- a/src/web/src/components/ops/StaffManager.tsx
+++ b/src/web/src/components/ops/StaffManager.tsx
@@ -257,6 +257,14 @@ export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
             >
               Abbrechen
             </button>
+            {editingId && (
+              <button
+                onClick={() => { handleDeactivate(editingId); resetForm(); }}
+                className="rounded-lg border border-red-200 px-4 py-2 text-xs font-medium text-red-600 hover:bg-red-50 transition-colors ml-auto"
+              >
+                Entfernen
+              </button>
+            )}
             {errorMsg && <span className="text-xs text-red-600">{errorMsg}</span>}
           </div>
         </div>
@@ -273,35 +281,37 @@ export function StaffManager({ tenantId, embedded }: StaffManagerProps) {
             <table className="w-full text-sm">
               <thead>
                 <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-200 bg-slate-50/80">
-                  <th className="px-4 py-3 font-medium">Name</th>
-                  <th className="px-4 py-3 font-medium">Rolle</th>
-                  <th className="px-4 py-3 font-medium hidden sm:table-cell">E-Mail</th>
-                  <th className="px-4 py-3 font-medium hidden sm:table-cell">Telefon</th>
-                  <th className="px-4 py-3 font-medium w-24"></th>
+                  <th className="px-3 py-2.5 font-medium">Name</th>
+                  <th className="px-3 py-2.5 font-medium">
+                    <span className="flex items-center gap-1">
+                      Rolle
+                      <button
+                        type="button"
+                        onClick={() => setShowRoleInfo(p => !p)}
+                        className="inline-flex items-center justify-center w-4 h-4 rounded-full border border-gray-300 text-gray-400 hover:text-gray-600 hover:border-gray-400 transition-colors text-[10px] font-bold leading-none"
+                        title="Was bedeuten die Rollen?"
+                      >i</button>
+                    </span>
+                  </th>
+                  <th className="px-3 py-2.5 font-medium hidden sm:table-cell">E-Mail</th>
+                  <th className="px-3 py-2.5 font-medium hidden sm:table-cell">Telefon</th>
+                  <th className="px-3 py-2.5 font-medium w-20"></th>
                 </tr>
               </thead>
               <tbody>
                 {staff.map((s) => (
                   <tr key={s.id} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
-                    <td className="px-4 py-3 font-medium text-gray-900 max-w-[140px] truncate">{s.display_name}</td>
-                    <td className="px-4 py-3 text-gray-600">{ROLE_LABELS[s.role] ?? s.role}</td>
-                    <td className="px-4 py-3 text-gray-500 hidden sm:table-cell max-w-[180px] truncate">{s.email ?? "—"}</td>
-                    <td className="px-4 py-3 text-gray-500 hidden sm:table-cell max-w-[140px] truncate">{s.phone ?? "—"}</td>
-                    <td className="px-4 py-3">
-                      <div className="flex gap-1">
-                        <button
-                          onClick={() => startEdit(s)}
-                          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                        >
-                          Bearbeiten
-                        </button>
-                        <button
-                          onClick={() => handleDeactivate(s.id)}
-                          className="text-xs text-red-400 hover:text-red-600 transition-colors ml-2"
-                        >
-                          Entfernen
-                        </button>
-                      </div>
+                    <td className="px-3 py-2.5 font-medium text-gray-900 text-[13px] sm:text-sm max-w-[120px] sm:max-w-[140px] truncate">{s.display_name}</td>
+                    <td className="px-3 py-2.5 text-gray-600 text-[13px] sm:text-sm">{ROLE_LABELS[s.role] ?? s.role}</td>
+                    <td className="px-3 py-2.5 text-gray-500 hidden sm:table-cell max-w-[180px] truncate">{s.email ?? "—"}</td>
+                    <td className="px-3 py-2.5 text-gray-500 hidden sm:table-cell max-w-[140px] truncate">{s.phone ?? "—"}</td>
+                    <td className="px-3 py-2.5">
+                      <button
+                        onClick={() => startEdit(s)}
+                        className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                      >
+                        Bearbeiten
+                      </button>
                     </td>
                   </tr>
                 ))}

--- a/src/web/src/lib/supabase/resolveTenantScope.ts
+++ b/src/web/src/lib/supabase/resolveTenantScope.ts
@@ -43,7 +43,9 @@ export async function resolveTenantScope(): Promise<TenantScope | null> {
   const isProspect = role === "prospect";
 
   return {
-    tenantId: isAdmin ? null : (tenantId ?? null),
+    // Admin keeps their tenant_id for branding/settings, but isAdmin=true
+    // allows viewing all tenants' cases via RLS bypass
+    tenantId: tenantId ?? null,
     isAdmin,
     isProspect,
     userId: user.id,


### PR DESCRIPTION
## Summary

**FB19 CRITICAL — "Dörfler AG" on Weinberger Einstellungen:**
- Root cause: `resolveTenantScope()` set `tenantId = null` for admins → settings API picked first DB tenant (Dörfler)
- Fix: Admin now keeps their `tenant_id` from JWT (Weinberger) while retaining `isAdmin=true` for cross-tenant case visibility
- This also scopes the Leitzentrale to the admin's tenant — no more Brunner demo cases mixed in

**FB19 — Staff table mobile:**
- Mobile: only Name + Rolle + Bearbeiten (3 columns, no horizontal scroll)
- "Entfernen" integrated into Bearbeiten form (red button)
- Info (i) button behind "Rolle" now visible in table header (both edit and view modes)
- Smaller text on mobile (13px)

**FB20 — Termin card:** Removed from Einstellungen completely

**FB21 — Einsatzplanung:** Added as disabled nav item with "Bald" badge

## Test plan
- [ ] Open Einstellungen → verify "Jul. Weinberger AG" (NOT "Dörfler AG")
- [ ] Leitzentrale → verify only Weinberger cases shown (no Brunner demo cases)
- [ ] Staff table on mobile → 3 columns, no scroll, "Entfernen" inside Bearbeiten
- [ ] Info (i) button visible in Rolle header column
- [ ] Sidebar → "Einsatzplanung" greyed out with "Bald" badge
- [ ] Termin card gone from Einstellungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)