### PR TITLE
fix: missing case data + colorful KPI icons

### DIFF
--- a/src/web/src/components/ops/FlowBar.tsx
+++ b/src/web/src/components/ops/FlowBar.tsx
@@ -170,23 +170,25 @@ export function FlowBar({
                     }
                   `}
                 >
-                  {step.icon && <span className="text-base sm:text-lg">{step.icon}</span>}
+                  {/* Source breakdown ABOVE the count (for "Neu" KPI) */}
+                  {step.sourceBreakdown && step.sourceBreakdown.length > 0 && (
+                    <span className="flex items-center justify-between w-full px-1 sm:px-2 mb-1 text-[9px] sm:text-[10px] text-gray-500">
+                      {step.sourceBreakdown.map((s, si) => (
+                        <span key={s.label} className={`inline-flex items-center gap-1 ${si === 0 ? "" : si === step.sourceBreakdown!.length - 1 ? "" : ""}`}>
+                          <span className="w-3.5 h-3.5 sm:w-4 sm:h-4 flex-shrink-0">{s.icon}</span>
+                          <span className="font-semibold">{s.count}</span>
+                        </span>
+                      ))}
+                    </span>
+                  )}
+                  {/* Icon (for steps like "Bei uns", "Erledigt") */}
+                  {step.icon && !step.sourceBreakdown && <span className="text-base sm:text-lg">{step.icon}</span>}
                   <span className="text-2xl sm:text-3xl font-extrabold text-gray-900 leading-none mt-0.5">
                     {step.count}
                   </span>
                   <span className="text-[9px] sm:text-[10px] font-semibold text-gray-500 uppercase tracking-wider mt-1">
                     {step.label}
                   </span>
-                  {step.sourceBreakdown && step.sourceBreakdown.length > 0 && (
-                    <span className="flex items-center gap-1.5 mt-1 text-[8px] sm:text-[9px] text-gray-400">
-                      {step.sourceBreakdown.map((s) => (
-                        <span key={s.label} className="inline-flex items-center gap-0.5">
-                          <span className="w-3 h-3">{s.icon}</span>
-                          <span>{s.count}</span>
-                        </span>
-                      ))}
-                    </span>
-                  )}
                   {step.subLabel && !step.sourceBreakdown && (
                     <span className="text-[8px] sm:text-[9px] text-gray-400 mt-0.5">
                       {step.subLabel}
@@ -278,23 +280,24 @@ export function FlowBar({
                   }
                 `}
               >
-                {step.icon && <span className="text-base">{step.icon}</span>}
+                {/* Source breakdown ABOVE count on mobile too */}
+                {step.sourceBreakdown && step.sourceBreakdown.length > 0 && (
+                  <span className="flex items-center justify-between w-full px-1 mb-1 text-[9px] text-gray-500">
+                    {step.sourceBreakdown.map((s) => (
+                      <span key={s.label} className="inline-flex items-center gap-0.5">
+                        <span className="w-3.5 h-3.5 flex-shrink-0">{s.icon}</span>
+                        <span className="font-semibold">{s.count}</span>
+                      </span>
+                    ))}
+                  </span>
+                )}
+                {step.icon && !step.sourceBreakdown && <span className="text-base">{step.icon}</span>}
                 <span className="text-2xl font-extrabold text-gray-900 leading-none mt-0.5">
                   {step.count}
                 </span>
                 <span className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1">
                   {step.label}
                 </span>
-                {step.sourceBreakdown && step.sourceBreakdown.length > 0 && (
-                  <span className="flex items-center gap-1 mt-1 text-[8px] text-gray-400">
-                    {step.sourceBreakdown.map((s) => (
-                      <span key={s.label} className="inline-flex items-center gap-0.5">
-                        <span className="w-3 h-3">{s.icon}</span>
-                        <span>{s.count}</span>
-                      </span>
-                    ))}
-                  </span>
-                )}
                 {step.subLabel && !step.sourceBreakdown && (
                   <span className="text-[8px] text-gray-400 mt-0.5">{step.subLabel}</span>
                 )}

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -66,32 +66,21 @@ const PAGE_SIZE_MOBILE = 8;
 // SVG Icons (inline, no extra deps)
 // ---------------------------------------------------------------------------
 
-const WrenchIcon = (
-  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" />
-  </svg>
-);
-
-const CheckIcon = (
-  <svg className="w-5 h-5 text-emerald-600" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-  </svg>
-);
-
+// Colorful source icons for "Neu" KPI
 const PhoneIcon = (
-  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+  <svg className="w-3.5 h-3.5 text-blue-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
     <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z" />
   </svg>
 );
 
 const GlobeIcon = (
-  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+  <svg className="w-3.5 h-3.5 text-emerald-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
     <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" />
   </svg>
 );
 
 const PencilIcon = (
-  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+  <svg className="w-3.5 h-3.5 text-amber-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
     <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
   </svg>
 );
@@ -231,7 +220,7 @@ export function LeitzentraleView({
   const [categoryFilter, setCategoryFilter] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [modalOpen, setModalOpen] = useState(false);
-  const [period, setPeriod] = useState<PeriodValue>("7d");
+  const [period, setPeriod] = useState<PeriodValue>("30d");
   const [pageSize, setPageSize] = useState(PAGE_SIZE_DESKTOP);
 
   useEffect(() => {
@@ -250,9 +239,17 @@ export function LeitzentraleView({
 
   const cutoff = useMemo(() => computeCutoff(period), [period]);
 
-  // Period-filter FIRST, then other filters (FB5: period filtert auch Tabelle)
+  // Period-filter: only exclude old DONE and old NEW cases.
+  // Active cases (scheduled, in_arbeit, warten) always show regardless of period.
   const filteredCases = useMemo(() => {
-    let result = cases.filter((c) => new Date(c.created_at).getTime() >= cutoff);
+    let result = cases.filter((c) => {
+      const isActive = c.status === "scheduled" || c.status === "in_arbeit" || c.status === "warten";
+      if (isActive) return true; // always show active cases
+      const t = c.status === "done"
+        ? new Date(c.updated_at).getTime()
+        : new Date(c.created_at).getTime();
+      return t >= cutoff;
+    });
 
     if (activeNode) {
       result = result.filter((c) => matchesNode(c, activeNode));
@@ -366,7 +363,7 @@ export function LeitzentraleView({
     },
     {
       key: "bei_uns",
-      icon: WrenchIcon,
+      icon: <span className="text-lg">👷</span>,
       count: flowStats.beiUns,
       label: "Bei uns",
       accent: "orange",
@@ -379,7 +376,7 @@ export function LeitzentraleView({
     },
     {
       key: "erledigt",
-      icon: CheckIcon,
+      icon: <span className="text-lg">✅</span>,
       count: flowStats.erledigt,
       label: "Erledigt",
       accent: "emerald",

--- a/src/web/src/components/ops/TechnikerView.tsx
+++ b/src/web/src/components/ops/TechnikerView.tsx
@@ -29,24 +29,10 @@ interface TechnikerViewProps {
 const PAGE_SIZE_DESKTOP = 15;
 const PAGE_SIZE_MOBILE = 8;
 
-// SVG Icons
-const WrenchIcon = (
-  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" />
-  </svg>
-);
-
-const CalendarIcon = (
-  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
-  </svg>
-);
-
-const CheckIcon = (
-  <svg className="w-5 h-5 text-emerald-600" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-  </svg>
-);
+// Emoji icons for Techniker KPIs (colorful, consistent with Admin)
+const BeiMirIcon = <span className="text-lg">👷</span>;
+const HeuteIcon = <span className="text-lg">📅</span>;
+const ErledigtIcon = <span className="text-lg">✅</span>;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -134,7 +120,7 @@ export function TechnikerView({
   const router = useRouter();
   const [activeStep, setActiveStep] = useState<TechFilter>(null);
   const [currentPage, setCurrentPage] = useState(1);
-  const [period, setPeriod] = useState<PeriodValue>("7d");
+  const [period, setPeriod] = useState<PeriodValue>("30d");
   const [pageSize, setPageSize] = useState(PAGE_SIZE_DESKTOP);
 
   useEffect(() => {
@@ -199,9 +185,9 @@ export function TechnikerView({
 
   // Steps with proper icons
   const steps: FlowStep[] = [
-    { key: "bei_mir", icon: WrenchIcon, count: beiMir, label: "Bei mir", accent: "blue" },
-    { key: "heute", icon: CalendarIcon, count: heute, label: "Heute", accent: "orange" },
-    { key: "erledigt", icon: CheckIcon, count: erledigt, label: "Erledigt", accent: "emerald" },
+    { key: "bei_mir", icon: BeiMirIcon, count: beiMir, label: "Bei mir", accent: "blue" },
+    { key: "heute", icon: HeuteIcon, count: heute, label: "Heute", accent: "orange" },
+    { key: "erledigt", icon: ErledigtIcon, count: erledigt, label: "Erledigt", accent: "emerald" },
   ];
 
   // Filtered + sorted cases (period + tech filter)
@@ -209,8 +195,15 @@ export function TechnikerView({
     let result = cases.filter((c) =>
       matchesTechFilter(c, activeStep, todayStr),
     );
-    // Period filter for table
-    result = result.filter((c) => new Date(c.created_at).getTime() >= cutoff);
+    // Period filter: active cases always show, only filter done/new by period
+    result = result.filter((c) => {
+      const isActive = c.status === "scheduled" || c.status === "in_arbeit" || c.status === "warten";
+      if (isActive) return true;
+      const t = c.status === "done"
+        ? new Date(c.updated_at).getTime()
+        : new Date(c.created_at).getTime();
+      return t >= cutoff;
+    });
 
     return [...result].sort((a, b) => {
       const rank = (c: LeitzentraleCase) => {


### PR DESCRIPTION
## Summary
- **Fix #1 (Missing data):** Default period changed from 7d to 30d. Active cases (scheduled/in_arbeit/warten) always visible regardless of period filter. Done filtered by updated_at, new by created_at.
- **Fix #2 (Neu KPI):** Source breakdown icons (Tel/Web/Stift) now ABOVE the count number with justify-between spacing. Icons are colorful: blue phone, green globe, amber pencil.
- **Fix #3 (Bei uns):** 👷 construction worker emoji (colorful, recognizable)
- **Fix #4 (Erledigt):** ✅ checkmark emoji (was monochrome SVG, now the familiar green checkmark)

## Test plan
- [ ] All 3 tenants (Weinberger, Dörfler, Brunner) show cases again
- [ ] Active cases visible even with 7d period selected
- [ ] "Neu" KPI: phone left, globe center, pencil right — above the number
- [ ] "Bei uns" shows 👷 construction worker
- [ ] "Erledigt" shows ✅ green checkmark
- [ ] Techniker same icons + data fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)