### PR TITLE
docs: SSOT update 19.03. — Leitzentrale v3, Review Pre-Filter

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # FlowSight — STATUS (Company SSOT)
 
-**Datum:** 2026-03-18 (Leitsystem Phase 1-4 komplett, Tenant-Scope-Hardening, Feedback-Runden FB1-FB21)
+**Datum:** 2026-03-19 (Leitzentrale v3 FlowBar, Review Pre-Filter, FB1-FB6 komplett)
 **Owner:** Founder + CC (Head Ops)
 
 ## Was ist FlowSight?
@@ -27,7 +27,7 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 | **Wizard** (Website Intake) | LIVE ✅ | /kunden/[slug]/meldung — "Was ist Ihr Anliegen?", Top-3 dynamic + fixed row (Allgemein/Angebot/Kontakt), photo upload in Step 3, branded per customer |
 | **Voice** (Telefon Intake) | LIVE ✅ | Dual-Agent DE/INTL, PLZ→City auto-lookup (24 Orte), Language Gate, SMS+Photo mention, reporter_name, deterministic closing, Notfall-Empathie, FAQ-safe edge logic |
 | **SMS Channel** | LIVE ✅ | Post-call SMS with short correction link `/v/[id]?t=<16hex>` (~85 chars) + photo upload. eCall.ch Swiss gateway (2-tier sender: alphanumeric → FlowSight-Servicenummer). HMAC-secured. |
-| **Ops Dashboard** | LIVE ✅ | /ops — Case Detail (UX v2), Case List (search, pagination, KPI click-to-filter), CSV-Export, Timeline |
+| **Leitzentrale v3** | LIVE ✅ | /ops — FlowBar (CSS Grid, YTD-Toggle, Gold-Sterne, Quellen-Aufschlüsselung), Admin+Techniker-Ansicht, Pagination, Period-Filter, Termin-Kollisions-Warnung |
 | **Email Notifications** | LIVE ✅ | HTML Ops-Notification + Melder-Bestätigung + Review-Anfrage + Demo + Sales Lead |
 | **Peoplefone Front Door** | LIVE ✅ | Brand-Nr → Twilio → SIP → Retell |
 | **Morning Report** | LIVE ✅ | 15 KPIs + Trial Status + Deep Health, GH Actions Cron (daily 07:30 UTC), Telegram + E-Mail (RED/YELLOW) |
@@ -36,7 +36,7 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 | **Customer Websites** | LIVE ✅ | /kunden/[slug] — SSG template (12 sections, ServiceDetailOverlay, lightbox, galleries) |
 | **Customer Links Page** | LIVE ✅ | /kunden/[slug]/links — SSG, alle Kunden-URLs auf einen Blick, noindex |
 | **Review Engine** | LIVE ✅ | Manual button, review_sent_at, tenant-scoped GOOGLE_REVIEW_URL, SMS fallback |
-| **Review Surface** | LIVE ✅ | /review/[caseId] — Google Review-style UI, HMAC-validated, tenant-dynamic, mobile-first |
+| **Review Surface** | LIVE ✅ | /review/[caseId] — Pre-Filter (★-Picker → ≥4★ Google, ≤3★ intern), HMAC-validated, tenant-branded |
 | **Entitlements** | LIVE ✅ | hasModule() — per-tenant module gating |
 | **CoreBot** | LIVE ✅ | Telegram → GitHub Issues (Voice→STT, Photo/Doc Attachments, /ticket, /status) |
 | **Demo-Strang** | LIVE ✅ | /brunner-haustechnik — High-End Demo + Voice Agent Intake+Info |
@@ -56,11 +56,12 @@ Kernnutzen: Geschwindigkeit + Klarheit. Notfälle sofort als Ticket (Voice), gep
 
 ## Aktueller Stand
 
-- **Leitzentrale v2 High-End (18.03.):** PRs #268-#280. Kompletter Neuaufbau: Systemfluss-Pipeline (📞→⚡→✅→★★★★★) mit Quellen-Aufschlüsselung, Handlungsbedarfs-Zone (intelligent priorisiert: Notfall→Überfällig→Wartet>48h→Neu), Wirkungs-Zone (Gold-Sterne, Bewertungstexte, Progress-Bar, Zeitfilter). Techniker-Ansicht: persönliche Begrüssung, Tages-Termine mit Navigation, nur eigene Fälle.
-- **Scaling & Access (18.03.):** PRs #277-#280. Tenant-Switcher (Admin wechselt per Dropdown zwischen Betrieben). Support-System ("Hilfe"-Seite → GitHub Issue). Rollen-Switch (Admin↔Techniker für Testing). Deploy-Status im Sidebar-Footer. Cookie-basiert, HttpOnly, skalierbar bis 100+ Tenants.
-- **Tenant-Scope-Hardening (18.03.):** PRs #270-#276. Admin behält tenant_id (kein Fallback auf ältesten Tenant). Brand Color Pipeline (CustomerSite → DB → Leitsystem). Alle E-Mails R4-konform. Dynamische Kanal-Hinweise aus Einstellungen.
-- **Leitsystem Phase 1-4 (17.-18.03.):** PRs #238-#267. Login High-End (OTP, Swiss Trust). PWA Auto-Update. Falldetail komplett (Status, Termin, Staff, Bewertungen). Kommunikation & SMS (160-Char-Audit). Rollen & Einstellungen (Staff CRUD, Techniker-Micro-Surface).
-- **Feedback-Runden FB1-FB21 (18.03.):** Alle Founder-Feedbacks abgearbeitet. Kritische Tenant-Bugs behoben.
+- **Leitzentrale v3 FlowBar (19.03.):** PRs #287-#290. Kompletter Overhaul: CSS Grid (gleiche KPI-Breiten), 7d/30d/YTD-Toggle, Quellen-Aufschlüsselung (📞Tel/🌐Web/✏️Stift) ÜBER Zahl, 👷 Bauarbeiter + ✅ Häkchen Emojis, immer goldene Sterne, Mobile 2x2 Grid. Period filtert Tabelle (aktive Fälle immer sichtbar). Techniker: Pagination (15/8 Desktop/Mobile), eigener Period-Toggle, "Nächster Einsatz" immer sichtbar.
+- **Review Pre-Filter (19.03.):** PR #288. Sterne-Picker auf /review/[caseId] → ≥4★ zeigt Google-Link, ≤3★ nur "Danke" (kein Google). `review_rating` + `review_received_at` in DB. API: POST /api/review/[caseId]/rate. Gold-Status in Tabelle (rating ≥ 4).
+- **Shared Utilities (19.03.):** statusColors.ts (in_arbeit=orange, warten=grau, done+rating≥4=gold), getGreeting.ts, plzCityMap.ts (shared zwischen Webhook + CreateCaseModal).
+- **Quick Wins (19.03.):** PLZ→Stadt Auto-Fill, Pflichtfeld-Markierung (rotes *), Termin-Kollisions-Warnung, Sticky Case-ID, 48px Mobile Tap-Targets, Techniker-Nav aufgeräumt, Reset-Button bei "Keine Fälle".
+- **Scaling & Access (18.03.):** PRs #277-#280. Tenant-Switcher, Support-System, Rollen-Switch, Deploy-Status.
+- **Leitsystem Phase 1-4 (17.-18.03.):** PRs #238-#267. Login OTP, PWA, Falldetail, Kommunikation, Staff CRUD.
 - **17 Module LIVE.** 7 Kunden-Websites. Weinberger = GTM Goldstandard.
 
 ### Kondensierte Historie (04.-14.03.)

--- a/docs/architecture/zielarchitektur.md
+++ b/docs/architecture/zielarchitektur.md
@@ -1,8 +1,8 @@
 # FlowSight — Zielarchitektur (Business + Produkt + GTM)
 
-**Version:** 1.5 | **Datum:** 2026-03-18
+**Version:** 1.6 | **Datum:** 2026-03-19
 **Autor:** CC (Head Ops) + Founder-Input
-**Status:** v1.5 — 25 Decisions (D1-D25). Leitzentrale v2, Scaling & Access, Kommunikationsmatrix. Thema C geparkt.
+**Status:** v1.6 — 27 Decisions (D1-D27). Leitzentrale v3 FlowBar, Review Pre-Filter, Shared Status-Farben. Thema C geparkt.
 **Regel:** Dieses Dokument beschreibt die **Zielarchitektur**. Aktueller Stand → `docs/STATUS.md`. Tasks → `docs/ticketlist.md`.
 **Pfad:** `docs/architecture/zielarchitektur.md` (umgezogen von `docs/gtm/architecture_detail.md`)
 
@@ -30,13 +30,15 @@
 | D16 | Product-Led Trial Machine (14-Tage Trial, provision_trial.mjs, offboard_tenant.mjs) | **ENTSCHIEDEN** ✅ | Founder | operating_model.md |
 | D17 | Tenant Scope: Admin behält tenant_id + isAdmin=true. Kein Fallback auf ältesten Tenant. | **ENTSCHIEDEN** ✅ | Founder + CC | resolveTenantScope.ts |
 | D18 | Brand Color Pipeline: CustomerSite → DB modules.primary_color → Leitsystem (Kalender, Buttons, Sidebar) | **ENTSCHIEDEN** ✅ | Founder + CC | sync_brand_colors.mjs |
-| D19 | Leitzentrale v2: 3-Zonen-Architektur (Systemfluss → Handlungsbedarf → Wirkung) statt 6 gleiche Cards | **ENTSCHIEDEN** ✅ | Founder + CC | plan_leitzentrale_v2.md |
+| D19 | Leitzentrale v2→v3: FlowBar (CSS Grid) statt 3-Zonen. v2 abgelehnt → v3: EINE Card, EIN geschlossenes System | **ENTSCHIEDEN** ✅ | Founder + CC | FlowBar.tsx |
 | D20 | Rollen-basierte Leitzentrale: Admin = "Mein Betrieb", Techniker = "Meine Arbeit" | **ENTSCHIEDEN** ✅ | Founder + CC | LeitzentraleView.tsx, TechnikerView.tsx |
 | D21 | Tenant-Switcher: HttpOnly Cookie `fs_active_tenant`, Admin-only, skalierbar | **ENTSCHIEDEN** ✅ | Founder + CC | scaling_access.md |
 | D22 | Rollen-Switch: Admin kann als Techniker testen (Cookie `fs_view_as_role`) | **ENTSCHIEDEN** ✅ | Founder + CC | scaling_access.md |
 | D23 | Support-System: "Hilfe"-Seite → GitHub Issue (+ Resend Fallback) | **ENTSCHIEDEN** ✅ | Founder + CC | scaling_access.md |
 | D24 | Benachrichtigungs-Kommunikationsmatrix: 25+ Trigger, 5 Kanäle, 5 Akteure | **ENTSCHIEDEN** ✅ | Founder + CC | Matrix_kommunikation.md |
 | D25 | FlowSight CEO-App (Thema C): Eigene Betreiber-PWA für Monitoring, Dev/Prod-Übersicht | **GEPARKT** | Founder | Nach Go-Live |
+| D26 | Leitzentrale v3 FlowBar: CSS Grid KPIs, 7d/30d/YTD, Quellen-Aufschlüsselung, Gold-Sterne, Mobile 2x2, Shared statusColors.ts | **ENTSCHIEDEN** ✅ | Founder + CC | FlowBar.tsx, LeitzentraleView.tsx |
+| D27 | Review Pre-Filter: ★-Picker → ≥4★ Google-Link, ≤3★ intern. review_rating/review_received_at auf Cases. Gold-Status bei ≥4★. | **ENTSCHIEDEN** ✅ | Founder + CC | ReviewSurfaceClient.tsx, statusColors.ts |
 
 ---
 

--- a/docs/business_briefing.md
+++ b/docs/business_briefing.md
@@ -2,7 +2,7 @@
 
 > Dieses Dokument ist der komplette Kontext für ChatGPT, Claude und externe Partner.
 > Copy-paste als System-Prompt oder ersten Message. Deckt Business, Produkt, Technik und Strategie ab.
-> Letzte Aktualisierung: 2026-03-17
+> Letzte Aktualisierung: 2026-03-19
 
 ---
 
@@ -87,20 +87,25 @@ FlowSight ist ein Multi-Tenant SaaS für Schweizer Handwerksbetriebe. Wir digita
 - **24/7 erreichbar**, keine verpassten Anrufe
 - **Template-System:** Agent-Configs als JSON-Schablone (~20 Min pro Kunde)
 
-### 3.4 Ops Dashboard
-- Web-App unter /ops (Login via Custom OTP: 6-Digit Code per E-Mail, server-side Session, keine Supabase Rate Limits. Sender: noreply@send.flowsight.ch)
-- **Fallliste:** Alle Fälle mit Status, Quelle (voice/wizard/manual), Datum, seq_number (FS-XXXX)
-- **Filter:** Status, Quelle, Kategorie, Zeitraum, Tenant
-- **Fall-Detailansicht:** Kontaktdaten, Fallbeschreibung, Fotos, Timeline (case_events), Notizen
-- **Aktionen:** Status ändern, Termin senden (E-Mail an Melder), Review anfragen, manueller Fall erstellen
-- **KPI-Cards:** Click-to-Filter (Total→all, Neu→new, In Bearbeitung→default, Erledigt→done). Status-Kette: Neu → Geplant → In Arbeit → Warten → Erledigt (kein "Abgeschlossen")
-- **CSV-Export** für Buchhaltung/Reporting
-- **Light Theme**, Sidebar-Navigation, responsive
+### 3.4 Leitzentrale (Ops Dashboard)
+- Web-App unter /ops (Login via Custom OTP: 6-Digit Code per E-Mail, server-side Session. Sender: noreply@send.flowsight.ch)
+- **Leitzentrale v3 (FlowBar):** CSS Grid KPIs (Neu/Bei uns/Erledigt/Bewertung), gleiche Breiten, 7d/30d/YTD-Toggle
+- **Quellen-Aufschlüsselung:** "Neu" KPI zeigt 📞 Tel / 🌐 Web / ✏️ Stift mit Anzahl
+- **Gold-Sterne:** Bewertungs-KPI immer goldene Sterne, Durchschnitt + "erhalten / angefragt"
+- **Admin-Ansicht:** Begrüssung, alle Betrieb-Fälle, Smart Sort, Spaltenfilter
+- **Techniker-Ansicht:** "Meine Arbeit" (nur zugewiesene Fälle), nächster Einsatz mit Maps-Link, Pagination
+- **Fall-Detailansicht:** Status, Termin (mit Kollisions-Warnung), Staff-Zuweisung, Bewertungs-Workflow, Timeline
+- **Status-Farben:** Neu=blau, Geplant=violett, In Arbeit=orange, Warten=grau, Erledigt=grün, Erledigt+4★=gold
+- **Mobile:** 2x2 Grid KPIs, 8 Fälle/Seite, 48px Tap-Targets
+- **PLZ Auto-Fill:** Bei Fallerfassung → Stadt automatisch aus Schweizer PLZ-Map
+- **Light Theme**, Sidebar-Navigation, responsive, PWA-installierbar
 
-### 3.5 Google Review Engine
+### 3.5 Google Review Engine (mit Pre-Filter)
 - Nach erledigtem Fall: Button "Review anfragen" im Ops Dashboard
-- Sendet E-Mail an Melder mit direktem Link zur Google-Bewertungsseite
-- Tracking: review_sent_at Timestamp pro Fall
+- Sendet E-Mail an Melder mit Link zur Bewertungs-Landingpage `/review/[caseId]`
+- **Pre-Filter:** Kunde gibt 1-5 Sterne → ≥4★ sieht Google-Link, ≤3★ sieht nur "Danke" (kein Google-Redirect)
+- Tracking: `review_rating`, `review_received_at`, `review_sent_count` auf Case
+- **Gold-Status:** Fälle mit rating ≥ 4 werden gold markiert in der Leitzentrale
 - Google Review URL pro Tenant konfigurierbar
 
 ### 3.6 Morning Report
@@ -320,7 +325,7 @@ Phase 5: Delivery      → Nur bei Conversion (Vertrag, Portierung)
 
 ## 10. Bekannte Limitationen & offene Punkte
 
-- **Kein Kalender-Sync** — Termine werden manuell im Dashboard eingetragen (N3)
+- **Kalender Phase 1 intern aktiv** — Kollisions-Warnung gegen DB-Termine. Phase 2 (Outlook/Google OAuth) wartet auf Founder-Setup (`docs/runbooks/founder_kalender_setup.md`)
 - **Review-Anfrage manuell** — kein Auto-Trigger nach Fall-Abschluss
 - **Terminerinnerung fehlt** — 24h-Reminder an Melder geplant (N15)
 - **Kunden-Historie fehlt** — kein Matching bei wiederholtem Kontakt (N16)

--- a/docs/ticketlist.md
+++ b/docs/ticketlist.md
@@ -1,6 +1,6 @@
 # Ticketlist — FlowSight (SSOT)
 
-**Updated:** 2026-03-18 (Leitzentrale v2 + Scaling & Access deployed)
+**Updated:** 2026-03-19 (Leitzentrale v3 FlowBar + Review Pre-Filter + FB1-FB6 deployed)
 **Rule:** CC updates after every deliverable. Founder reviews weekly.
 **Einziger Ticket-Tracker.** Alle offenen Tickets leben hier.
 **Bug-Klassen:** `[STOPP]` = blockiert E2E/Proof/Versand. Wird sofort gefixt. Alles andere = Ticketliste.
@@ -9,10 +9,10 @@
 
 ## Snapshot
 
-- **Produkt:** 17 Module LIVE + Tenant-Switcher + Support-System + Leitzentrale v2
+- **Produkt:** 17 Module LIVE + Leitzentrale v3 (FlowBar, Gold-Sterne, Review Pre-Filter)
 - **Kunden:** 7 Websites live (Doerfler, Brunner HT, Walter Leuthold, Orlandini, Widmer, **Weinberger AG**, BigBen Pub)
 - **BLOCKER:** 0
-- **Phase:** Leitzentrale v2 deployed (18.03.). Scaling & Access live. Go-Live-Vorbereitung.
+- **Phase:** Leitzentrale v3 deployed (19.03.). Review Pre-Filter live. Kalender-Integration wartet auf Founder-Setup.
 - **CI/CD:** GitHub Actions (lint + build + Telegram notify + lifecycle-tick + morning-report). Branch Protection: PR required.
 
 ### How to Operate (Founder via Handy)
@@ -33,20 +33,28 @@ Keine.
 
 ---
 
-## OFFEN — Founder-Feedback (Session 19.03.)
-
-> RM1-RM7 Feedback-Runde. RM1-RM6 in Bearbeitung (PR in Arbeit). RM7 = Konzept.
+## OFFEN — Founder-Actions
 
 | # | Titel | Beschreibung | Status |
 |---|-------|-------------|--------|
-| RM1 | **Nav-Reihenfolge** | Leitzentrale → Einstellungen → Support → Einsatzplanung. Techniker ohne Einstellungen/Support. | IN ARBEIT |
 | RM2.1 | **support@flowsight.ch einrichten** | E-Mail in Outlook aktivieren (Founder-Task) | OFFEN — Founder |
 | RM2.2 | **Lisa auf Support-Tickets trainieren** | Voice Agent soll Support-Anfragen sauber verarbeiten | OFFEN |
-| RM3 | **Info-Button (i) hinter Rolle** | Klick zeigt nichts → Fix: Info-Panel auch ausserhalb Form | IN ARBEIT |
-| RM4 | **Settings zeigt falschen Tenant** | KRITISCH: Brunner-Switch → Weinberger in Settings. SAFETY guards eingebaut. | IN ARBEIT |
-| RM5 | **Techniker-View nicht aktiv** | Admin→Techniker-Switch zeigt Admin-View statt TechnikerView | IN ARBEIT |
-| RM6 | **Admin = Techniker identisch** | Folge von RM5: viewAsRole wird in cases/page.tsx nicht respektiert | IN ARBEIT |
-| RM7 | **Bewertungs-Weiche (≤3★ intern, ≥4★ → Google)** | Konzept-Frage: technisch machbar, rechtlich prüfen | KONZEPT |
+| KAL1 | **Outlook OAuth App anlegen** | Azure App Registration für Kalender-Integration (Phase 2). Anleitung: `docs/runbooks/founder_kalender_setup.md` | OFFEN — Founder |
+| KAL2 | **Google Calendar OAuth App anlegen** | Google Cloud Console für Kalender-Integration (Phase 2). Gleiche Anleitung. | OFFEN — Founder |
+
+## ERLEDIGT — Feedback Session 19.03. (PRs #286-#290)
+
+| # | Titel | Status |
+|---|-------|--------|
+| RM1 | Nav-Reihenfolge + Techniker-Nav aufgeräumt | DONE (PR #286) |
+| RM3-RM6 | Role Toggle, Settings Tenant, Techniker-View, hooks crash | DONE (PR #286) |
+| RM7 | Bewertungs-Weiche (≤3★ intern, ≥4★ → Google) | DONE (PR #288) — Review Pre-Filter live |
+| FB1 | FlowBar: Grid, YTD, Quellen, Badge, Gold-Sterne | DONE (PR #287) |
+| FB2/FB4 | Mobile 2x2 Grid | DONE (PR #287) |
+| FB3 | Techniker Pagination + Icons + Period-Toggle | DONE (PR #287) |
+| FB5 | "Kategorie" ausgeschrieben | DONE (PR #287) |
+| FB6 | Status-Farben (orange/grau/gold) | DONE (PR #287) |
+| 6a-6g | PLZ-Lookup, Pflichtfelder, Kollision, Mobile PageSize, Ramon | DONE (PR #288) |
 
 ---
 


### PR DESCRIPTION
## Summary
- **STATUS.md:** Updated to reflect Leitzentrale v3, Review Pre-Filter, FB1-FB6 complete
- **ticketlist.md:** RM1-RM7 + FB1-FB6 → ERLEDIGT. Founder Kalender-Actions added (KAL1/KAL2)
- **business_briefing.md:** Ops Dashboard → Leitzentrale v3 with full feature description, Review Pre-Filter section
- **zielarchitektur.md:** v1.6, D26 (FlowBar) + D27 (Review Pre-Filter), D19 updated v2→v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)