### PR TITLE
feat: agent_hangup RED alert + morning report

### DIFF
--- a/scripts/_ops/morning_report.mjs
+++ b/scripts/_ops/morning_report.mjs
@@ -117,6 +117,39 @@ if (oldestRow) {
 }
 
 // ---------------------------------------------------------------------------
+// Voice Agent Health: agent_hangup detection (last 24h)
+// ---------------------------------------------------------------------------
+
+let agentHangupCount = 0;
+let agentHangupCalls = [];
+try {
+  const retellKey = process.env.RETELL_API_KEY?.replace(/^"|"$/g, "");
+  if (retellKey) {
+    const retellResp = await fetch("https://api.retellai.com/v2/list-calls", {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${retellKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ limit: 100, sort_order: "descending" }),
+    });
+    if (retellResp.ok) {
+      const calls = await retellResp.json();
+      const cutoff = new Date(now.getTime() - 24 * 60 * 60 * 1000).getTime();
+      agentHangupCalls = (calls || []).filter(c => {
+        const start = c.start_timestamp || 0;
+        const end = c.end_timestamp || 0;
+        const dur = end - start;
+        return c.disconnection_reason === "agent_hangup"
+          && start > cutoff
+          && dur > 0
+          && dur < 120_000;
+      });
+      agentHangupCount = agentHangupCalls.length;
+    }
+  }
+} catch (e) {
+  console.error("Retell agent_hangup check failed:", e.message);
+}
+
+// ---------------------------------------------------------------------------
 // Trial Lifecycle Queries
 // ---------------------------------------------------------------------------
 
@@ -221,7 +254,7 @@ try {
 // Severity
 // ---------------------------------------------------------------------------
 
-const isRed = (stuck48h ?? 0) > 0 || !healthOk || !resendOk || expiring24h.length > 0 || staleCount > 0;
+const isRed = (stuck48h ?? 0) > 0 || !healthOk || !resendOk || expiring24h.length > 0 || staleCount > 0 || agentHangupCount > 0;
 const isYellow = (backlogNew ?? 0) > 5 || notfallCount > 0 || followUpDueCount > 0;
 const severity = isRed ? "🔴" : isYellow ? "🟡" : "🟢";
 
@@ -252,6 +285,8 @@ const report = [
   `expiring_48h:   ${expiring48hCount}${expiringNames ? ` (${expiringNames})` : ""}`,
   `zombie_trials:  ${zombieCount}`,
   `tick_stale:     ${staleCount}${staleNames ? ` (${staleNames})` : ""}`,
+  `━━━ VOICE ━━━━━━━━━━`,
+  `agent_hangup:   ${agentHangupCount}${agentHangupCount > 0 ? " ⚠ AGENT HAT AUFGELEGT" : ""}`,
   `━━━ HEALTH ━━━━━━━━━`,
   `api:            ${healthOk ? "OK" : "FAIL"}`,
   `db:             ${healthDb}`,

--- a/src/web/app/api/retell/webhook/route.ts
+++ b/src/web/app/api/retell/webhook/route.ts
@@ -314,6 +314,35 @@ export async function POST(req: Request) {
     return new NextResponse(null, { status: 204 });
   }
 
+  // ── Agent-hangup detection (CRITICAL — image damage) ─────────────────
+  // If the AGENT hung up (not the user), this is likely a bug.
+  // Alert immediately so founder can investigate.
+  const disconnectionReason = call?.disconnection_reason as string | undefined;
+  if (disconnectionReason === "agent_hangup" && callDurationMs > 0 && callDurationMs < 120_000) {
+    const durationS = Math.round(callDurationMs / 1000);
+    Sentry.captureMessage("agent_hangup_short_call", {
+      level: "error",
+      tags: {
+        area: "voice",
+        provider: "retell",
+        retell_call_id: retellCallId,
+        decision: "agent_hangup_alert",
+      },
+      extra: {
+        disconnection_reason: disconnectionReason,
+        duration_ms: callDurationMs,
+        from_number: call?.from_number,
+        to_number: call?.to_number,
+      },
+    });
+    // Fire-and-forget: RED alert to founder
+    notify({
+      severity: "RED",
+      code: "AGENT_HANGUP",
+      refs: { call_id: retellCallId, duration: `${durationS}s`, from: call?.from_number ?? "unknown" },
+    }).catch(() => {});
+  }
+
   // ── Probe extraction paths ──────────────────────────────────────────
   const { data: extractedData, path: extractedPath } = probeExtractedData(call, payload);
   const extractedKeys = Object.keys(extractedData);


### PR DESCRIPTION
## Summary
CRITICAL safety net: When the voice agent hangs up on a caller (bug), this now triggers:

1. **Real-time:** Sentry error + RED alert to founder (WhatsApp/Telegram) — within seconds
2. **Daily:** Morning report VOICE section shows agent_hangup count. Any hangup = RED severity.

Previously: agent_hangup was completely invisible. Founder never knew.

## What triggers the alert
- `disconnection_reason === "agent_hangup"` AND `duration < 120s`
- This filters out intentional end_call (long successful calls) vs bug-induced hangups

## Test plan
- [x] Build passes
- [ ] Trigger a test agent_hangup → verify Sentry event + WhatsApp alert
- [ ] Run morning report with --send → verify VOICE section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)