### PR TITLE
fix: Techniker Bewertungs-KPI — correct filter + global review permissions

### DIFF
--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -108,7 +108,7 @@ function matchesNode(c: LeitzentraleCase, node: string): boolean {
     case "erledigt":
       return c.status === "done";
     case "bewertung":
-      return c.status === "done" && !!c.review_sent_at;
+      return c.status === "done" && (c.review_sent_at != null || c.review_rating != null);
     case "bewertung_erhalten":
       return c.status === "done" && c.review_rating != null;
     case "bewertung_angefragt":

--- a/src/web/src/components/ops/TechnikerView.tsx
+++ b/src/web/src/components/ops/TechnikerView.tsx
@@ -101,7 +101,7 @@ function matchesTechFilter(c: LeitzentraleCase, f: TechFilter, todayStr: string)
     case "erledigt":
       return c.status === "done";
     case "bewertung":
-      return c.status === "done" && !c.review_sent_at;
+      return c.status === "done" && (c.review_sent_at != null || c.review_rating != null);
     default:
       return true;
   }
@@ -147,7 +147,7 @@ export function TechnikerView({
     (c) => c.status === "done" && new Date(c.updated_at).getTime() >= cutoff,
   ).length;
   const reviewCount = cases.filter(
-    (c) => c.status === "done" && c.review_rating != null,
+    (c) => c.status === "done" && (c.review_sent_at != null || c.review_rating != null),
   ).length;
 
   // Next appointment — always computed, shown above FlowBar


### PR DESCRIPTION
## Summary
- **Bewertungs-KPI Klick (Techniker):** Zeigt jetzt Fälle MIT Review-Aktivität (angefragt + erhalten) statt Fälle OHNE Review-Anfrage
- **Count = Tabelle:** "25 Bew." → klick → 25 Fälle in der Tabelle (konsistent)
- **Admin-Filter:** Gleiche Konsistenz-Fix für den generischen `bewertung`-Filter
- **Bewertung anfragen:** War bereits rollenunabhängig (API + UI) — Techniker konnte schon, kein Code-Change nötig

## Gold-Ring-Logik (unverändert, bereits korrekt)
| Zustand | Status-Button |
|---------|--------------|
| Erledigt + Bew. angefragt, noch nicht erhalten | Grün mit **goldenem Rand** |
| Erledigt + Bew. erhalten (≥4★) | **Goldener Button** |
| Erledigt + Bew. erhalten (≤3★) | Grün (kein Gold) |

## Test plan
- [ ] Als Techniker einloggen → Bewertungs-KPI (★) klicken → Tabelle zeigt nur Fälle mit Review-Aktivität
- [ ] Anzahl in KPI = Anzahl Fälle in Tabelle
- [ ] Gold-Ring/Gold-Button konsistent in Tabelle
- [ ] Als Techniker: Fall öffnen → "Bewertung anfragen" Button sichtbar + funktional
- [ ] Als Admin: Sub-Filter "erhalten"/"angefragt" weiterhin korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)