### PR TITLE
fix: cookie path + role switch for testing

### DIFF
--- a/src/web/app/api/ops/switch-tenant/route.ts
+++ b/src/web/app/api/ops/switch-tenant/route.ts
@@ -3,6 +3,7 @@ import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 
 const COOKIE_NAME = "fs_active_tenant";
 const RECENT_COOKIE = "fs_recent_tenants";
+const ROLE_COOKIE = "fs_view_as_role";
 const MAX_RECENT = 3;
 
 /**
@@ -19,15 +20,16 @@ export async function POST(request: NextRequest) {
 
   const body = await request.json().catch(() => ({}));
   const tenantId = body.tenantId as string | null;
+  const viewAsRole = body.viewAsRole as string | null; // "techniker" or null
 
-  const res = NextResponse.json({ ok: true, tenantId });
+  const res = NextResponse.json({ ok: true, tenantId, viewAsRole });
 
   if (tenantId && /^[0-9a-f-]{36}$/i.test(tenantId)) {
     // Set active tenant cookie
     res.cookies.set(COOKIE_NAME, tenantId, {
       httpOnly: true,
       sameSite: "lax",
-      path: "/ops",
+      path: "/",
       maxAge: 60 * 60 * 24 * 30, // 30 days
     });
 
@@ -39,12 +41,24 @@ export async function POST(request: NextRequest) {
     res.cookies.set(RECENT_COOKIE, JSON.stringify(recent), {
       httpOnly: true,
       sameSite: "lax",
-      path: "/ops",
+      path: "/",
       maxAge: 60 * 60 * 24 * 30,
     });
   } else {
     // Clear → reset to home tenant (JWT)
-    res.cookies.delete({ name: COOKIE_NAME, path: "/ops" });
+    res.cookies.delete({ name: COOKIE_NAME, path: "/" });
+  }
+
+  // Role override cookie (admin can view as techniker for testing)
+  if (viewAsRole === "techniker") {
+    res.cookies.set(ROLE_COOKIE, "techniker", {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 30,
+    });
+  } else {
+    res.cookies.delete({ name: ROLE_COOKIE, path: "/" });
   }
 
   return res;

--- a/src/web/app/ops/(dashboard)/layout.tsx
+++ b/src/web/app/ops/(dashboard)/layout.tsx
@@ -30,12 +30,16 @@ export default async function DashboardLayout({
     ? await resolveTenantIdentityById(scope.tenantId)
     : null;
 
-  // Resolve staff role for RBAC
+  // Resolve staff role for RBAC (respects viewAsRole override)
   let staffRole: "admin" | "techniker" | undefined;
   const effectiveTenantId = scope?.tenantId ?? identity?.tenantId;
   if (effectiveTenantId && user.email) {
     const ctx = await resolveStaffRole(user.email, effectiveTenantId);
     if (ctx) staffRole = ctx.role;
+  }
+  // Admin can override role for testing
+  if (scope?.isAdmin && scope.viewAsRole === "techniker") {
+    staffRole = "techniker";
   }
 
   return (
@@ -48,6 +52,7 @@ export default async function DashboardLayout({
       isImpersonating={scope?.isImpersonating}
       activeTenantId={scope?.tenantId}
       homeTenantId={scope?.homeTenantId}
+      viewAsRole={scope?.viewAsRole}
     >
       {children}
     </OpsShell>

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -73,6 +73,7 @@ export function OpsShell({
   isImpersonating,
   activeTenantId,
   homeTenantId,
+  viewAsRole,
   children,
 }: {
   userEmail: string;
@@ -89,6 +90,8 @@ export function OpsShell({
   activeTenantId?: string | null;
   /** Admin's own JWT tenant ID (for "Mein Betrieb" reset) */
   homeTenantId?: string | null;
+  /** Role override for testing (admin views as techniker) */
+  viewAsRole?: "techniker" | null;
   children: React.ReactNode;
 }) {
   // Identity Contract R4: No "FlowSight" visible to end users
@@ -272,7 +275,7 @@ export function OpsShell({
     <>
       {brandHeader}
       {isAdmin && (
-        <TenantSwitcher activeTenantId={activeTenantId ?? null} homeTenantId={homeTenantId ?? null} />
+        <TenantSwitcher activeTenantId={activeTenantId ?? null} homeTenantId={homeTenantId ?? null} viewAsRole={viewAsRole} />
       )}
       {navLinks}
       {footer}
@@ -337,10 +340,12 @@ export function OpsShell({
 
       {/* Main content */}
       <main className="md:ml-64 overflow-x-hidden">
-        {/* Impersonation banner — admin viewing another tenant */}
-        {isImpersonating && (
+        {/* Impersonation banner — admin viewing another tenant or role */}
+        {(isImpersonating || viewAsRole) && (
           <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-center text-amber-800 text-xs font-medium sticky top-0 z-20 md:top-0">
-            Ansicht: <strong>{tenantName}</strong> — Nicht Ihr Betrieb
+            {isImpersonating && <>Ansicht: <strong>{tenantName}</strong></>}
+            {isImpersonating && viewAsRole && <> · </>}
+            {viewAsRole && <>Rolle: <strong>Techniker</strong></>}
           </div>
         )}
         <InstallPrompt />

--- a/src/web/src/components/ops/TenantSwitcher.tsx
+++ b/src/web/src/components/ops/TenantSwitcher.tsx
@@ -13,9 +13,10 @@ interface Tenant {
 interface TenantSwitcherProps {
   activeTenantId: string | null;
   homeTenantId: string | null;
+  viewAsRole?: "techniker" | null;
 }
 
-export function TenantSwitcher({ activeTenantId, homeTenantId }: TenantSwitcherProps) {
+export function TenantSwitcher({ activeTenantId, homeTenantId, viewAsRole }: TenantSwitcherProps) {
   const router = useRouter();
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [open, setOpen] = useState(false);
@@ -39,16 +40,28 @@ export function TenantSwitcher({ activeTenantId, homeTenantId }: TenantSwitcherP
     return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
 
-  async function switchTo(tenantId: string | null) {
+  async function switchTo(tenantId: string | null, role?: "techniker" | null) {
     setSwitching(true);
     setOpen(false);
     await fetch("/api/ops/switch-tenant", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tenantId }),
+      body: JSON.stringify({ tenantId, viewAsRole: role ?? null }),
     });
     router.refresh();
-    // Small delay to let server re-render with new cookie
+    setTimeout(() => setSwitching(false), 500);
+  }
+
+  async function toggleRole() {
+    const newRole = viewAsRole === "techniker" ? null : "techniker";
+    setSwitching(true);
+    setOpen(false);
+    await fetch("/api/ops/switch-tenant", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tenantId: activeTenantId, viewAsRole: newRole }),
+    });
+    router.refresh();
     setTimeout(() => setSwitching(false), 500);
   }
 
@@ -130,6 +143,19 @@ export function TenantSwitcher({ activeTenantId, homeTenantId }: TenantSwitcherP
               </button>
             );
           })}
+
+          {/* Role toggle — test as techniker */}
+          <button
+            onClick={toggleRole}
+            className="w-full flex items-center gap-2.5 px-3 py-3 hover:bg-white/[0.06] transition-colors border-t border-gray-800 min-h-[44px]"
+          >
+            <svg className="w-4 h-4 text-violet-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+            </svg>
+            <span className="text-[12px] text-violet-400 font-medium">
+              {viewAsRole === "techniker" ? "Zurück zu Admin" : "Als Techniker ansehen"}
+            </span>
+          </button>
         </div>
       )}
     </div>

--- a/src/web/src/lib/supabase/resolveTenantScope.ts
+++ b/src/web/src/lib/supabase/resolveTenantScope.ts
@@ -9,6 +9,7 @@ import { getAuthClient } from "./server-auth";
 // ---------------------------------------------------------------------------
 
 const TENANT_COOKIE = "fs_active_tenant";
+const ROLE_COOKIE = "fs_view_as_role";
 
 export interface TenantScope {
   /** Active tenant ID for scoping queries, branding, settings. */
@@ -23,6 +24,8 @@ export interface TenantScope {
   isImpersonating: boolean;
   /** Admin's own tenant_id from JWT (for "Mein Betrieb" reset). */
   homeTenantId: string | null;
+  /** Role override for testing: "techniker" when admin views as techniker. */
+  viewAsRole: "techniker" | null;
 }
 
 /**
@@ -51,6 +54,7 @@ export async function resolveTenantScope(): Promise<TenantScope | null> {
   // Admin cookie override — only trusted when JWT proves admin role
   let activeTenantId = jwtTenantId ?? null;
   let isImpersonating = false;
+  let viewAsRole: "techniker" | null = null;
 
   if (isAdmin) {
     const cookieStore = await cookies();
@@ -59,6 +63,9 @@ export async function resolveTenantScope(): Promise<TenantScope | null> {
       activeTenantId = cookieVal;
       isImpersonating = cookieVal !== (jwtTenantId ?? "");
     }
+    // Role override cookie — admin can test as techniker
+    const roleCookie = cookieStore.get(ROLE_COOKIE)?.value;
+    if (roleCookie === "techniker") viewAsRole = "techniker";
   }
 
   return {
@@ -68,5 +75,6 @@ export async function resolveTenantScope(): Promise<TenantScope | null> {
     userId: user.id,
     isImpersonating,
     homeTenantId: jwtTenantId ?? null,
+    viewAsRole,
   };
 }


### PR DESCRIPTION
## Summary

**Bug Fix — Settings showed wrong tenant:**
- Cookie path was `/ops` → API routes at `/api/ops/*` didn't receive it
- Fixed: path `/` → all routes receive the tenant override cookie

**Role Switch (Admin → Techniker):**
- New toggle in tenant dropdown: "Als Techniker ansehen"
- Sets `fs_view_as_role=techniker` cookie → layout overrides staffRole
- Admin sees Techniker-Leitzentrale (personal greeting, my cases, my appointments)
- "Zurück zu Admin" resets to admin view
- Amber banner: "Rolle: Techniker" when active
- Combined with tenant switch: "Ansicht: Brunner HT · Rolle: Techniker"

## Test plan
- [ ] Switch to Brunner → Settings shows "Brunner Haustechnik AG" (NOT Weinberger)
- [ ] Staff list shows Brunner's staff (NOT Weinberger's)
- [ ] Click "Als Techniker ansehen" → see Techniker-Leitzentrale
- [ ] Banner: "Rolle: Techniker"
- [ ] Click "Zurück zu Admin" → back to Admin view

🤖 Generated with [Claude Code](https://claude.com/claude-code)