### PR TITLE
fix: RM18-22 role toggle, equal KPIs, hooks crash, seed data

### DIFF
--- a/docs/redesign/leitstand/plan_bewertungen.md
+++ b/docs/redesign/leitstand/plan_bewertungen.md
@@ -1,0 +1,85 @@
+# Bewertungen — Ganzheitlicher Prozess-Plan
+
+## Ist-Zustand
+
+- **Bewertungsanfrage:** `review_sent_at` Timestamp auf Case (manuell gesetzt)
+- **Keine Rückmeldung-Tracking:** Kein Feld für "Bewertung erhalten" oder Rating-Wert
+- **Google-Anbindung:** Keine (manueller Refresh als bewusste Entscheidung)
+- **Darstellung:** Sterne-Widget in FlowBar, "X von Y" Anzeige
+
+## Prozess E2E
+
+```
+Fall erledigt → Bewertungsanfrage senden → Kunde bewertet auf Google → Rating erfassen → Analyse
+```
+
+### Schritt 1: Bewertungsanfrage
+- **Wann:** Nach Fallabschluss (status=done), manuell durch Betrieb
+- **Wie:** E-Mail mit direktem Google-Bewertungslink
+- **Max:** 2 Anfragen pro Fall (bestehende Regel)
+- **Tracking:** `review_sent_at` (erster Versand), `review_sent_count` (Anzahl)
+
+### Schritt 2: Rückmeldung erfassen
+- **Neues Feld:** `review_rating` (1-5, nullable) — manuell eingetragen
+- **Neues Feld:** `review_received_at` (timestamp) — wann eingegangen
+- **Kein Auto-Sync:** Bewusste Entscheidung (kein Google API in MVP)
+- **Manueller Refresh:** Betrieb prüft Google-Profil, trägt Rating ein
+
+### Schritt 3: Darstellung
+
+#### FlowBar (KPI-Kachel "Bewertung")
+- **Sterne:** Immer 5 Sterne anzeigen, gefüllt nach Durchschnitt (Gold)
+- **Kein Strich:** Wenn kein Rating vorhanden → "Noch keine" statt "—"
+- **Zahl:** Durchschnitts-Rating (z.B. "4.7")
+- **Sub:** "X erhalten / Y angefragt" (statt "X von Y")
+
+#### Admin-Sicht
+- Sieht alle Bewertungen aller Fälle
+- Aggregat: Durchschnitt, Anzahl angefragt vs. erhalten, Antwortquote
+- Bewertungen 1-3 Sterne: Rot markiert (Handlungsbedarf)
+- Bewertungen 4-5 Sterne: Grün markiert (Erfolg)
+
+#### Techniker-Sicht
+- Sieht nur Bewertungen seiner eigenen Fälle
+- Gleiche Darstellung: persönlicher Durchschnitt, eigene Anfragen/Antworten
+- Motivation: "Deine Kunden bewerten dich mit 4.8 ★"
+
+### Schritt 4: Analyse (Handlungsbedarf)
+
+| Rating | Bedeutung | Aktion |
+|--------|-----------|--------|
+| 5 ★ | Exzellent | Zitat als Featured Review nutzen |
+| 4 ★ | Gut | Keine Aktion nötig |
+| 3 ★ | Mittelmässig | Betrieb prüft, ob Nachfrage sinnvoll |
+| 1-2 ★ | Schlecht | Sofort-Alert an Admin, Nachbearbeitung |
+
+### Schritt 5: Google-Strategie
+- **Ziel:** Nur 4-5-Sterne-Bewertungen auf Google
+- **1-3 Sterne:** Intern erfassen, NICHT auf Google-Link drängen
+- **Pre-Filter:** Bewertungsanfrage-E-Mail könnte "Waren Sie zufrieden?" fragen:
+  - Ja → Google-Link
+  - Nein → Internes Feedback-Formular (kein Google)
+- **Phase 2 Feature:** Optional, nicht im MVP
+
+## DB-Änderungen (Migration)
+
+```sql
+ALTER TABLE cases
+  ADD COLUMN review_rating smallint CHECK (review_rating >= 1 AND review_rating <= 5),
+  ADD COLUMN review_received_at timestamptz,
+  ADD COLUMN review_sent_count smallint DEFAULT 0;
+```
+
+## UI-Änderungen
+
+1. **FlowBar:** Durchschnitt aus `review_rating` (statt statisch null), Sterne gold, kein "—"
+2. **CaseDetailForm:** Feld "Bewertung" (1-5 Sterne-Picker) + "Anfrage senden" Button
+3. **Tabelle:** Optional: Bewertungsspalte für erledigte Fälle
+
+## Reihenfolge
+
+1. Migration (review_rating, review_received_at, review_sent_count)
+2. CaseDetailForm: Rating-Eingabe
+3. FlowBar: Durchschnittsberechnung aus DB
+4. Admin-Analyse: Antwortquote, Handlungsbedarf bei 1-3 Sternen
+5. (Phase 2) Pre-Filter in Bewertungs-E-Mail

--- a/src/web/src/components/ops/FlowBar.tsx
+++ b/src/web/src/components/ops/FlowBar.tsx
@@ -175,7 +175,7 @@ export function FlowBar({
           })}
 
           {/* Arrow to stars */}
-          <div className="flex items-center gap-1.5 sm:gap-2.5 min-w-0">
+          <div className="flex items-center gap-1.5 sm:gap-2.5 flex-1 min-w-0">
             <svg
               className="w-5 h-5 text-gray-300 flex-shrink-0"
               fill="none"
@@ -190,13 +190,13 @@ export function FlowBar({
               />
             </svg>
 
-            {/* Star step */}
+            {/* Star step — same flex-1 as other steps */}
             <button
               onClick={() => toggle("bewertung")}
               className={`
-                flex flex-col items-center justify-center
+                flex-1 flex flex-col items-center justify-center
                 rounded-xl border-t-[3px] border border-gray-200
-                px-2 py-3 sm:px-4 sm:py-4 min-w-[72px] sm:min-w-[90px]
+                px-2 py-3 sm:px-4 sm:py-4
                 transition-all duration-200 cursor-pointer
                 border-t-amber-400
                 ${

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -234,7 +234,40 @@ export function LeitzentraleView({
     return smartSort(result);
   }, [cases, activeNode, statusFilter, urgencyFilter, categoryFilter, searchQuery]);
 
-  // ── Techniker view (after all hooks) ────────────────────────────────
+  // ── Flow step data (MUST be above early return — hooks rule) ────────
+  const cutoff = useMemo(() => Date.now() - (period === "7d" ? 7 : 30) * 86400000, [period]);
+
+  const flowStats = useMemo(() => {
+    let eingang = 0, beiUns = 0, erledigt = 0, notfaelle = 0;
+    let voice = 0, web = 0, manual = 0;
+    let reviewSent = 0, doneTotal = 0;
+    for (const c of cases) {
+      const ct = new Date(c.created_at).getTime();
+      const ut = new Date(c.updated_at).getTime();
+      if (c.status === "new" && ct >= cutoff) {
+        eingang++;
+        if (c.source === "voice") voice++;
+        else if (c.source === "wizard" || c.source === "website") web++;
+        else manual++;
+      }
+      if (c.status === "scheduled" || c.status === "in_arbeit" || c.status === "warten") {
+        beiUns++;
+        if (c.urgency === "notfall") notfaelle++;
+      }
+      if (c.status === "done" && ut >= cutoff) erledigt++;
+      if (c.status === "done") {
+        doneTotal++;
+        if (c.review_sent_at) reviewSent++;
+      }
+    }
+    const srcParts: string[] = [];
+    if (voice) srcParts.push(`${voice} Tel`);
+    if (web) srcParts.push(`${web} Web`);
+    if (manual) srcParts.push(`${manual} Man`);
+    return { eingang, beiUns, erledigt, notfaelle, srcText: srcParts.join(" · ") || undefined, reviewSent, doneTotal };
+  }, [cases, cutoff]);
+
+  // ── Techniker view (after ALL hooks) ──────────────────────────────
   if (staffRole === "techniker" && staffName) {
     return (
       <TechnikerView
@@ -246,7 +279,7 @@ export function LeitzentraleView({
     );
   }
 
-  // ── Pagination ───────────────────────────────────────────────────────
+  // ── Admin-only derived state (no hooks below) ─────────────────────
   const totalPages = Math.max(1, Math.ceil(filteredCases.length / PAGE_SIZE));
   const safePage = Math.min(currentPage, totalPages);
   const paginatedCases = filteredCases.slice(
@@ -280,42 +313,8 @@ export function LeitzentraleView({
     !!categoryFilter ||
     !!searchQuery;
 
-  // ── Dropdown helper ─────────────────────────────────────────────────
   const selectClass =
     "text-[10px] font-semibold uppercase tracking-wide bg-transparent border-none focus:outline-none cursor-pointer text-gray-500 appearance-none pr-3";
-
-  // ── Flow step data ──────────────────────────────────────────────────
-  const cutoff = Date.now() - (period === "7d" ? 7 : 30) * 86400000;
-
-  const flowStats = useMemo(() => {
-    let eingang = 0, beiUns = 0, erledigt = 0, notfaelle = 0;
-    let voice = 0, web = 0, manual = 0;
-    let reviewSent = 0, doneTotal = 0;
-    for (const c of cases) {
-      const ct = new Date(c.created_at).getTime();
-      const ut = new Date(c.updated_at).getTime();
-      if (c.status === "new" && ct >= cutoff) {
-        eingang++;
-        if (c.source === "voice") voice++;
-        else if (c.source === "wizard" || c.source === "website") web++;
-        else manual++;
-      }
-      if (c.status === "scheduled" || c.status === "in_arbeit" || c.status === "warten") {
-        beiUns++;
-        if (c.urgency === "notfall") notfaelle++;
-      }
-      if (c.status === "done" && ut >= cutoff) erledigt++;
-      if (c.status === "done") {
-        doneTotal++;
-        if (c.review_sent_at) reviewSent++;
-      }
-    }
-    const srcParts: string[] = [];
-    if (voice) srcParts.push(`${voice} Tel`);
-    if (web) srcParts.push(`${web} Web`);
-    if (manual) srcParts.push(`${manual} Man`);
-    return { eingang, beiUns, erledigt, notfaelle, srcText: srcParts.join(" · ") || undefined, reviewSent, doneTotal };
-  }, [cases, cutoff]);
 
   const adminSteps: FlowStep[] = [
     { key: "eingang", icon: "📞", count: flowStats.eingang, label: "Eingang", accent: "blue", subLabel: flowStats.srcText },

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -334,20 +334,62 @@ export function OpsShell({
 
       {/* Main content */}
       <main className="md:ml-64 overflow-x-hidden">
-        {/* Impersonation indicator — subtle, no amber banner */}
-        {(isImpersonating || viewAsRole) && (
-          <div className="px-4 py-1.5 text-right text-gray-400 text-[10px] sticky top-0 z-20 md:top-0">
-            {isImpersonating && <>Ansicht: {tenantName}</>}
-            {isImpersonating && viewAsRole && <> · </>}
-            {viewAsRole && <>Rolle: Techniker</>}
-          </div>
-        )}
         <InstallPrompt />
-        {/* Dev: Mobile Preview Toggle (top-right, desktop only) */}
-        <div className="hidden md:flex justify-end px-4 pt-2">
+        {/* Top bar: Role toggle (admin only) + mobile preview */}
+        <div className="flex items-center justify-end gap-2 px-4 pt-2">
+          {/* Tenant indicator */}
+          {isImpersonating && (
+            <span className="text-[10px] text-gray-400 mr-auto">
+              Ansicht: {tenantName}
+            </span>
+          )}
+          {/* Role toggle — admin can switch between Admin/Techniker */}
+          {isAdmin && (
+            <div className="flex gap-0.5 bg-gray-100 rounded-lg p-0.5">
+              <button
+                onClick={async () => {
+                  if (viewAsRole) {
+                    await fetch("/api/ops/switch-tenant", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ tenantId: activeTenantId, viewAsRole: null }),
+                    });
+                    window.location.reload();
+                  }
+                }}
+                className={`px-2.5 py-1 rounded-md text-[10px] font-medium transition-colors ${
+                  !viewAsRole
+                    ? "bg-white text-gray-900 shadow-sm"
+                    : "text-gray-500 hover:text-gray-700 cursor-pointer"
+                }`}
+              >
+                Rolle: Admin
+              </button>
+              <button
+                onClick={async () => {
+                  if (!viewAsRole) {
+                    await fetch("/api/ops/switch-tenant", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ tenantId: activeTenantId, viewAsRole: "techniker" }),
+                    });
+                    window.location.reload();
+                  }
+                }}
+                className={`px-2.5 py-1 rounded-md text-[10px] font-medium transition-colors ${
+                  viewAsRole === "techniker"
+                    ? "bg-white text-gray-900 shadow-sm"
+                    : "text-gray-500 hover:text-gray-700 cursor-pointer"
+                }`}
+              >
+                Rolle: Techniker
+              </button>
+            </div>
+          )}
+          {/* Mobile Preview Toggle (desktop only) */}
           <button
             onClick={() => setMobilePreview(p => !p)}
-            className={`p-1.5 rounded-md text-xs transition-colors ${mobilePreview ? "bg-gray-900 text-white" : "text-gray-400 hover:text-gray-600 hover:bg-gray-200"}`}
+            className={`hidden md:block p-1.5 rounded-md text-xs transition-colors ${mobilePreview ? "bg-gray-900 text-white" : "text-gray-400 hover:text-gray-600 hover:bg-gray-200"}`}
             title={mobilePreview ? "Desktop-Ansicht" : "Mobile-Vorschau"}
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">


### PR DESCRIPTION
## Summary
- **RM18:** Clickable Admin/Techniker role toggle in top-right (replaces text)
- **RM19:** Seeded 120 realistic cases for Weinberger AG (6 months, 87 done, 35 assigned to techniker, 39 reviews)
- **RM20:** Bewertung KPI step now equal width (flex-1) with other steps
- **RM21:** Created review process plan: `docs/redesign/leitstand/plan_bewertungen.md`
- **RM22:** Fixed hooks-after-return crash (moved flowStats useMemo above early return)

## Test plan
- [ ] Role toggle visible top-right, active role highlighted
- [ ] Click "Rolle: Admin" / "Rolle: Techniker" switches view without crash
- [ ] All 4 KPI steps equal width on desktop AND mobile
- [ ] Weinberger AG shows ~133 cases (13 old + 120 new)
- [ ] Techniker view shows ~35 assigned cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)