### PR TITLE
feat: leitzentrale FB1-FB6 finalization

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -41,7 +41,7 @@ export default async function OpsCasesPage({
   let casesQuery = supabase
     .from("cases")
     .select(
-      "id, seq_number, created_at, updated_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, review_sent_at, scheduled_at"
+      "id, seq_number, created_at, updated_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, reporter_phone, review_sent_at, review_rating, scheduled_at"
     )
     .eq("is_demo", showDemo)
     .order("created_at", { ascending: false })

--- a/src/web/src/components/ops/FlowBar.tsx
+++ b/src/web/src/components/ops/FlowBar.tsx
@@ -1,19 +1,31 @@
 "use client";
 
+import React from "react";
+
 // ---------------------------------------------------------------------------
 // FlowBar — High-End horizontaler Flow für Admin UND Techniker
-// Klickbare Steps mit farbigen Akzenten, Hover-Effekten, Gold-Sterne.
+// CSS Grid für gleiche KPI-Breiten, YTD-Toggle, Gold-Sterne, Mobile 2x2.
 // ---------------------------------------------------------------------------
+
+export interface SourceItem {
+  icon: React.ReactNode;
+  label: string;
+  count: number;
+}
 
 export interface FlowStep {
   key: string;
-  icon: string;
+  icon: React.ReactNode;
   count: number;
   label: string;
   subLabel?: string;
-  accent: "blue" | "indigo" | "emerald" | "amber";
+  accent: "blue" | "indigo" | "emerald" | "amber" | "orange" | "gray";
   badge?: number;
+  onBadgeClick?: () => void;
+  sourceBreakdown?: SourceItem[];
 }
+
+export type PeriodValue = "7d" | "30d" | "ytd";
 
 interface FlowBarProps {
   steps: FlowStep[];
@@ -23,8 +35,8 @@ interface FlowBarProps {
   onStepClick: (key: string | null) => void;
   greeting?: string;
   periodToggle?: {
-    value: "7d" | "30d";
-    onChange: (v: "7d" | "30d") => void;
+    value: PeriodValue;
+    onChange: (v: PeriodValue) => void;
   };
   nextAppointment?: {
     time: string;
@@ -33,35 +45,23 @@ interface FlowBarProps {
   } | null;
 }
 
-const ACCENT = {
-  blue: {
-    border: "border-t-blue-500",
-    activeBg: "bg-blue-50",
-    activeRing: "ring-blue-300",
-    hoverBg: "hover:bg-blue-50/50",
-  },
-  indigo: {
-    border: "border-t-indigo-500",
-    activeBg: "bg-indigo-50",
-    activeRing: "ring-indigo-300",
-    hoverBg: "hover:bg-indigo-50/50",
-  },
-  emerald: {
-    border: "border-t-emerald-500",
-    activeBg: "bg-emerald-50",
-    activeRing: "ring-emerald-300",
-    hoverBg: "hover:bg-emerald-50/50",
-  },
-  amber: {
-    border: "border-t-amber-400",
-    activeBg: "bg-amber-50",
-    activeRing: "ring-amber-300",
-    hoverBg: "hover:bg-amber-50/50",
-  },
+const ACCENT: Record<string, { border: string; activeBg: string; activeRing: string; hoverBg: string }> = {
+  blue: { border: "border-t-blue-500", activeBg: "bg-blue-50", activeRing: "ring-blue-300", hoverBg: "hover:bg-blue-50/50" },
+  indigo: { border: "border-t-indigo-500", activeBg: "bg-indigo-50", activeRing: "ring-indigo-300", hoverBg: "hover:bg-indigo-50/50" },
+  emerald: { border: "border-t-emerald-500", activeBg: "bg-emerald-50", activeRing: "ring-emerald-300", hoverBg: "hover:bg-emerald-50/50" },
+  amber: { border: "border-t-amber-400", activeBg: "bg-amber-50", activeRing: "ring-amber-300", hoverBg: "hover:bg-amber-50/50" },
+  orange: { border: "border-t-orange-500", activeBg: "bg-orange-50", activeRing: "ring-orange-300", hoverBg: "hover:bg-orange-50/50" },
+  gray: { border: "border-t-gray-400", activeBg: "bg-gray-50", activeRing: "ring-gray-300", hoverBg: "hover:bg-gray-50/50" },
 };
 
 const STAR_PATH =
   "M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z";
+
+const PERIOD_LABELS: Record<PeriodValue, string> = {
+  "7d": "7 Tage",
+  "30d": "30 Tage",
+  ytd: "YTD",
+};
 
 export function FlowBar({
   steps,
@@ -73,13 +73,15 @@ export function FlowBar({
   periodToggle,
   nextAppointment,
 }: FlowBarProps) {
-  const starsFilled = starRating != null ? Math.round(starRating) : 0;
-  const starDisplay = starRating != null ? starRating.toFixed(1) : "—";
+  const starDisplay = starRating != null ? starRating.toFixed(1) : "Noch keine";
   const starActive = activeStep === "bewertung";
 
   function toggle(key: string) {
     onStepClick(activeStep === key ? null : key);
   }
+
+  // Total columns = steps + 1 (star step)
+  const colCount = steps.length + 1;
 
   return (
     <div className="bg-white border border-gray-200 rounded-2xl shadow-sm overflow-hidden">
@@ -93,7 +95,7 @@ export function FlowBar({
           )}
           {periodToggle && (
             <div className="flex gap-0.5 bg-gray-100 rounded-lg p-0.5">
-              {(["7d", "30d"] as const).map((p) => (
+              {(["7d", "30d", "ytd"] as const).map((p) => (
                 <button
                   key={p}
                   onClick={() => periodToggle.onChange(p)}
@@ -103,7 +105,7 @@ export function FlowBar({
                       : "text-gray-500 hover:text-gray-700"
                   }`}
                 >
-                  {p === "7d" ? "7 Tage" : "30 Tage"}
+                  {PERIOD_LABELS[p]}
                 </button>
               ))}
             </div>
@@ -111,61 +113,93 @@ export function FlowBar({
         </div>
       )}
 
-      {/* Flow steps */}
+      {/* Next appointment (Techniker) — above flow steps, always visible */}
+      {nextAppointment && (
+        <div className="mx-4 mb-2 flex items-center gap-3 bg-gray-50 rounded-xl border border-gray-200 px-4 py-3">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-gray-900">
+              <span className="font-semibold">Nächster Einsatz:</span>{" "}
+              <span className="text-gray-600">
+                {nextAppointment.time}, {nextAppointment.location}
+              </span>
+            </p>
+          </div>
+          <a
+            href={nextAppointment.mapsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white hover:bg-gray-800 transition-colors flex-shrink-0"
+          >
+            Nav
+          </a>
+        </div>
+      )}
+
+      {/* Flow steps — CSS Grid for equal widths */}
       <div className="px-3 sm:px-5 pb-5 pt-2">
-        <div className="flex items-stretch gap-2 sm:gap-3">
+        {/* Desktop: all columns in one row with chevrons between */}
+        <div className={`hidden md:grid gap-2 sm:gap-3`} style={{ gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))` }}>
           {steps.map((step, i) => {
-            const a = ACCENT[step.accent];
+            const a = ACCENT[step.accent] ?? ACCENT.gray;
             const active = activeStep === step.key;
             return (
-              <div
-                key={step.key}
-                className="flex items-center gap-1.5 sm:gap-2.5 flex-1 min-w-0"
-              >
+              <div key={step.key} className="relative">
+                {/* Chevron between steps */}
                 {i > 0 && (
                   <svg
-                    className="w-5 h-5 text-gray-300 flex-shrink-0"
+                    className="absolute -left-3.5 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-300 z-10"
                     fill="none"
                     viewBox="0 0 24 24"
                     strokeWidth={2.5}
                     stroke="currentColor"
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M8.25 4.5l7.5 7.5-7.5 7.5"
-                    />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
                   </svg>
                 )}
                 <button
                   onClick={() => toggle(step.key)}
                   className={`
-                    flex-1 flex flex-col items-center justify-center
+                    w-full flex flex-col items-center justify-center
                     rounded-xl border-t-[3px] border border-gray-200
                     px-2 py-3 sm:px-4 sm:py-4
                     transition-all duration-200 cursor-pointer relative
                     ${a.border}
-                    ${
-                      active
-                        ? `${a.activeBg} ring-2 ${a.activeRing} shadow-md`
-                        : `bg-white ${a.hoverBg} hover:shadow-sm`
+                    ${active
+                      ? `${a.activeBg} ring-2 ${a.activeRing} shadow-md`
+                      : `bg-white ${a.hoverBg} hover:shadow-sm`
                     }
                   `}
                 >
-                  <span className="text-base sm:text-lg">{step.icon}</span>
+                  {step.icon && <span className="text-base sm:text-lg">{step.icon}</span>}
                   <span className="text-2xl sm:text-3xl font-extrabold text-gray-900 leading-none mt-0.5">
                     {step.count}
                   </span>
                   <span className="text-[9px] sm:text-[10px] font-semibold text-gray-500 uppercase tracking-wider mt-1">
                     {step.label}
                   </span>
-                  {step.subLabel && (
+                  {step.sourceBreakdown && step.sourceBreakdown.length > 0 && (
+                    <span className="flex items-center gap-1.5 mt-1 text-[8px] sm:text-[9px] text-gray-400">
+                      {step.sourceBreakdown.map((s) => (
+                        <span key={s.label} className="inline-flex items-center gap-0.5">
+                          <span className="w-3 h-3">{s.icon}</span>
+                          <span>{s.count}</span>
+                        </span>
+                      ))}
+                    </span>
+                  )}
+                  {step.subLabel && !step.sourceBreakdown && (
                     <span className="text-[8px] sm:text-[9px] text-gray-400 mt-0.5">
                       {step.subLabel}
                     </span>
                   )}
                   {step.badge != null && step.badge > 0 && (
-                    <span className="absolute -top-1.5 -right-1.5 bg-red-500 text-white text-[9px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 shadow">
+                    <span
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        step.onBadgeClick?.();
+                      }}
+                      className={`absolute -top-1.5 -right-1.5 bg-red-500 text-white text-[9px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 shadow ${step.onBadgeClick ? "cursor-pointer hover:bg-red-600" : ""}`}
+                    >
                       {step.badge}
                     </span>
                   )}
@@ -174,35 +208,28 @@ export function FlowBar({
             );
           })}
 
-          {/* Arrow to stars */}
-          <div className="flex items-center gap-1.5 sm:gap-2.5 flex-1 min-w-0">
+          {/* Star step (last column) */}
+          <div className="relative">
             <svg
-              className="w-5 h-5 text-gray-300 flex-shrink-0"
+              className="absolute -left-3.5 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-300 z-10"
               fill="none"
               viewBox="0 0 24 24"
               strokeWidth={2.5}
               stroke="currentColor"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8.25 4.5l7.5 7.5-7.5 7.5"
-              />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
             </svg>
-
-            {/* Star step — same flex-1 as other steps */}
             <button
               onClick={() => toggle("bewertung")}
               className={`
-                flex-1 flex flex-col items-center justify-center
+                w-full flex flex-col items-center justify-center
                 rounded-xl border-t-[3px] border border-gray-200
                 px-2 py-3 sm:px-4 sm:py-4
                 transition-all duration-200 cursor-pointer
                 border-t-amber-400
-                ${
-                  starActive
-                    ? "bg-amber-50 ring-2 ring-amber-300 shadow-md"
-                    : "bg-white hover:bg-amber-50/50 hover:shadow-sm"
+                ${starActive
+                  ? "bg-amber-50 ring-2 ring-amber-300 shadow-md"
+                  : "bg-white hover:bg-amber-50/50 hover:shadow-sm"
                 }
               `}
             >
@@ -210,7 +237,7 @@ export function FlowBar({
                 {[1, 2, 3, 4, 5].map((n) => (
                   <svg
                     key={n}
-                    className={`w-3 h-3 sm:w-3.5 sm:h-3.5 ${n <= starsFilled ? "text-amber-400" : "text-gray-200"}`}
+                    className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-amber-400"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -230,29 +257,98 @@ export function FlowBar({
             </button>
           </div>
         </div>
-      </div>
 
-      {/* Next appointment (Techniker) */}
-      {nextAppointment && (
-        <div className="mx-4 mb-4 flex items-center gap-3 bg-gray-50 rounded-xl border border-gray-200 px-4 py-3">
-          <div className="flex-1 min-w-0">
-            <p className="text-sm text-gray-900">
-              <span className="font-semibold">Nächster Einsatz:</span>{" "}
-              <span className="text-gray-600">
-                {nextAppointment.time}, {nextAppointment.location}
-              </span>
-            </p>
-          </div>
-          <a
-            href={nextAppointment.mapsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white hover:bg-gray-800 transition-colors flex-shrink-0"
+        {/* Mobile: 2x2 grid, no arrows */}
+        <div className="md:hidden grid grid-cols-2 gap-2">
+          {steps.map((step) => {
+            const a = ACCENT[step.accent] ?? ACCENT.gray;
+            const active = activeStep === step.key;
+            return (
+              <button
+                key={step.key}
+                onClick={() => toggle(step.key)}
+                className={`
+                  flex flex-col items-center justify-center
+                  rounded-xl border-t-[3px] border border-gray-200
+                  px-2 py-3 transition-all duration-200 cursor-pointer relative
+                  ${a.border}
+                  ${active
+                    ? `${a.activeBg} ring-2 ${a.activeRing} shadow-md`
+                    : `bg-white ${a.hoverBg} hover:shadow-sm`
+                  }
+                `}
+              >
+                {step.icon && <span className="text-base">{step.icon}</span>}
+                <span className="text-2xl font-extrabold text-gray-900 leading-none mt-0.5">
+                  {step.count}
+                </span>
+                <span className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1">
+                  {step.label}
+                </span>
+                {step.sourceBreakdown && step.sourceBreakdown.length > 0 && (
+                  <span className="flex items-center gap-1 mt-1 text-[8px] text-gray-400">
+                    {step.sourceBreakdown.map((s) => (
+                      <span key={s.label} className="inline-flex items-center gap-0.5">
+                        <span className="w-3 h-3">{s.icon}</span>
+                        <span>{s.count}</span>
+                      </span>
+                    ))}
+                  </span>
+                )}
+                {step.subLabel && !step.sourceBreakdown && (
+                  <span className="text-[8px] text-gray-400 mt-0.5">{step.subLabel}</span>
+                )}
+                {step.badge != null && step.badge > 0 && (
+                  <span
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      step.onBadgeClick?.();
+                    }}
+                    className={`absolute -top-1.5 -right-1.5 bg-red-500 text-white text-[9px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 shadow ${step.onBadgeClick ? "cursor-pointer hover:bg-red-600" : ""}`}
+                  >
+                    {step.badge}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+
+          {/* Star step mobile */}
+          <button
+            onClick={() => toggle("bewertung")}
+            className={`
+              flex flex-col items-center justify-center
+              rounded-xl border-t-[3px] border border-gray-200
+              px-2 py-3 transition-all duration-200 cursor-pointer
+              border-t-amber-400
+              ${starActive
+                ? "bg-amber-50 ring-2 ring-amber-300 shadow-md"
+                : "bg-white hover:bg-amber-50/50 hover:shadow-sm"
+              }
+            `}
           >
-            📍 Nav
-          </a>
+            <div className="flex items-center gap-0.5">
+              {[1, 2, 3, 4, 5].map((n) => (
+                <svg
+                  key={n}
+                  className="w-3 h-3 text-amber-400"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path d={STAR_PATH} />
+                </svg>
+              ))}
+            </div>
+            <span className="text-xl font-extrabold text-amber-600 leading-none mt-1">
+              {starDisplay}
+            </span>
+            <span className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1">
+              Bewertung
+            </span>
+            <span className="text-[8px] text-gray-400 mt-0.5">{starSub}</span>
+          </button>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CreateCaseModal } from "./CreateCaseModal";
 import { formatCaseId } from "@/src/lib/cases/formatCaseId";
 import { FlowBar } from "./FlowBar";
-import type { FlowStep } from "./FlowBar";
+import type { FlowStep, PeriodValue } from "./FlowBar";
 import { TechnikerView } from "./TechnikerView";
+import { getGreeting } from "@/src/lib/ui/getGreeting";
+import {
+  STATUS_LABELS,
+  URGENCY_DOT,
+  URGENCY_LABEL,
+  getStatusColorClass,
+} from "@/src/lib/cases/statusColors";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,7 +35,9 @@ export interface LeitzentraleCase {
   source: string;
   assignee_text?: string | null;
   reporter_name?: string | null;
+  reporter_phone?: string | null;
   review_sent_at?: string | null;
+  review_rating?: number | null;
   scheduled_at?: string | null;
 }
 
@@ -50,35 +59,41 @@ export interface LeitzentraleProps {
 // Constants
 // ---------------------------------------------------------------------------
 
-const STATUS_LABELS: Record<string, string> = {
-  new: "Neu",
-  scheduled: "Geplant",
-  in_arbeit: "In Arbeit",
-  warten: "Warten",
-  done: "Erledigt",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  new: "bg-blue-100 text-blue-700",
-  scheduled: "bg-violet-100 text-violet-700",
-  in_arbeit: "bg-indigo-100 text-indigo-700",
-  warten: "bg-amber-100 text-amber-700",
-  done: "bg-emerald-100 text-emerald-700",
-};
-
-const URGENCY_DOT: Record<string, string> = {
-  notfall: "bg-red-500",
-  dringend: "bg-amber-500",
-  normal: "bg-gray-400",
-};
-
-const URGENCY_LABEL: Record<string, string> = {
-  notfall: "Hoch",
-  dringend: "Mittel",
-  normal: "Normal",
-};
-
 const PAGE_SIZE = 15;
+
+// ---------------------------------------------------------------------------
+// SVG Icons (inline, no extra deps)
+// ---------------------------------------------------------------------------
+
+const WrenchIcon = (
+  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" />
+  </svg>
+);
+
+const CheckIcon = (
+  <svg className="w-5 h-5 text-emerald-600" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+  </svg>
+);
+
+const PhoneIcon = (
+  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z" />
+  </svg>
+);
+
+const GlobeIcon = (
+  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" />
+  </svg>
+);
+
+const PencilIcon = (
+  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+  </svg>
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -167,7 +182,6 @@ function formatDate(iso: string): string {
   });
 }
 
-// Smart sort: active Notfälle > active Dringende > active Normale > Erledigte
 function smartSort(cases: LeitzentraleCase[]): LeitzentraleCase[] {
   return [...cases].sort((a, b) => {
     const rank = (c: LeitzentraleCase): number => {
@@ -181,6 +195,19 @@ function smartSort(cases: LeitzentraleCase[]): LeitzentraleCase[] {
     if (ra !== rb) return ra - rb;
     return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
   });
+}
+
+function maskPhone(phone: string): string {
+  if (phone.length <= 6) return phone;
+  return phone.slice(0, -3) + "...";
+}
+
+function computeCutoff(period: PeriodValue): number {
+  if (period === "ytd") {
+    const now = new Date();
+    return new Date(now.getFullYear(), 0, 1).getTime();
+  }
+  return Date.now() - (period === "7d" ? 7 : 30) * 86400000;
 }
 
 // ---------------------------------------------------------------------------
@@ -203,7 +230,7 @@ export function LeitzentraleView({
   const [categoryFilter, setCategoryFilter] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [modalOpen, setModalOpen] = useState(false);
-  const [period, setPeriod] = useState<"7d" | "30d">("7d");
+  const [period, setPeriod] = useState<PeriodValue>("7d");
 
   // ── ALL hooks MUST be above early returns (React rules of hooks) ────
   const categories = useMemo(() => {
@@ -212,8 +239,11 @@ export function LeitzentraleView({
     return Array.from(set).sort();
   }, [cases]);
 
+  const cutoff = useMemo(() => computeCutoff(period), [period]);
+
+  // Period-filter FIRST, then other filters (FB5: period filtert auch Tabelle)
   const filteredCases = useMemo(() => {
-    let result = cases;
+    let result = cases.filter((c) => new Date(c.created_at).getTime() >= cutoff);
 
     if (activeNode) {
       result = result.filter((c) => matchesNode(c, activeNode));
@@ -232,15 +262,13 @@ export function LeitzentraleView({
     }
 
     return smartSort(result);
-  }, [cases, activeNode, statusFilter, urgencyFilter, categoryFilter, searchQuery]);
+  }, [cases, cutoff, activeNode, statusFilter, urgencyFilter, categoryFilter, searchQuery]);
 
   // ── Flow step data (MUST be above early return — hooks rule) ────────
-  const cutoff = useMemo(() => Date.now() - (period === "7d" ? 7 : 30) * 86400000, [period]);
-
   const flowStats = useMemo(() => {
     let eingang = 0, beiUns = 0, erledigt = 0, notfaelle = 0;
     let voice = 0, web = 0, manual = 0;
-    let reviewSent = 0, doneTotal = 0;
+    let reviewSent = 0, reviewReceived = 0;
     for (const c of cases) {
       const ct = new Date(c.created_at).getTime();
       const ut = new Date(c.updated_at).getTime();
@@ -256,15 +284,11 @@ export function LeitzentraleView({
       }
       if (c.status === "done" && ut >= cutoff) erledigt++;
       if (c.status === "done") {
-        doneTotal++;
         if (c.review_sent_at) reviewSent++;
+        if (c.review_rating != null) reviewReceived++;
       }
     }
-    const srcParts: string[] = [];
-    if (voice) srcParts.push(`${voice} Tel`);
-    if (web) srcParts.push(`${web} Web`);
-    if (manual) srcParts.push(`${manual} Man`);
-    return { eingang, beiUns, erledigt, notfaelle, srcText: srcParts.join(" · ") || undefined, reviewSent, doneTotal };
+    return { eingang, beiUns, erledigt, notfaelle, voice, web, manual, reviewSent, reviewReceived };
   }, [cases, cutoff]);
 
   // ── Techniker view (after ALL hooks) ──────────────────────────────
@@ -316,10 +340,41 @@ export function LeitzentraleView({
   const selectClass =
     "text-[10px] font-semibold uppercase tracking-wide bg-transparent border-none focus:outline-none cursor-pointer text-gray-500 appearance-none pr-3";
 
+  const greetingText = `${getGreeting()}, ${staffName?.split(" ")[0] ?? "Admin"}`;
+
   const adminSteps: FlowStep[] = [
-    { key: "eingang", icon: "📞", count: flowStats.eingang, label: "Eingang", accent: "blue", subLabel: flowStats.srcText },
-    { key: "bei_uns", icon: "⚡", count: flowStats.beiUns, label: "Bei uns", accent: "indigo", badge: flowStats.notfaelle > 0 ? flowStats.notfaelle : undefined },
-    { key: "erledigt", icon: "✅", count: flowStats.erledigt, label: "Erledigt", accent: "emerald", subLabel: `+${weekStats.erledigt} /Woche` },
+    {
+      key: "eingang",
+      icon: null,
+      count: flowStats.eingang,
+      label: "Neu",
+      accent: "blue",
+      sourceBreakdown: [
+        { icon: PhoneIcon, label: "Tel", count: flowStats.voice },
+        { icon: GlobeIcon, label: "Web", count: flowStats.web },
+        { icon: PencilIcon, label: "Stift", count: flowStats.manual },
+      ],
+    },
+    {
+      key: "bei_uns",
+      icon: WrenchIcon,
+      count: flowStats.beiUns,
+      label: "Bei uns",
+      accent: "orange",
+      badge: flowStats.notfaelle > 0 ? flowStats.notfaelle : undefined,
+      onBadgeClick: () => {
+        setUrgencyFilter("notfall");
+        setActiveNode("bei_uns");
+        setCurrentPage(1);
+      },
+    },
+    {
+      key: "erledigt",
+      icon: CheckIcon,
+      count: flowStats.erledigt,
+      label: "Erledigt",
+      accent: "emerald",
+    },
   ];
 
   // ── Admin/Inhaber view ──────────────────────────────────────────────
@@ -329,10 +384,11 @@ export function LeitzentraleView({
       <FlowBar
         steps={adminSteps}
         starRating={avgRating ?? null}
-        starSub={`${flowStats.reviewSent} von ${flowStats.doneTotal}`}
+        starSub={`${flowStats.reviewReceived} erhalten / ${flowStats.reviewSent} angefragt`}
         activeStep={activeNode}
         onStepClick={handleNodeClick}
-        periodToggle={{ value: period, onChange: setPeriod }}
+        greeting={greetingText}
+        periodToggle={{ value: period, onChange: (v) => { setPeriod(v); setCurrentPage(1); } }}
       />
 
       {/* Search + New Case */}
@@ -382,7 +438,7 @@ export function LeitzentraleView({
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-gray-100 bg-gray-50/50">
-                <th className="text-left px-3 py-2">
+                <th className="text-left px-3 py-2 sticky left-0 z-10 bg-gray-50/50">
                   <span className="text-[11px] font-semibold text-gray-500 uppercase tracking-wide">
                     Nr
                   </span>
@@ -402,7 +458,7 @@ export function LeitzentraleView({
                     className={selectClass}
                     title="Kategorie filtern"
                   >
-                    <option value="">Kat. ▾</option>
+                    <option value="">Kategorie ▾</option>
                     {categories.map((cat) => (
                       <option key={cat} value={cat}>
                         {cat}
@@ -463,7 +519,12 @@ export function LeitzentraleView({
                     colSpan={7}
                     className="text-center text-gray-400 py-12 text-sm"
                   >
-                    Keine Fälle gefunden.
+                    Keine Fälle gefunden.{" "}
+                    {hasFilters && (
+                      <button onClick={resetFilters} className="text-blue-500 hover:underline">
+                        Filter zurücksetzen
+                      </button>
+                    )}
                   </td>
                 </tr>
               )}
@@ -483,12 +544,16 @@ export function LeitzentraleView({
                           : ""
                     }`}
                   >
-                    <td className="px-3 py-2 font-mono text-xs text-gray-500 whitespace-nowrap">
+                    <td className="px-3 py-2 font-mono text-xs text-gray-500 whitespace-nowrap sticky left-0 z-10 bg-white">
                       {formatCaseId(c.seq_number, caseIdPrefix)}
                     </td>
                     <td className="px-3 py-2 text-gray-900 truncate max-w-[180px]">
                       {c.reporter_name || (
-                        <span className="text-gray-400">—</span>
+                        c.reporter_phone ? (
+                          <span className="text-gray-400">{maskPhone(c.reporter_phone)}</span>
+                        ) : (
+                          <span className="text-gray-400">—</span>
+                        )
                       )}
                     </td>
                     <td className="px-3 py-2 text-gray-700 truncate max-w-[140px]">
@@ -511,10 +576,7 @@ export function LeitzentraleView({
                     </td>
                     <td className="px-3 py-2">
                       <span
-                        className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                          STATUS_COLORS[c.status] ??
-                          "bg-gray-100 text-gray-700"
-                        }`}
+                        className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${getStatusColorClass(c.status, c.review_sent_at, c.review_rating)}`}
                       >
                         {STATUS_LABELS[c.status] ?? c.status}
                       </span>
@@ -533,7 +595,12 @@ export function LeitzentraleView({
         <div className="md:hidden divide-y divide-gray-50">
           {paginatedCases.length === 0 && (
             <div className="text-center text-gray-400 py-12 text-sm">
-              Keine Fälle gefunden.
+              Keine Fälle gefunden.{" "}
+              {hasFilters && (
+                <button onClick={resetFilters} className="text-blue-500 hover:underline">
+                  Filter zurücksetzen
+                </button>
+              )}
             </div>
           )}
           {paginatedCases.map((c) => {
@@ -543,7 +610,7 @@ export function LeitzentraleView({
               <div
                 key={c.id}
                 onClick={() => router.push(`/ops/cases/${c.id}`)}
-                className={`px-4 py-3.5 hover:bg-gray-50 cursor-pointer transition-colors ${
+                className={`px-4 py-3.5 min-h-[48px] hover:bg-gray-50 cursor-pointer transition-colors ${
                   isNotfall
                     ? "border-l-4 border-l-red-500 bg-red-50/30"
                     : isDone
@@ -556,9 +623,7 @@ export function LeitzentraleView({
                     {formatCaseId(c.seq_number, caseIdPrefix)}
                   </span>
                   <span
-                    className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${
-                      STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-700"
-                    }`}
+                    className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${getStatusColorClass(c.status, c.review_sent_at, c.review_rating)}`}
                   >
                     {STATUS_LABELS[c.status] ?? c.status}
                   </span>
@@ -567,11 +632,11 @@ export function LeitzentraleView({
                   {c.category}
                 </p>
                 <div className="flex items-center gap-2 mt-1 text-xs text-gray-500">
-                  {c.reporter_name && (
-                    <span className="truncate max-w-[120px]">
-                      {c.reporter_name}
-                    </span>
-                  )}
+                  {c.reporter_name ? (
+                    <span className="truncate max-w-[120px]">{c.reporter_name}</span>
+                  ) : c.reporter_phone ? (
+                    <span className="truncate max-w-[120px] text-gray-400">{maskPhone(c.reporter_phone)}</span>
+                  ) : null}
                   {c.city && (
                     <>
                       <span className="text-gray-300">·</span>

--- a/src/web/src/components/ops/OpsShell.tsx
+++ b/src/web/src/components/ops/OpsShell.tsx
@@ -110,8 +110,9 @@ export function OpsShell({
 
   // RBAC: hide Einstellungen for techniker
   // Techniker: only Leitzentrale (no Einstellungen, no Support)
+  // QW2: Techniker sees only Leitzentrale — no disabled "Bald" items
   const visibleNavItems = staffRole === "techniker"
-    ? NAV_ITEMS.filter(item => item.href === "/ops/cases" || item.disabled)
+    ? NAV_ITEMS.filter(item => item.href === "/ops/cases")
     : NAV_ITEMS;
 
   function isNavActive(href: string): boolean {

--- a/src/web/src/components/ops/TechnikerView.tsx
+++ b/src/web/src/components/ops/TechnikerView.tsx
@@ -1,15 +1,22 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import React, { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { FlowBar } from "./FlowBar";
-import type { FlowStep } from "./FlowBar";
+import type { FlowStep, PeriodValue } from "./FlowBar";
 import type { LeitzentraleCase } from "./LeitzentraleView";
 import { formatCaseId } from "@/src/lib/cases/formatCaseId";
+import { getGreeting } from "@/src/lib/ui/getGreeting";
+import {
+  STATUS_LABELS,
+  URGENCY_DOT,
+  URGENCY_LABEL,
+  getStatusColorClass,
+} from "@/src/lib/cases/statusColors";
 
 // ---------------------------------------------------------------------------
 // TechnikerView — "Meine Arbeit"
-// FlowBar (klickbar) + vollständige Tabelle mit Spaltenüberschriften.
+// FlowBar (klickbar) + Pagination + Period Toggle + shared status colors.
 // ---------------------------------------------------------------------------
 
 interface TechnikerViewProps {
@@ -19,37 +26,30 @@ interface TechnikerViewProps {
   avgRating: number | null;
 }
 
-const STATUS_LABELS: Record<string, string> = {
-  new: "Neu",
-  scheduled: "Geplant",
-  in_arbeit: "In Arbeit",
-  warten: "Warten",
-  done: "Erledigt",
-};
-const STATUS_COLORS: Record<string, string> = {
-  new: "bg-blue-100 text-blue-700",
-  scheduled: "bg-violet-100 text-violet-700",
-  in_arbeit: "bg-indigo-100 text-indigo-700",
-  warten: "bg-amber-100 text-amber-700",
-  done: "bg-emerald-100 text-emerald-700",
-};
-const URGENCY_DOT: Record<string, string> = {
-  notfall: "bg-red-500",
-  dringend: "bg-amber-500",
-  normal: "bg-gray-400",
-};
-const URGENCY_LABEL: Record<string, string> = {
-  notfall: "Hoch",
-  dringend: "Mittel",
-  normal: "Normal",
-};
+const PAGE_SIZE = 15;
 
-function getGreeting(): string {
-  const h = new Date().getHours();
-  if (h < 12) return "Guten Morgen";
-  if (h < 17) return "Guten Tag";
-  return "Guten Abend";
-}
+// SVG Icons
+const WrenchIcon = (
+  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" />
+  </svg>
+);
+
+const CalendarIcon = (
+  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+  </svg>
+);
+
+const CheckIcon = (
+  <svg className="w-5 h-5 text-emerald-600" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+  </svg>
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function getTodayZurich(): string {
   return new Intl.DateTimeFormat("en-CA", {
@@ -84,6 +84,19 @@ function formatDate(iso: string): string {
   });
 }
 
+function maskPhone(phone: string): string {
+  if (phone.length <= 6) return phone;
+  return phone.slice(0, -3) + "...";
+}
+
+function computeCutoff(period: PeriodValue): number {
+  if (period === "ytd") {
+    const now = new Date();
+    return new Date(now.getFullYear(), 0, 1).getTime();
+  }
+  return Date.now() - (period === "7d" ? 7 : 30) * 86400000;
+}
+
 type TechFilter = "bei_mir" | "heute" | "erledigt" | "bewertung" | null;
 
 function matchesTechFilter(c: LeitzentraleCase, f: TechFilter, todayStr: string): boolean {
@@ -107,6 +120,10 @@ function matchesTechFilter(c: LeitzentraleCase, f: TechFilter, todayStr: string)
   }
 }
 
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export function TechnikerView({
   staffName,
   cases,
@@ -115,10 +132,13 @@ export function TechnikerView({
 }: TechnikerViewProps) {
   const router = useRouter();
   const [activeStep, setActiveStep] = useState<TechFilter>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [period, setPeriod] = useState<PeriodValue>("7d");
   const firstName = staffName.split(" ")[0];
   const todayStr = getTodayZurich();
+  const cutoff = useMemo(() => computeCutoff(period), [period]);
 
-  // Counts
+  // Counts (period-filtered for erledigt, unfiltered for active)
   const beiMir = cases.filter((c) => c.status !== "done").length;
   const heute = cases.filter(
     (c) =>
@@ -128,26 +148,31 @@ export function TechnikerView({
         timeZone: "Europe/Zurich",
       }) === todayStr,
   ).length;
-  const erledigt = cases.filter((c) => c.status === "done").length;
+  const erledigt = cases.filter(
+    (c) => c.status === "done" && new Date(c.updated_at).getTime() >= cutoff,
+  ).length;
   const reviewCount = cases.filter(
-    (c) => c.status === "done" && c.review_sent_at,
+    (c) => c.status === "done" && c.review_rating != null,
   ).length;
 
-  // Next appointment
-  const todayAppointments = cases
-    .filter(
-      (c) =>
-        c.scheduled_at &&
-        c.status !== "done" &&
-        new Date(c.scheduled_at).toLocaleDateString("en-CA", {
-          timeZone: "Europe/Zurich",
-        }) === todayStr,
-    )
-    .sort(
-      (a, b) =>
-        new Date(a.scheduled_at!).getTime() -
-        new Date(b.scheduled_at!).getTime(),
-    );
+  // Next appointment — always computed, shown above FlowBar
+  const todayAppointments = useMemo(() =>
+    cases
+      .filter(
+        (c) =>
+          c.scheduled_at &&
+          c.status !== "done" &&
+          new Date(c.scheduled_at).toLocaleDateString("en-CA", {
+            timeZone: "Europe/Zurich",
+          }) === todayStr,
+      )
+      .sort(
+        (a, b) =>
+          new Date(a.scheduled_at!).getTime() -
+          new Date(b.scheduled_at!).getTime(),
+      ),
+    [cases, todayStr],
+  );
   const next = todayAppointments[0] ?? null;
   const nextAppt = next
     ? {
@@ -163,19 +188,21 @@ export function TechnikerView({
       }
     : null;
 
-  // Steps
+  // Steps with proper icons
   const steps: FlowStep[] = [
-    { key: "bei_mir", icon: "📋", count: beiMir, label: "Bei mir", accent: "blue" },
-    { key: "heute", icon: "📅", count: heute, label: "Heute", accent: "indigo" },
-    { key: "erledigt", icon: "✅", count: erledigt, label: "Erledigt", accent: "emerald" },
+    { key: "bei_mir", icon: WrenchIcon, count: beiMir, label: "Bei mir", accent: "blue" },
+    { key: "heute", icon: CalendarIcon, count: heute, label: "Heute", accent: "orange" },
+    { key: "erledigt", icon: CheckIcon, count: erledigt, label: "Erledigt", accent: "emerald" },
   ];
 
-  // Filtered cases
+  // Filtered + sorted cases (period + tech filter)
   const displayCases = useMemo(() => {
     let result = cases.filter((c) =>
       matchesTechFilter(c, activeStep, todayStr),
     );
-    // Sort: active notfall > dringend > normal > done
+    // Period filter for table
+    result = result.filter((c) => new Date(c.created_at).getTime() >= cutoff);
+
     return [...result].sort((a, b) => {
       const rank = (c: LeitzentraleCase) => {
         if (c.status === "done") return 4;
@@ -190,7 +217,20 @@ export function TechnikerView({
         new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
       );
     });
-  }, [cases, activeStep, todayStr]);
+  }, [cases, activeStep, todayStr, cutoff]);
+
+  // Pagination
+  const totalPages = Math.max(1, Math.ceil(displayCases.length / PAGE_SIZE));
+  const safePage = Math.min(currentPage, totalPages);
+  const paginatedCases = displayCases.slice(
+    (safePage - 1) * PAGE_SIZE,
+    safePage * PAGE_SIZE,
+  );
+
+  function handleStepClick(k: string | null) {
+    setActiveStep(k as TechFilter);
+    setCurrentPage(1);
+  }
 
   return (
     <div className="space-y-3">
@@ -201,8 +241,9 @@ export function TechnikerView({
         starRating={avgRating}
         starSub={`${reviewCount} Bew.`}
         activeStep={activeStep}
-        onStepClick={(k) => setActiveStep(k as TechFilter)}
+        onStepClick={handleStepClick}
         nextAppointment={nextAppt}
+        periodToggle={{ value: period, onChange: (v) => { setPeriod(v); setCurrentPage(1); } }}
       />
 
       {/* Case Table — with proper headers */}
@@ -213,7 +254,7 @@ export function TechnikerView({
           </h2>
           {activeStep && (
             <button
-              onClick={() => setActiveStep(null)}
+              onClick={() => { setActiveStep(null); setCurrentPage(1); }}
               className="text-[10px] text-gray-400 hover:text-gray-600 transition-colors"
             >
               Filter zurücksetzen
@@ -226,7 +267,7 @@ export function TechnikerView({
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-gray-100 bg-gray-50/50">
-                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">
+                <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2 sticky left-0 z-10 bg-gray-50/50">
                   Nr
                 </th>
                 <th className="text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide px-3 py-2">
@@ -250,17 +291,22 @@ export function TechnikerView({
               </tr>
             </thead>
             <tbody>
-              {displayCases.length === 0 && (
+              {paginatedCases.length === 0 && (
                 <tr>
                   <td
                     colSpan={7}
                     className="text-center text-gray-400 py-10 text-sm"
                   >
-                    Keine Fälle gefunden.
+                    Keine Fälle gefunden.{" "}
+                    {activeStep && (
+                      <button onClick={() => { setActiveStep(null); setCurrentPage(1); }} className="text-blue-500 hover:underline">
+                        Filter zurücksetzen
+                      </button>
+                    )}
                   </td>
                 </tr>
               )}
-              {displayCases.map((c) => {
+              {paginatedCases.map((c) => {
                 const isNotfall =
                   c.urgency === "notfall" && c.status !== "done";
                 const isDone = c.status === "done";
@@ -276,7 +322,7 @@ export function TechnikerView({
                           : ""
                     }`}
                   >
-                    <td className="px-3 py-2.5 font-mono text-xs text-gray-500 whitespace-nowrap">
+                    <td className="px-3 py-2.5 font-mono text-xs text-gray-500 whitespace-nowrap sticky left-0 z-10 bg-white">
                       {formatCaseId(c.seq_number, caseIdPrefix)}
                     </td>
                     <td className="px-3 py-2.5 text-gray-900 font-medium truncate max-w-[140px]">
@@ -284,7 +330,11 @@ export function TechnikerView({
                     </td>
                     <td className="px-3 py-2.5 text-gray-700 truncate max-w-[140px]">
                       {c.reporter_name || (
-                        <span className="text-gray-300">—</span>
+                        c.reporter_phone ? (
+                          <span className="text-gray-400">{maskPhone(c.reporter_phone)}</span>
+                        ) : (
+                          <span className="text-gray-300">—</span>
+                        )
                       )}
                     </td>
                     <td className="px-3 py-2.5 text-gray-600 truncate max-w-[180px]">
@@ -304,10 +354,7 @@ export function TechnikerView({
                     </td>
                     <td className="px-3 py-2.5">
                       <span
-                        className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                          STATUS_COLORS[c.status] ??
-                          "bg-gray-100 text-gray-700"
-                        }`}
+                        className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${getStatusColorClass(c.status, c.review_sent_at, c.review_rating)}`}
                       >
                         {STATUS_LABELS[c.status] ?? c.status}
                       </span>
@@ -324,19 +371,24 @@ export function TechnikerView({
 
         {/* Mobile list */}
         <div className="md:hidden divide-y divide-gray-50">
-          {displayCases.length === 0 && (
+          {paginatedCases.length === 0 && (
             <div className="text-center text-gray-400 py-10 text-sm">
-              Keine Fälle gefunden.
+              Keine Fälle gefunden.{" "}
+              {activeStep && (
+                <button onClick={() => { setActiveStep(null); setCurrentPage(1); }} className="text-blue-500 hover:underline">
+                  Filter zurücksetzen
+                </button>
+              )}
             </div>
           )}
-          {displayCases.map((c) => {
+          {paginatedCases.map((c) => {
             const isNotfall = c.urgency === "notfall" && c.status !== "done";
             const isDone = c.status === "done";
             return (
               <div
                 key={c.id}
                 onClick={() => router.push(`/ops/cases/${c.id}`)}
-                className={`px-4 py-3 hover:bg-gray-50 cursor-pointer transition-colors ${
+                className={`px-4 py-3 min-h-[48px] hover:bg-gray-50 cursor-pointer transition-colors ${
                   isNotfall
                     ? "border-l-4 border-l-red-500 bg-red-50/30"
                     : isDone
@@ -358,9 +410,7 @@ export function TechnikerView({
                       </span>
                     </span>
                     <span
-                      className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
-                        STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-700"
-                      }`}
+                      className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${getStatusColorClass(c.status, c.review_sent_at, c.review_rating)}`}
                     >
                       {STATUS_LABELS[c.status] ?? c.status}
                     </span>
@@ -370,12 +420,12 @@ export function TechnikerView({
                   {c.category}
                 </p>
                 <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-500">
-                  {c.reporter_name && (
-                    <span className="truncate max-w-[100px]">
-                      {c.reporter_name}
-                    </span>
-                  )}
-                  {c.reporter_name && (c.street || c.city) && (
+                  {c.reporter_name ? (
+                    <span className="truncate max-w-[100px]">{c.reporter_name}</span>
+                  ) : c.reporter_phone ? (
+                    <span className="truncate max-w-[100px] text-gray-400">{maskPhone(c.reporter_phone)}</span>
+                  ) : null}
+                  {(c.reporter_name || c.reporter_phone) && (c.street || c.city) && (
                     <span className="text-gray-300">·</span>
                   )}
                   {c.street ? (
@@ -393,6 +443,29 @@ export function TechnikerView({
           })}
         </div>
       </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+            disabled={safePage <= 1}
+            className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            &lt;
+          </button>
+          <span className="text-sm text-gray-500">
+            Seite {safePage} von {totalPages}
+          </span>
+          <button
+            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+            disabled={safePage >= totalPages}
+            className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            &gt;
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/web/src/lib/cases/statusColors.ts
+++ b/src/web/src/lib/cases/statusColors.ts
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------
+// Shared status colors, labels, urgency helpers — single source of truth
+// Used by LeitzentraleView + TechnikerView
+// ---------------------------------------------------------------------------
+
+export const STATUS_LABELS: Record<string, string> = {
+  new: "Neu",
+  scheduled: "Geplant",
+  in_arbeit: "In Arbeit",
+  warten: "Warten",
+  done: "Erledigt",
+};
+
+export const URGENCY_DOT: Record<string, string> = {
+  notfall: "bg-red-500",
+  dringend: "bg-amber-500",
+  normal: "bg-gray-400",
+};
+
+export const URGENCY_LABEL: Record<string, string> = {
+  notfall: "Hoch",
+  dringend: "Mittel",
+  normal: "Normal",
+};
+
+/**
+ * Returns Tailwind classes for a case status badge.
+ * FB6: in_arbeit=orange, warten=grau, done+review=gold-ring, done+rating≥4=gold
+ */
+export function getStatusColorClass(
+  status: string,
+  reviewSentAt?: string | null,
+  reviewRating?: number | null,
+): string {
+  switch (status) {
+    case "new":
+      return "bg-blue-100 text-blue-700";
+    case "scheduled":
+      return "bg-violet-100 text-violet-700";
+    case "in_arbeit":
+      return "bg-orange-100 text-orange-700";
+    case "warten":
+      return "bg-gray-100 text-gray-600";
+    case "done":
+      if (reviewRating != null && reviewRating >= 4)
+        return "bg-amber-100 text-amber-800 ring-1 ring-amber-400";
+      if (reviewSentAt)
+        return "bg-emerald-100 text-emerald-700 ring-1 ring-amber-400";
+      return "bg-emerald-100 text-emerald-700";
+    default:
+      return "bg-gray-100 text-gray-700";
+  }
+}

--- a/src/web/src/lib/ui/getGreeting.ts
+++ b/src/web/src/lib/ui/getGreeting.ts
@@ -1,0 +1,6 @@
+export function getGreeting(): string {
+  const h = new Date().getHours();
+  if (h < 12) return "Guten Morgen";
+  if (h < 17) return "Guten Tag";
+  return "Guten Abend";
+}

--- a/supabase/migrations/20260319000000_review_rating.sql
+++ b/supabase/migrations/20260319000000_review_rating.sql
@@ -1,0 +1,5 @@
+-- Add review rating fields to cases (FB6 gold status + review KPI)
+ALTER TABLE cases
+  ADD COLUMN IF NOT EXISTS review_rating smallint CHECK (review_rating >= 1 AND review_rating <= 5),
+  ADD COLUMN IF NOT EXISTS review_received_at timestamptz,
+  ADD COLUMN IF NOT EXISTS review_sent_count smallint DEFAULT 0;


### PR DESCRIPTION
## Summary
- **FB1** FlowBar: CSS Grid equal-width KPIs, YTD toggle, source breakdown under "Neu", clickable Notfall badge, always-gold stars, mobile 2x2
- **FB2/FB4** Mobile: 2x2 grid (no arrows), min-h-[48px] tap targets, compact padding
- **FB3** Techniker: pagination (15/page), wrench + calendar SVG icons, period toggle, "Nächster Einsatz" always visible
- **FB5** "Kat." → "Kategorie" in both Admin + Techniker tables
- **FB6** Shared status colors: in_arbeit=orange, warten=gray, done+review-sent=green+gold-ring, done+rating≥4=full-gold
- **DB** Migration: review_rating, review_received_at, review_sent_count on cases
- **QW** Sticky case-ID column, phone fallback, reset-button on empty, techniker nav cleanup

## Test plan
- [ ] Admin Laptop: greeting visible, 3 period buttons (7d/30d/YTD), equal KPI widths
- [ ] KPI "Neu" shows source breakdown (Tel/Web/Stift icons)
- [ ] Notfall badge clickable → filters to notfall cases
- [ ] Stars always gold, "Noch keine" when no rating
- [ ] Period toggle changes KPIs AND table
- [ ] Techniker: pagination works, wrench + calendar icons visible
- [ ] Status colors: Warten=gray, In Arbeit=orange
- [ ] Mobile: 2x2 grid, nothing cut off, min 48px rows
- [ ] "Kategorie" spelled out in table headers
- [ ] Techniker sidebar: no disabled "Bald" items

🤖 Generated with [Claude Code](https://claude.com/claude-code)