### PR TITLE
feat: soft delete cases — trash icon + restore

### DIFF
--- a/src/web/app/api/ops/cases/[id]/route.ts
+++ b/src/web/app/api/ops/cases/[id]/route.ts
@@ -58,6 +58,7 @@ const OPS_UPDATABLE_FIELDS = [
   "street",
   "house_number",
   "reporter_name",
+  "is_deleted",
 ] as const;
 
 type OpsField = (typeof OPS_UPDATABLE_FIELDS)[number];
@@ -236,12 +237,21 @@ export async function PATCH(
     // Read old status before update (for status_changed event)
     const oldStatus = "status" in update ? existing.status : undefined;
 
+    // Soft-delete: set deleted_at timestamp, or clear it on restore
+    if ("is_deleted" in update) {
+      if (update.is_deleted) {
+        (update as Record<string, unknown>).deleted_at = new Date().toISOString();
+      } else {
+        (update as Record<string, unknown>).deleted_at = null;
+      }
+    }
+
     const { data: row, error } = await supabase
       .from("cases")
       .update(update)
       .eq("id", id)
       .select(
-        "id, seq_number, status, urgency, category, plz, city, description, assignee_text, scheduled_at, scheduled_end_at, internal_notes, contact_email, contact_phone, street, house_number, reporter_name, updated_at"
+        "id, seq_number, status, urgency, category, plz, city, description, assignee_text, scheduled_at, scheduled_end_at, internal_notes, contact_email, contact_phone, street, house_number, reporter_name, is_deleted, deleted_at, updated_at"
       )
       .single();
 
@@ -266,7 +276,18 @@ export async function PATCH(
       }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
     }
 
-    const nonStatusFields = Object.keys(update).filter((f) => f !== "status");
+    // Soft-delete / restore event
+    if ("is_deleted" in update) {
+      const isDelete = !!update.is_deleted;
+      await supabase.from("case_events").insert({
+        case_id: id,
+        event_type: isDelete ? "case_deleted" : "case_restored",
+        title: isDelete ? "Fall gelöscht" : "Fall wiederhergestellt",
+        metadata: { user_id: scope.userId },
+      }).then(({ error: evErr }) => { if (evErr) Sentry.captureException(evErr); });
+    }
+
+    const nonStatusFields = Object.keys(update).filter((f) => f !== "status" && f !== "is_deleted" && f !== "deleted_at");
     if (nonStatusFields.length > 0) {
       const humanFields = nonStatusFields.map(f => FIELD_LABELS[f] ?? f);
       const title = humanFields.length === 1

--- a/src/web/app/ops/(dashboard)/cases/[id]/DeleteButton.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/DeleteButton.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function DeleteButton({ caseId, isDeleted }: { caseId: string; isDeleted: boolean }) {
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const action = isDeleted ? "restore" : "delete";
+  const label = isDeleted ? "Wiederherstellen" : "Löschen";
+  const confirmText = isDeleted
+    ? "Diesen Fall wirklich wiederherstellen?"
+    : "Diesen Fall wirklich löschen?";
+
+  async function handleAction() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/ops/cases/${caseId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_deleted: !isDeleted }),
+      });
+      if (res.ok) {
+        router.refresh();
+        setShowConfirm(false);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setShowConfirm(true)}
+        className={`p-1.5 rounded-lg transition-colors print:hidden ${
+          isDeleted
+            ? "text-green-500 hover:text-green-700 hover:bg-green-50"
+            : "text-gray-400 hover:text-red-600 hover:bg-red-50"
+        }`}
+        title={label}
+      >
+        {isDeleted ? (
+          /* Restore icon (arrow-uturn-left) */
+          <svg className="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
+          </svg>
+        ) : (
+          /* Trash icon */
+          <svg className="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+          </svg>
+        )}
+      </button>
+
+      {/* Confirmation Dialog */}
+      {showConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 print:hidden">
+          <div className="bg-white rounded-xl shadow-xl p-6 max-w-sm mx-4">
+            <p className="text-gray-900 font-medium mb-4">{confirmText}</p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setShowConfirm(false)}
+                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 rounded-lg hover:bg-gray-100"
+                disabled={loading}
+              >
+                Abbrechen
+              </button>
+              <button
+                onClick={handleAction}
+                className={`px-4 py-2 text-sm text-white rounded-lg disabled:opacity-50 ${
+                  isDeleted
+                    ? "bg-green-600 hover:bg-green-700"
+                    : "bg-red-600 hover:bg-red-700"
+                }`}
+                disabled={loading}
+              >
+                {loading ? "..." : label}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -8,6 +8,7 @@ import { resolveTenantIdentityById } from "@/src/lib/tenants/resolveTenantIdenti
 import { formatCaseId } from "@/src/lib/cases/formatCaseId";
 import { CaseDetailForm } from "./CaseDetailForm";
 import { PrintButton } from "./PrintButton";
+import { DeleteButton } from "./DeleteButton";
 import type { CaseEvent } from "@/src/components/ops/CaseTimeline";
 
 // ---------------------------------------------------------------------------
@@ -38,6 +39,8 @@ export interface CaseDetail {
   scheduled_end_at: string | null;
   internal_notes: string | null;
   review_sent_at: string | null;
+  is_deleted: boolean | null;
+  deleted_at: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +168,7 @@ export default async function CaseDetailPage({
         </div>
         <div className="flex items-center gap-2.5 flex-shrink-0">
           <PrintButton />
+          <DeleteButton caseId={caseData.id} isDeleted={!!caseData.is_deleted} />
           <span className="bg-gray-900 text-white px-3.5 py-1.5 rounded-lg text-sm font-bold tracking-wide">
             {caseId}
           </span>

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -44,6 +44,7 @@ export default async function OpsCasesPage({
       "id, seq_number, created_at, updated_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, contact_phone, review_sent_at, review_rating, scheduled_at"
     )
     .eq("is_demo", showDemo)
+    .eq("is_deleted", false)
     .order("created_at", { ascending: false })
     .limit(200);
   if (filterTenantId) casesQuery = casesQuery.eq("tenant_id", filterTenantId);
@@ -68,6 +69,7 @@ export default async function OpsCasesPage({
     .from("cases")
     .select("id", { count: "exact", head: true })
     .eq("is_demo", showDemo)
+    .eq("is_deleted", false)
     .gte("created_at", sevenDaysAgo);
   if (filterTenantId) statsNeueQuery = statsNeueQuery.eq("tenant_id", filterTenantId);
 
@@ -75,6 +77,7 @@ export default async function OpsCasesPage({
     .from("cases")
     .select("id", { count: "exact", head: true })
     .eq("is_demo", showDemo)
+    .eq("is_deleted", false)
     .eq("status", "done")
     .gte("updated_at", sevenDaysAgo);
   if (filterTenantId) statsErledigtQuery = statsErledigtQuery.eq("tenant_id", filterTenantId);
@@ -85,6 +88,7 @@ export default async function OpsCasesPage({
     .from("cases")
     .select("id", { count: "exact", head: true })
     .eq("is_demo", showDemo)
+    .eq("is_deleted", false)
     .eq("status", "done")
     .gte("updated_at", thirtyDaysAgo);
   if (filterTenantId) erledigt30dQuery = erledigt30dQuery.eq("tenant_id", filterTenantId);
@@ -94,6 +98,7 @@ export default async function OpsCasesPage({
     .from("cases")
     .select("id", { count: "exact", head: true })
     .eq("is_demo", showDemo)
+    .eq("is_deleted", false)
     .eq("status", "done")
     .not("review_sent_at", "is", null)
     .gte("updated_at", sevenDaysAgo);
@@ -104,6 +109,7 @@ export default async function OpsCasesPage({
     .from("cases")
     .select("id", { count: "exact", head: true })
     .eq("is_demo", showDemo)
+    .eq("is_deleted", false)
     .eq("status", "done")
     .not("review_sent_at", "is", null);
   if (filterTenantId) reviewSentTotalQuery = reviewSentTotalQuery.eq("tenant_id", filterTenantId);
@@ -114,6 +120,7 @@ export default async function OpsCasesPage({
     .from("cases")
     .select("id", { count: "exact", head: true })
     .eq("is_demo", showDemo)
+    .eq("is_deleted", false)
     .eq("status", "done")
     .not("review_sent_at", "is", null)
     .gte("updated_at", thirtyDaysAgo);
@@ -123,6 +130,7 @@ export default async function OpsCasesPage({
     .from("cases")
     .select("id", { count: "exact", head: true })
     .eq("is_demo", showDemo)
+    .eq("is_deleted", false)
     .eq("status", "done")
     .is("review_sent_at", null)
     .gte("updated_at", thirtyDaysAgo);

--- a/src/web/supabase/migrations/20260410000000_soft_delete_cases.sql
+++ b/src/web/supabase/migrations/20260410000000_soft_delete_cases.sql
@@ -1,0 +1,6 @@
+-- Soft delete for cases: is_deleted flag + deleted_at timestamp
+-- Cases are never physically deleted, only flagged.
+-- KPIs and active views filter on is_deleted = false.
+
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS is_deleted boolean DEFAULT false;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS deleted_at timestamptz;

--- a/supabase/migrations/20260410000000_soft_delete_cases.sql
+++ b/supabase/migrations/20260410000000_soft_delete_cases.sql
@@ -1,0 +1,6 @@
+-- Soft delete for cases: is_deleted flag + deleted_at timestamp
+-- Cases are never physically deleted, only flagged.
+-- KPIs and active views filter on is_deleted = false.
+
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS is_deleted boolean DEFAULT false;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS deleted_at timestamptz;


### PR DESCRIPTION
## Summary
- Trash icon next to print icon on case detail page
- Confirmation dialog: "Diesen Fall wirklich löschen?"
- Soft delete: `is_deleted = true` + `deleted_at` timestamp (no physical deletion)
- Restore button on deleted cases: "Diesen Fall wirklich wiederherstellen?"
- Timeline events: "Fall gelöscht" / "Fall wiederhergestellt"
- All KPIs (8 queries) filter `is_deleted = false` — deleted cases don't affect counts
- DB migration: `is_deleted boolean DEFAULT false` + `deleted_at timestamptz`

## Use cases
- Duplicate cases (email + phone for same issue)
- False cases from voice agent
- Manual entry errors

## Test plan
- [ ] Open any case → trash icon visible next to print
- [ ] Click trash → confirmation dialog
- [ ] Confirm → case gets `is_deleted = true`, timeline shows "Fall gelöscht"
- [ ] KPIs don't count deleted case
- [ ] Open deleted case → restore icon (green arrow) visible
- [ ] Click restore → confirmation → case restored, timeline updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)