### PR TITLE
fix: reporter_phone → contact_phone (restores all case data)

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -41,7 +41,7 @@ export default async function OpsCasesPage({
   let casesQuery = supabase
     .from("cases")
     .select(
-      "id, seq_number, created_at, updated_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, reporter_phone, review_sent_at, review_rating, scheduled_at"
+      "id, seq_number, created_at, updated_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, contact_phone, review_sent_at, review_rating, scheduled_at"
     )
     .eq("is_demo", showDemo)
     .order("created_at", { ascending: false })

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -35,7 +35,7 @@ export interface LeitzentraleCase {
   source: string;
   assignee_text?: string | null;
   reporter_name?: string | null;
-  reporter_phone?: string | null;
+  contact_phone?: string | null;
   review_sent_at?: string | null;
   review_rating?: number | null;
   scheduled_at?: string | null;
@@ -555,8 +555,8 @@ export function LeitzentraleView({
                     </td>
                     <td className="px-3 py-2 text-gray-900 truncate max-w-[180px]">
                       {c.reporter_name || (
-                        c.reporter_phone ? (
-                          <span className="text-gray-400">{maskPhone(c.reporter_phone)}</span>
+                        c.contact_phone ? (
+                          <span className="text-gray-400">{maskPhone(c.contact_phone)}</span>
                         ) : (
                           <span className="text-gray-400">—</span>
                         )
@@ -640,8 +640,8 @@ export function LeitzentraleView({
                 <div className="flex items-center gap-2 mt-1 text-xs text-gray-500">
                   {c.reporter_name ? (
                     <span className="truncate max-w-[120px]">{c.reporter_name}</span>
-                  ) : c.reporter_phone ? (
-                    <span className="truncate max-w-[120px] text-gray-400">{maskPhone(c.reporter_phone)}</span>
+                  ) : c.contact_phone ? (
+                    <span className="truncate max-w-[120px] text-gray-400">{maskPhone(c.contact_phone)}</span>
                   ) : null}
                   {c.city && (
                     <>

--- a/src/web/src/components/ops/TechnikerView.tsx
+++ b/src/web/src/components/ops/TechnikerView.tsx
@@ -332,8 +332,8 @@ export function TechnikerView({
                     </td>
                     <td className="px-3 py-2.5 text-gray-700 truncate max-w-[140px]">
                       {c.reporter_name || (
-                        c.reporter_phone ? (
-                          <span className="text-gray-400">{maskPhone(c.reporter_phone)}</span>
+                        c.contact_phone ? (
+                          <span className="text-gray-400">{maskPhone(c.contact_phone)}</span>
                         ) : (
                           <span className="text-gray-300">—</span>
                         )
@@ -424,10 +424,10 @@ export function TechnikerView({
                 <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-500">
                   {c.reporter_name ? (
                     <span className="truncate max-w-[100px]">{c.reporter_name}</span>
-                  ) : c.reporter_phone ? (
-                    <span className="truncate max-w-[100px] text-gray-400">{maskPhone(c.reporter_phone)}</span>
+                  ) : c.contact_phone ? (
+                    <span className="truncate max-w-[100px] text-gray-400">{maskPhone(c.contact_phone)}</span>
                   ) : null}
-                  {(c.reporter_name || c.reporter_phone) && (c.street || c.city) && (
+                  {(c.reporter_name || c.contact_phone) && (c.street || c.city) && (
                     <span className="text-gray-300">·</span>
                   )}
                   {c.street ? (


### PR DESCRIPTION
## Summary
- PR #288 added `reporter_phone` to the SELECT query, but the actual DB column is `contact_phone`
- Supabase PostgREST returns empty results when an invalid column is referenced
- This broke ALL case data display for ALL tenants (Weinberger, Dörfler, Brunner)
- Fix: rename all references from `reporter_phone` to `contact_phone`

## Test plan
- [ ] All 3 tenants show cases again immediately after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)