### PR TITLE
feat: FB12 photo upload + FB13 email always sent in support form

### DIFF
--- a/src/web/app/api/ops/support/route.ts
+++ b/src/web/app/api/ops/support/route.ts
@@ -3,35 +3,58 @@ import * as Sentry from "@sentry/nextjs";
 import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 import { resolveTenantIdentityById } from "@/src/lib/tenants/resolveTenantIdentity";
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
+import { getServiceClient } from "@/src/lib/supabase/server";
 
 /**
  * POST /api/ops/support — Create support ticket from Leitsystem.
  *
  * Primary: GitHub Issue (if GITHUB_ISSUES_TOKEN set)
- * Fallback: Resend email to Founder
+ * ALWAYS: Notification email to Founder (not just fallback)
  *
- * Body: { subject: string, message: string }
+ * Body: { subject: string, message: string, attachments?: string[] }
+ *       attachments = array of storage_path strings from /api/ops/support/upload
  */
+
+const BUCKET = "case-attachments";
+const DOWNLOAD_URL_TTL = 7 * 24 * 3600; // 7 days
+
 export async function POST(request: NextRequest) {
   const scope = await resolveTenantScope();
   if (!scope) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { subject, message } = await request.json().catch(() => ({} as Record<string, string>));
-  if (!message?.trim()) {
+  const body = await request.json().catch(() => ({} as Record<string, unknown>));
+  const subject = typeof body.subject === "string" ? body.subject : "Anfrage";
+  const message = typeof body.message === "string" ? body.message : "";
+  const attachments = Array.isArray(body.attachments) ? body.attachments.filter((a: unknown) => typeof a === "string") as string[] : [];
+
+  if (!message.trim()) {
     return NextResponse.json({ error: "Nachricht fehlt" }, { status: 400 });
   }
 
-  // Resolve context for structured issue
+  // Resolve context
   const authClient = await getAuthClient();
   const { data: { user } } = await authClient.auth.getUser();
   const userEmail = user?.email ?? "unbekannt";
   const identity = scope.tenantId ? await resolveTenantIdentityById(scope.tenantId) : null;
   const tenantName = identity?.displayName ?? "Unbekannt";
-  const tenantSlug = identity?.tenantId ?? scope.tenantId;
 
-  const issueTitle = `[Support] ${subject ?? "Anfrage"} — ${tenantName}`;
+  // Generate signed download URLs for attachments
+  const supabase = getServiceClient();
+  const attachmentLines: string[] = [];
+  for (const path of attachments) {
+    if (!path.startsWith("support/")) continue; // safety
+    const { data } = await supabase.storage
+      .from(BUCKET)
+      .createSignedUrl(path, DOWNLOAD_URL_TTL);
+    if (data?.signedUrl) {
+      const fileName = path.split("/").pop() ?? path;
+      attachmentLines.push(`- [${fileName}](${data.signedUrl})`);
+    }
+  }
+
+  const issueTitle = `[Support] ${subject} — ${tenantName}`;
   const issueBody = [
     `## Kontext`,
     `- **Betrieb:** ${tenantName}`,
@@ -41,15 +64,20 @@ export async function POST(request: NextRequest) {
     ``,
     `## Beschreibung`,
     message.trim(),
+    ...(attachmentLines.length > 0
+      ? [``, `## Anhänge (${attachmentLines.length})`, ...attachmentLines]
+      : []),
     ``,
     `---`,
     `*Erstellt aus dem Leitsystem via /ops/hilfe*`,
   ].join("\n");
 
-  const ghToken = process.env.GITHUB_ISSUES_TOKEN;
+  let ghSuccess = false;
+  let issueNumber: number | undefined;
 
+  // Primary: GitHub Issue
+  const ghToken = process.env.GITHUB_ISSUES_TOKEN;
   if (ghToken) {
-    // Primary: GitHub Issue
     try {
       const res = await fetch("https://api.github.com/repos/gunnarwende/flowsight_mvp/issues", {
         method: "POST",
@@ -65,44 +93,60 @@ export async function POST(request: NextRequest) {
         }),
       });
 
-      if (!res.ok) {
-        const err = await res.text();
-        console.error("[support] GitHub Issue creation failed:", err);
-        throw new Error("GitHub API error");
+      if (res.ok) {
+        const issue = await res.json();
+        issueNumber = issue.number;
+        ghSuccess = true;
+        Sentry.captureMessage("Support ticket created", {
+          level: "info",
+          tags: { area: "support", tenant_id: scope.tenantId ?? "", issue_number: issue.number },
+        });
+      } else {
+        console.error("[support] GitHub Issue creation failed:", await res.text());
       }
-
-      const issue = await res.json();
-      Sentry.captureMessage("Support ticket created", {
-        level: "info",
-        tags: { area: "support", tenant_id: scope.tenantId ?? "", issue_number: issue.number },
-      });
-
-      return NextResponse.json({ ok: true, channel: "github", issueNumber: issue.number });
-    } catch {
-      // Fall through to email fallback
+    } catch (e) {
+      console.error("[support] GitHub Issue error:", e);
     }
   }
 
-  // Fallback: Email via Resend
+  // ALWAYS send notification email (not just fallback)
   const resendKey = process.env.RESEND_API_KEY;
   const founderEmail = process.env.FOUNDER_EMAIL ?? process.env.MAIL_REPLY_TO;
+  let emailSent = false;
 
   if (resendKey && founderEmail) {
     try {
       const { Resend } = await import("resend");
       const resend = new Resend(resendKey);
+
+      const emailSubject = ghSuccess
+        ? `${issueTitle} (#${issueNumber})`
+        : issueTitle;
+
+      const emailText = [
+        issueBody,
+        ...(ghSuccess ? [``, `GitHub Issue: https://github.com/gunnarwende/flowsight_mvp/issues/${issueNumber}`] : []),
+      ].join("\n");
+
       await resend.emails.send({
         from: process.env.MAIL_FROM ?? "noreply@send.flowsight.ch",
         to: founderEmail,
-        subject: issueTitle,
-        text: issueBody,
+        subject: emailSubject,
+        text: emailText,
       });
-
-      return NextResponse.json({ ok: true, channel: "email" });
-    } catch {
-      return NextResponse.json({ error: "Senden fehlgeschlagen" }, { status: 500 });
+      emailSent = true;
+    } catch (e) {
+      console.error("[support] Email send error:", e);
     }
   }
 
-  return NextResponse.json({ error: "Kein Support-Kanal konfiguriert" }, { status: 500 });
+  if (!ghSuccess && !emailSent) {
+    return NextResponse.json({ error: "Senden fehlgeschlagen" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    channel: ghSuccess ? "github" : "email",
+    ...(issueNumber != null ? { issueNumber } : {}),
+  });
 }

--- a/src/web/app/api/ops/support/upload/route.ts
+++ b/src/web/app/api/ops/support/upload/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceClient } from "@/src/lib/supabase/server";
+import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
+
+/**
+ * POST /api/ops/support/upload — Get signed upload URL for support attachment.
+ * Uses same bucket as case-attachments but under support/ prefix.
+ * Body: { file_name: string, mime_type: string, size_bytes: number }
+ */
+
+const BUCKET = "case-attachments";
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_MIME_PREFIXES = ["image/", "application/pdf"] as const;
+
+function isAllowedMime(mime: string): boolean {
+  return ALLOWED_MIME_PREFIXES.some((p) => mime.startsWith(p));
+}
+
+function sanitizeFileName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 100);
+}
+
+export async function POST(request: NextRequest) {
+  const scope = await resolveTenantScope();
+  if (!scope) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const fileName = typeof body.file_name === "string" ? body.file_name : "";
+  const mimeType = typeof body.mime_type === "string" ? body.mime_type : "";
+  const sizeBytes = typeof body.size_bytes === "number" ? body.size_bytes : 0;
+
+  if (!fileName) {
+    return NextResponse.json({ error: "file_name required" }, { status: 400 });
+  }
+  if (mimeType && !isAllowedMime(mimeType)) {
+    return NextResponse.json({ error: "Only images and PDFs allowed" }, { status: 400 });
+  }
+  if (sizeBytes > MAX_FILE_SIZE) {
+    return NextResponse.json({ error: "Max 10 MB per file" }, { status: 400 });
+  }
+
+  const safeName = sanitizeFileName(fileName);
+  const uid = crypto.randomUUID().slice(0, 8);
+  const storagePath = `support/${uid}-${safeName}`;
+
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUploadUrl(storagePath);
+
+  if (error) {
+    return NextResponse.json({ error: "Upload URL creation failed" }, { status: 502 });
+  }
+
+  return NextResponse.json({
+    upload_url: data.signedUrl,
+    storage_path: storagePath,
+  });
+}

--- a/src/web/app/ops/(dashboard)/hilfe/page.tsx
+++ b/src/web/app/ops/(dashboard)/hilfe/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 const FAQ_ITEMS = [
   {
@@ -32,13 +32,96 @@ const SUBJECTS = [
   "Sonstiges",
 ];
 
+const MAX_FILES = 5;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+interface UploadedFile {
+  name: string;
+  storagePath: string;
+}
+
 export default function HilfePage() {
   const [openFaq, setOpenFaq] = useState<number | null>(null);
   const [subject, setSubject] = useState(SUBJECTS[0]);
   const [message, setMessage] = useState("");
+  const [files, setFiles] = useState<UploadedFile[]>([]);
+  const [uploading, setUploading] = useState(false);
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
   const [error, setError] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const selected = e.target.files;
+    if (!selected || selected.length === 0) return;
+
+    const remaining = MAX_FILES - files.length;
+    if (remaining <= 0) {
+      setError(`Maximal ${MAX_FILES} Dateien erlaubt.`);
+      return;
+    }
+
+    const toUpload = Array.from(selected).slice(0, remaining);
+    setUploading(true);
+    setError("");
+
+    for (const file of toUpload) {
+      if (file.size > MAX_FILE_SIZE) {
+        setError(`"${file.name}" ist zu gross (max 10 MB).`);
+        continue;
+      }
+      if (!file.type.startsWith("image/") && file.type !== "application/pdf") {
+        setError(`"${file.name}" — nur Bilder und PDFs erlaubt.`);
+        continue;
+      }
+
+      try {
+        // 1. Get signed upload URL
+        const urlRes = await fetch("/api/ops/support/upload", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            file_name: file.name,
+            mime_type: file.type,
+            size_bytes: file.size,
+          }),
+        });
+
+        if (!urlRes.ok) {
+          setError(`Upload von "${file.name}" fehlgeschlagen.`);
+          continue;
+        }
+
+        const { upload_url, storage_path } = await urlRes.json();
+
+        // 2. Upload directly to Supabase Storage
+        const uploadRes = await fetch(upload_url, {
+          method: "PUT",
+          headers: {
+            "Content-Type": file.type,
+          },
+          body: file,
+        });
+
+        if (!uploadRes.ok) {
+          setError(`Upload von "${file.name}" fehlgeschlagen.`);
+          continue;
+        }
+
+        setFiles((prev) => [...prev, { name: file.name, storagePath: storage_path }]);
+      } catch {
+        setError(`Upload von "${file.name}" fehlgeschlagen.`);
+      }
+    }
+
+    setUploading(false);
+    // Reset file input so same file can be re-selected
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function removeFile(idx: number) {
+    setFiles((prev) => prev.filter((_, i) => i !== idx));
+  }
 
   async function handleSubmit() {
     if (!message.trim()) return;
@@ -48,11 +131,16 @@ export default function HilfePage() {
       const res = await fetch("/api/ops/support", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ subject, message: message.trim() }),
+        body: JSON.stringify({
+          subject,
+          message: message.trim(),
+          attachments: files.map((f) => f.storagePath),
+        }),
       });
       if (!res.ok) throw new Error("Senden fehlgeschlagen");
       setSent(true);
       setMessage("");
+      setFiles([]);
     } catch {
       setError("Nachricht konnte nicht gesendet werden. Bitte versuchen Sie es erneut.");
     }
@@ -133,10 +221,76 @@ export default function HilfePage() {
                 className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400/30 resize-none"
               />
             </div>
+
+            {/* File upload */}
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">
+                Anhänge <span className="text-gray-400 font-normal">(optional, max {MAX_FILES} Dateien, je 10 MB)</span>
+              </label>
+
+              {/* Uploaded files */}
+              {files.length > 0 && (
+                <div className="space-y-1.5 mb-2">
+                  {files.map((f, i) => (
+                    <div key={i} className="flex items-center gap-2 bg-gray-50 rounded-lg px-3 py-2 text-sm">
+                      <svg className="w-4 h-4 text-emerald-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z" />
+                      </svg>
+                      <span className="text-gray-700 truncate flex-1">{f.name}</span>
+                      <button
+                        onClick={() => removeFile(i)}
+                        className="text-gray-400 hover:text-red-500 transition-colors flex-shrink-0"
+                        title="Entfernen"
+                      >
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {files.length < MAX_FILES && (
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploading}
+                  className="inline-flex items-center gap-2 rounded-lg border border-dashed border-gray-300 px-4 py-2.5 text-sm text-gray-600 hover:border-gray-400 hover:bg-gray-50 disabled:opacity-40 transition-colors min-h-[44px]"
+                >
+                  {uploading ? (
+                    <>
+                      <svg className="w-4 h-4 animate-spin text-gray-400" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                      </svg>
+                      Wird hochgeladen…
+                    </>
+                  ) : (
+                    <>
+                      <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 16.5V9.75m0 0 3 3m-3-3-3 3M6.75 19.5a4.5 4.5 0 0 1-1.41-8.775 5.25 5.25 0 0 1 10.233-2.33 3 3 0 0 1 3.758 3.848A3.752 3.752 0 0 1 18 19.5H6.75Z" />
+                      </svg>
+                      Foto oder PDF hinzufügen
+                    </>
+                  )}
+                </button>
+              )}
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*,.pdf"
+                multiple
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+            </div>
+
             <div className="flex items-center gap-3">
               <button
                 onClick={handleSubmit}
-                disabled={!message.trim() || sending}
+                disabled={!message.trim() || sending || uploading}
                 className="rounded-lg bg-gray-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-40 transition-colors min-h-[44px]"
               >
                 {sending ? "Wird gesendet…" : "Absenden"}


### PR DESCRIPTION
## Summary
- **FB12:** Foto-/PDF-Upload im Support-Formular. Max 5 Dateien, je 10 MB. Upload via Signed URLs direkt in Supabase Storage (`support/` Prefix im `case-attachments` Bucket). Download-Links erscheinen im GitHub Issue.
- **FB13:** E-Mail-Benachrichtigung wird IMMER gesendet (an FOUNDER_EMAIL), nicht nur als Fallback wenn GitHub fehlschlägt. E-Mail enthält vollen Kontext + GitHub Issue Link.

## Architektur
```
Client: Foto auswählen
  → POST /api/ops/support/upload (signed URL holen)
  → PUT direkt an Supabase Storage (bypassed Vercel 4.5MB Limit)
  → POST /api/ops/support (Text + Storage Paths)
    → GitHub Issue erstellen (mit Anhang-Links)
    → E-Mail an Founder (IMMER, nicht nur Fallback)
```

## Test plan
- [ ] Support-Formular öffnen → "Foto oder PDF hinzufügen" Button sichtbar
- [ ] Foto hochladen → Dateiname erscheint mit grünem Icon + X-Button
- [ ] Mehrere Fotos (bis 5) → alle gelistet
- [ ] Formular absenden → GitHub Issue enthält Anhang-Links (klickbar, 7d gültig)
- [ ] E-Mail kommt bei Founder an (auch wenn GitHub Issue erfolgreich)
- [ ] Zu grosse Datei (>10MB) → Fehlermeldung
- [ ] Nicht erlaubter Typ (.exe) → Fehlermeldung

🤖 Generated with [Claude Code](https://claude.com/claude-code)