### PR TITLE
fix: show full case category in detail header

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -156,7 +156,7 @@ export default async function CaseDetailPage({
               <span className="text-sm font-medium">Zurück</span>
             </Link>
             <div className="flex items-baseline gap-2.5 min-w-0">
-              <h1 className="text-xl font-bold text-gray-900 truncate">{caseData.category}</h1>
+              <h1 className="text-xl font-bold text-gray-900">{caseData.category}</h1>
               <span className="text-sm text-gray-400 whitespace-nowrap hidden sm:inline">
                 {SOURCE_LABELS[caseData.source] ?? caseData.source} · {formatDate(caseData.created_at)}
               </span>


### PR DESCRIPTION
## Summary
- Removes `truncate` CSS class from case detail h1 so "Rohrbruch" shows fully instead of "Rohr..."
- One-line change in `cases/[id]/page.tsx`

## Test plan
- [ ] Open any case detail on mobile → category name should NOT be truncated
- [ ] Verify on desktop too

🤖 Generated with [Claude Code](https://claude.com/claude-code)