### PR TITLE
feat: FB10 gold-ring fix + FB11 source breakdown + clickable filters

### DIFF
--- a/src/web/src/components/ops/FlowBar.tsx
+++ b/src/web/src/components/ops/FlowBar.tsx
@@ -11,6 +11,7 @@ export interface SourceItem {
   icon: React.ReactNode;
   label: string;
   count: number;
+  onClick?: () => void;
 }
 
 export interface FlowStep {
@@ -172,23 +173,31 @@ export function FlowBar({
                     }
                   `}
                 >
-                  {/* Source breakdown ABOVE the count (for "Neu" KPI) */}
+                  {/* Source breakdown ABOVE the count */}
                   {step.sourceBreakdown && step.sourceBreakdown.length > 0 && (
                     <span className="flex items-center justify-between w-full px-1 sm:px-2 mb-1 text-[9px] sm:text-[10px] text-gray-500">
-                      {step.sourceBreakdown.map((s, si) => (
-                        <span key={s.label} className={`inline-flex items-center gap-1 ${si === 0 ? "" : si === step.sourceBreakdown!.length - 1 ? "" : ""}`}>
-                          <span className="w-3.5 h-3.5 sm:w-4 sm:h-4 flex-shrink-0">{s.icon}</span>
-                          <span className="font-semibold">{s.count}</span>
-                        </span>
+                      {step.sourceBreakdown.map((s) => (
+                        s.onClick ? (
+                          <button key={s.label} onClick={(e) => { e.stopPropagation(); s.onClick!(); }} className="inline-flex items-center gap-1 hover:text-gray-700 transition-colors">
+                            <span className="w-3.5 h-3.5 sm:w-4 sm:h-4 flex-shrink-0">{s.icon}</span>
+                            <span className="font-semibold">{s.count}</span>
+                          </button>
+                        ) : (
+                          <span key={s.label} className="inline-flex items-center gap-1">
+                            <span className="w-3.5 h-3.5 sm:w-4 sm:h-4 flex-shrink-0">{s.icon}</span>
+                            <span className="font-semibold">{s.count}</span>
+                          </span>
+                        )
                       ))}
                     </span>
                   )}
-                  {/* Icon (for steps like "Bei uns", "Erledigt") */}
+                  {/* Icon (for steps like "Bei uns" — above count when no source breakdown) */}
                   {step.icon && !step.sourceBreakdown && <span className="text-base sm:text-lg">{step.icon}</span>}
                   <span className="text-2xl sm:text-3xl font-extrabold text-gray-900 leading-none mt-0.5">
                     {step.count}
                   </span>
-                  <span className="text-[9px] sm:text-[10px] font-semibold text-gray-500 uppercase tracking-wider mt-1">
+                  <span className="inline-flex items-center gap-0.5 text-[9px] sm:text-[10px] font-semibold text-gray-500 uppercase tracking-wider mt-1">
+                    {step.icon && step.sourceBreakdown && <span className="text-xs leading-none">{step.icon}</span>}
                     {step.label}
                   </span>
                   {step.subLabel && !step.sourceBreakdown && (
@@ -302,10 +311,17 @@ export function FlowBar({
                 {step.sourceBreakdown && step.sourceBreakdown.length > 0 && (
                   <span className="flex items-center justify-between w-full px-1 mb-1 text-[9px] text-gray-500">
                     {step.sourceBreakdown.map((s) => (
-                      <span key={s.label} className="inline-flex items-center gap-0.5">
-                        <span className="w-3.5 h-3.5 flex-shrink-0">{s.icon}</span>
-                        <span className="font-semibold">{s.count}</span>
-                      </span>
+                      s.onClick ? (
+                        <button key={s.label} onClick={(e) => { e.stopPropagation(); s.onClick!(); }} className="inline-flex items-center gap-0.5 hover:text-gray-700 transition-colors">
+                          <span className="w-3.5 h-3.5 flex-shrink-0">{s.icon}</span>
+                          <span className="font-semibold">{s.count}</span>
+                        </button>
+                      ) : (
+                        <span key={s.label} className="inline-flex items-center gap-0.5">
+                          <span className="w-3.5 h-3.5 flex-shrink-0">{s.icon}</span>
+                          <span className="font-semibold">{s.count}</span>
+                        </span>
+                      )
                     ))}
                   </span>
                 )}
@@ -313,7 +329,8 @@ export function FlowBar({
                 <span className="text-2xl font-extrabold text-gray-900 leading-none mt-0.5">
                   {step.count}
                 </span>
-                <span className="text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1">
+                <span className="inline-flex items-center gap-0.5 text-[9px] font-semibold text-gray-500 uppercase tracking-wider mt-1">
+                  {step.icon && step.sourceBreakdown && <span className="text-xs leading-none">{step.icon}</span>}
                   {step.label}
                 </span>
                 {step.subLabel && !step.sourceBreakdown && (

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -113,6 +113,18 @@ function matchesNode(c: LeitzentraleCase, node: string): boolean {
       return c.status === "done" && c.review_rating != null;
     case "bewertung_angefragt":
       return c.status === "done" && !!c.review_sent_at && c.review_rating == null;
+    case "eingang_voice":
+      return c.status === "new" && c.source === "voice";
+    case "eingang_web":
+      return c.status === "new" && (c.source === "wizard" || c.source === "website");
+    case "eingang_manual":
+      return c.status === "new" && c.source !== "voice" && c.source !== "wizard" && c.source !== "website";
+    case "erledigt_voice":
+      return c.status === "done" && c.source === "voice";
+    case "erledigt_web":
+      return c.status === "done" && (c.source === "wizard" || c.source === "website");
+    case "erledigt_manual":
+      return c.status === "done" && c.source !== "voice" && c.source !== "wizard" && c.source !== "website";
     default:
       return true;
   }
@@ -278,6 +290,7 @@ export function LeitzentraleView({
   const flowStats = useMemo(() => {
     let eingang = 0, beiUns = 0, erledigt = 0, notfaelle = 0;
     let voice = 0, web = 0, manual = 0;
+    let doneVoice = 0, doneWeb = 0, doneManual = 0;
     let reviewSent = 0, reviewReceived = 0;
     for (const c of cases) {
       const ct = new Date(c.created_at).getTime();
@@ -292,13 +305,18 @@ export function LeitzentraleView({
         beiUns++;
         if (c.urgency === "notfall") notfaelle++;
       }
-      if (c.status === "done" && ut >= cutoff) erledigt++;
+      if (c.status === "done" && ut >= cutoff) {
+        erledigt++;
+        if (c.source === "voice") doneVoice++;
+        else if (c.source === "wizard" || c.source === "website") doneWeb++;
+        else doneManual++;
+      }
       if (c.status === "done") {
         if (c.review_sent_at) reviewSent++;
         if (c.review_rating != null) reviewReceived++;
       }
     }
-    return { eingang, beiUns, erledigt, notfaelle, voice, web, manual, reviewSent, reviewReceived };
+    return { eingang, beiUns, erledigt, notfaelle, voice, web, manual, doneVoice, doneWeb, doneManual, reviewSent, reviewReceived };
   }, [cases, cutoff]);
 
   // ── Techniker view (after ALL hooks) ──────────────────────────────
@@ -360,9 +378,9 @@ export function LeitzentraleView({
       label: "Neu",
       accent: "blue",
       sourceBreakdown: [
-        { icon: PhoneIcon, label: "Tel", count: flowStats.voice },
-        { icon: GlobeIcon, label: "Web", count: flowStats.web },
-        { icon: PencilIcon, label: "Stift", count: flowStats.manual },
+        { icon: PhoneIcon, label: "Tel", count: flowStats.voice, onClick: () => { setActiveNode("eingang_voice"); setCurrentPage(1); } },
+        { icon: GlobeIcon, label: "Web", count: flowStats.web, onClick: () => { setActiveNode("eingang_web"); setCurrentPage(1); } },
+        { icon: PencilIcon, label: "Stift", count: flowStats.manual, onClick: () => { setActiveNode("eingang_manual"); setCurrentPage(1); } },
       ],
     },
     {
@@ -380,10 +398,15 @@ export function LeitzentraleView({
     },
     {
       key: "erledigt",
-      icon: <span className="text-lg">✅</span>,
+      icon: <span className="text-sm">✅</span>,
       count: flowStats.erledigt,
       label: "Erledigt",
       accent: "emerald",
+      sourceBreakdown: [
+        { icon: PhoneIcon, label: "Tel", count: flowStats.doneVoice, onClick: () => { setActiveNode("erledigt_voice"); setCurrentPage(1); } },
+        { icon: GlobeIcon, label: "Web", count: flowStats.doneWeb, onClick: () => { setActiveNode("erledigt_web"); setCurrentPage(1); } },
+        { icon: PencilIcon, label: "Stift", count: flowStats.doneManual, onClick: () => { setActiveNode("erledigt_manual"); setCurrentPage(1); } },
+      ],
     },
   ];
 

--- a/src/web/src/lib/cases/statusColors.ts
+++ b/src/web/src/lib/cases/statusColors.ts
@@ -44,6 +44,8 @@ export function getStatusColorClass(
     case "done":
       if (reviewRating != null && reviewRating >= 4)
         return "bg-amber-100 text-amber-800 ring-2 ring-amber-400";
+      if (reviewRating != null)
+        return "bg-emerald-100 text-emerald-700"; // ≤3★ received — no gold ring
       if (reviewSentAt)
         return "bg-emerald-100 text-emerald-700 ring-2 ring-amber-400";
       return "bg-emerald-100 text-emerald-700";


### PR DESCRIPTION
## Summary
- **FB10:** ≤3★ Bewertungen zeigen keinen Gold-Ring mehr (plain grün). Nur angefragt-aber-nicht-erhalten = Gold-Ring. ≥4★ = voll Gold.
- **FB11:** ✅ vor "ERLEDIGT" Label. Source-Breakdown (📞+Zahl, 🌐+Zahl, ✏️+Zahl) auf Erledigt-KPI wie bei Neu-KPI.
- **Klickbare Sub-Filter:** Alle Source-Items auf Neu + Erledigt klickbar → filtern Tabelle (eingang_voice, eingang_web, eingang_manual, erledigt_voice, erledigt_web, erledigt_manual)

## Gold-Ring-Logik (nach Fix)
| Zustand | Status-Button |
|---------|--------------|
| Erledigt + Bew. ≥4★ erhalten | **Gold** (amber bg + ring) |
| Erledigt + Bew. ≤3★ erhalten | Grün (kein Ring) |
| Erledigt + Bew. angefragt, nicht erhalten | Grün + **Gold-Ring** |
| Erledigt (kein Review) | Grün |

## Test plan
- [ ] FB10: Klick auf "25 erhalten" → nur Gold-Badges (≥4★) und plain grün (≤3★), KEINE grün-mit-Ring
- [ ] FB11: ✅ Häkchen vor "ERLEDIGT" sichtbar, kleiner als Zahl
- [ ] FB11: Source-Breakdown auf Erledigt-KPI (Tel/Web/Stift + Zahlen)
- [ ] Klick auf Tel-Icon bei Neu → Tabelle zeigt nur Voice-Eingänge
- [ ] Klick auf Web-Icon bei Erledigt → Tabelle zeigt nur Website-erledigte
- [ ] Mobile: 2x2 Grid korrekt mit Source-Breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)