### PR TITLE
fix: trash view, staff email safety, large project seed

### DIFF
--- a/scripts/_ops/seed_demo_data_v2.mjs
+++ b/scripts/_ops/seed_demo_data_v2.mjs
@@ -41,6 +41,7 @@ const slug = args.slug;
 if (!slug) { console.error("--slug=<tenant-slug> is required"); process.exit(1); }
 const targetCount = parseInt(args.count ?? "70", 10);
 const clean = args.clean === "true";
+const asDemo = args.demo === "true"; // default: false = real cases (visible in main tab)
 
 // ── HELPERS ───────────────────────────────────────────────────────────
 
@@ -205,6 +206,56 @@ const CATEGORY_TEMPLATES = {
     wizard: ["Bitte um Rückruf. Erreichbar Mo-Fr 9-17 Uhr.","Terminwunsch für Beratung vor Ort."],
     manual: ["Rückruf-Wunsch: Terminvereinbarung."],
   },
+  // ── Large projects (Renovationen, Sanierungen) — min 2 per tenant on page 1
+  "Badsanierung": {
+    seasonal: [1,2,3,4,5,6,7,8,9,10,11,12],
+    urgencyDist: { notfall: 0, dringend: 0.05, normal: 0.95 },
+    voice: [
+      "Komplette Badsanierung geplant. Möchten gerne eine Beratung vor Ort und dann eine Offerte.",
+      "Wir planen unser Badezimmer zu renovieren. Dusche, WC, Lavabo — alles komplett neu.",
+    ],
+    wizard: [
+      "Guten Tag, wir planen die Komplettsanierung unseres Badezimmers (Baujahr 1985). Dusche, Badewanne, Lavabo und WC sollen erneuert werden. Bitte Termin für Beratung und Offerte.",
+      "Badsanierung EG: barrierefreie Dusche, neues WC, Doppellavabo. Budget ca. CHF 25'000-35'000. Bitte Offerte.",
+      "Renovation Gäste-Bad OG: Komplett neu inkl. Fliesen, Dusche, WC. Bitte Besichtigung + Offerte.",
+    ],
+    manual: [
+      "Beratungsgespräch Badsanierung: 2 Bäder, Altbau 1978. Offerte folgt nach Besichtigung.",
+      "Offerte erstellt: Komplettsanierung Bad EG, CHF 32'500 inkl. MwSt. Kunde überlegt.",
+    ],
+  },
+  "Heizungsersatz": {
+    seasonal: [3,4,5,6,7,8,9,10], // planned outside heating season
+    urgencyDist: { notfall: 0, dringend: 0.1, normal: 0.9 },
+    voice: [
+      "Unsere Ölheizung ist 25 Jahre alt. Wir möchten auf Wärmepumpe umsteigen. Beratung gewünscht.",
+      "Heizungsersatz geplant: aktuell Gas, möchten wissen was die Optionen sind.",
+    ],
+    wizard: [
+      "Heizungsersatz: Öl auf Wärmepumpe. EFH Baujahr 1992, 180m². Bitte Beratung und Offerte.",
+      "Planen den Ersatz unserer Gasheizung (20 Jahre alt). Wärmepumpe oder Pellets? Bitte Termin.",
+      "Heizungssanierung MFH (6 Wohnungen): Zentrale Ölheizung ersetzen. Bitte Offerte + Beratung.",
+    ],
+    manual: [
+      "Beratung Heizungsersatz: Öl → WP, EFH 200m². Besichtigung durchgeführt. Offerte in Arbeit.",
+      "Offerte Heizungsersatz: Luft-Wasser WP inkl. Demontage Öltank. CHF 38'000.",
+    ],
+  },
+  "Komplettrenovation": {
+    seasonal: [2,3,4,5,6,7,8,9,10], // spring to autumn
+    urgencyDist: { notfall: 0, dringend: 0.05, normal: 0.95 },
+    voice: [
+      "Wir planen eine Komplettrenovation Sanitär im ganzen Haus. 3 Bäder und Küche. Bitte Beratung.",
+    ],
+    wizard: [
+      "Komplettrenovation Sanitär: EFH Baujahr 1975, 3 Bäder + Küche. Leitungen müssen komplett erneuert werden. Bitte Besichtigung + Offerte.",
+      "Sanierung Altbau: Steigleitungen, 2 Bäder, Küche. Koordination mit Elektriker nötig. Bitte Offerte.",
+    ],
+    manual: [
+      "Grossprojekt: Komplettsanierung Sanitär EFH, 3 Bäder + Küche. Baustart geplant Juni. Offerte CHF 65'000.",
+      "Renovation MFH 4 Wohnungen: Bäder + Leitungen. Etappenweise. Offerte in Arbeit.",
+    ],
+  },
 };
 
 // ── DISTRIBUTION LOGIC ──────────────────────────────────────────────
@@ -313,7 +364,7 @@ async function main() {
   const staffNames = staff?.map(s => s.display_name) ?? [];
 
   // 3. Try to load CustomerSite config for categories + serviceArea
-  let categories = ["Verstopfung","Leck","Heizung","Boiler","Rohrbruch","Sanitär allgemein","Allgemein","Angebot","Kontakt"];
+  let categories = ["Verstopfung","Leck","Heizung","Boiler","Rohrbruch","Sanitär allgemein","Badsanierung","Heizungsersatz","Komplettrenovation","Allgemein","Angebot","Kontakt"];
   let gemeinden = Object.keys(GEMEINDE_PLZ);
 
   try {
@@ -326,10 +377,11 @@ async function main() {
       if (catMatches) {
         categories = catMatches.map(m => m.match(/"([^"]+)"/)[1]);
       }
-      // Always include FIXED_CATEGORIES + common Voice Agent categories
+      // Always include FIXED_CATEGORIES + common Voice Agent categories + large projects
       const FIXED = ["Allgemein", "Angebot", "Kontakt"];
       const VOICE_EXTRA = ["Boiler", "Rohrbruch", "Sanitär allgemein"];
-      for (const c of [...FIXED, ...VOICE_EXTRA]) {
+      const LARGE_PROJECTS = ["Badsanierung", "Heizungsersatz", "Komplettrenovation"];
+      for (const c of [...FIXED, ...VOICE_EXTRA, ...LARGE_PROJECTS]) {
         if (!categories.includes(c)) categories.push(c);
       }
       console.log(`  Categories from config: ${categories.join(", ")}`);
@@ -362,7 +414,7 @@ async function main() {
   // Clean
   if (clean) {
     const { count: deleted } = await supabase
-      .from("cases").delete({ count: "exact" }).eq("tenant_id", tenant.id).eq("is_demo", true);
+      .from("cases").delete({ count: "exact" }).eq("tenant_id", tenant.id).eq("is_demo", asDemo);
     // Also clean events for deleted demo cases
     console.log(`  Cleaned ${deleted ?? 0} existing demo cases`);
   }
@@ -392,6 +444,66 @@ async function main() {
   const cases = [];
   const events = [];
   let usedAddresses = new Set();
+
+  // 6a. Featured case — the "hero" case used for video screenshots / demos.
+  // Always the NEWEST voice case: Rohrbruch, Dringend, status "new".
+  // Uses the tenant's primary city (first location) for the address.
+  {
+    const featLoc = locations[0] || { plz: "8000", city: "Zürich" };
+    const featStreet = "Seestrasse";
+    const featHN = "14";
+    const featContact = {
+      name: `${pick(SWISS_FIRST)} ${pick(SWISS_LAST)}`,
+      phone: randomPhone(),
+      email: null,
+      plz: featLoc.plz,
+      city: featLoc.city,
+      street: featStreet,
+      houseNumber: featHN,
+    };
+    // Created "today" at 15:00 — matches the video storyboard
+    const featCreated = new Date(now);
+    featCreated.setHours(15, 0, 0, 0);
+    const featId = randomUUID();
+    const featDesc = `Der Anrufer steht im Keller knöcheltief im Wasser, vermutlich wegen eines Rohrbruchs. Die Adresse ist ${featStreet} ${featHN}, ${featLoc.plz} ${featLoc.city}. Der Schaden wurde als dringend eingestuft, und der Anrufer gab an, wo der Techniker klingeln soll.`;
+    cases.push({
+      id: featId,
+      tenant_id: tenant.id,
+      source: "voice",
+      created_at: featCreated.toISOString(),
+      updated_at: featCreated.toISOString(),
+      reporter_name: featContact.name,
+      contact_phone: featContact.phone,
+      contact_email: null,
+      plz: featContact.plz,
+      city: featContact.city,
+      street: featContact.street,
+      house_number: featContact.houseNumber,
+      category: "Rohrbruch",
+      urgency: "dringend",
+      description: featDesc,
+      status: "new",
+      assignee_text: null,
+      scheduled_at: null,
+      review_sent_at: null,
+      review_rating: null,
+      review_received_at: null,
+      review_text: null,
+      is_demo: asDemo,
+    });
+    events.push({
+      case_id: featId, tenant_id: tenant.id,
+      event_type: "case_created", title: "Fall erstellt via Voice Agent",
+      created_at: featCreated.toISOString(),
+    });
+    events.push({
+      case_id: featId, tenant_id: tenant.id,
+      event_type: "sms_verification_sent", title: "SMS-Bestätigung an Kunden gesendet",
+      created_at: new Date(featCreated.getTime() + 30000).toISOString(),
+    });
+    usedAddresses.add(`${featStreet}${featHN}${featLoc.city}`);
+    console.log(`  Featured case: Rohrbruch in ${featLoc.plz} ${featLoc.city} (video hero)`);
+  }
 
   for (let i = 0; i < targetCount; i++) {
     const createdAt = timeline[i];
@@ -519,7 +631,7 @@ async function main() {
       review_rating: reviewRating,
       review_received_at: reviewReceivedAt,
       review_text: reviewText,
-      is_demo: true,
+      is_demo: asDemo,
     });
 
     // Events
@@ -558,7 +670,48 @@ async function main() {
     }
   }
 
-  // 6b. Guarantee minimum "new" cases by source in last 30 days
+  // 6b. Guarantee minimum 2 large projects (Badsanierung, Heizungsersatz, Komplettrenovation)
+  // on page 1: recent (last 14 days), active status (in_arbeit or scheduled), detailed descriptions
+  const LARGE_PROJECT_CATS = ["Badsanierung", "Heizungsersatz", "Komplettrenovation"];
+  const recentLargeProjects = cases.filter(c =>
+    LARGE_PROJECT_CATS.includes(c.category) &&
+    (c.status === "in_arbeit" || c.status === "scheduled") &&
+    (now.getTime() - new Date(c.created_at).getTime()) < 14 * 86400000
+  );
+
+  if (recentLargeProjects.length < 2) {
+    // Promote or create large project cases by flipping recent non-large cases
+    const deficit = 2 - recentLargeProjects.length;
+    const recent14d = cases.filter(c =>
+      !LARGE_PROJECT_CATS.includes(c.category) &&
+      c.category !== "Rohrbruch" && // don't touch featured case category
+      (now.getTime() - new Date(c.created_at).getTime()) < 14 * 86400000 &&
+      c.status !== "new" && c.status !== "done"
+    );
+    const candidates = recent14d.slice(0, deficit);
+    const projectPool = [
+      { cat: "Badsanierung", desc: "Komplettsanierung Badezimmer: Dusche, WC, Lavabo, Fliesen. Besichtigung durchgeführt, Offerte in Arbeit.", src: "wizard" },
+      { cat: "Heizungsersatz", desc: "Heizungsersatz Öl → Wärmepumpe. EFH 200m², Besichtigung abgeschlossen. Offerte und Zeitplan in Abstimmung.", src: "manual" },
+      { cat: "Komplettrenovation", desc: "Komplettsanierung Sanitär EFH: 2 Bäder + Küche, Leitungen ab Hauptverteilung. Baustart geplant. Koordination mit Elektriker.", src: "manual" },
+    ];
+    for (let i = 0; i < candidates.length; i++) {
+      const c = candidates[i];
+      const proj = projectPool[i % projectPool.length];
+      c.category = proj.cat;
+      c.description = proj.desc;
+      c.source = proj.src;
+      c.status = i === 0 ? "in_arbeit" : "scheduled";
+      c.urgency = "normal";
+      // Schedule the project
+      const scheduleDays = 3 + Math.floor(Math.random() * 10);
+      c.scheduled_at = new Date(now.getTime() + scheduleDays * 86400000).toISOString();
+    }
+    console.log(`  Large projects: ${recentLargeProjects.length} existing + ${candidates.length} promoted = ${recentLargeProjects.length + candidates.length}`);
+  } else {
+    console.log(`  Large projects: ${recentLargeProjects.length} (sufficient)`);
+  }
+
+  // 6c. Guarantee minimum "new" cases by source in last 30 days
   // Requirement: min 5 voice + 3 wizard + 2 manual on status "new"
   const MIN_NEW = { voice: 5, wizard: 3, manual: 2 };
   const thirtyDaysAgo = new Date(now.getTime() - 30 * 86400000);

--- a/src/web/app/api/ops/cases/[id]/route.ts
+++ b/src/web/app/api/ops/cases/[id]/route.ts
@@ -336,7 +336,10 @@ export async function PATCH(
         ]);
 
         const modules = (tenantRow?.modules ?? {}) as Record<string, unknown>;
-        const notifyEnabled = modules.notify_staff_assignment !== false;
+        // Safe default: only send assignment emails when explicitly enabled.
+        // Phase A tenants (no notification_email set) must NEVER email prospect staff.
+        const hasNotificationEmail = typeof modules.notification_email === "string" && modules.notification_email.length > 0;
+        const notifyEnabled = modules.notify_staff_assignment === true || (modules.notify_staff_assignment !== false && hasNotificationEmail);
 
         if (notifyEnabled && identity && staffMatches && staffMatches.length > 0) {
           const caseLabel = formatCaseId(row.seq_number, identity.caseIdPrefix);

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -17,6 +17,7 @@ export default async function OpsCasesPage({
 }) {
   const params = await searchParams;
   const showDemo = params.tab === "demo";
+  const showDeleted = params.deleted === "true";
 
   const supabase = getServiceClient();
   const scope = await resolveTenantScope();
@@ -41,10 +42,10 @@ export default async function OpsCasesPage({
   let casesQuery = supabase
     .from("cases")
     .select(
-      "id, seq_number, created_at, updated_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, contact_phone, review_sent_at, review_rating, scheduled_at"
+      "id, seq_number, created_at, updated_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, contact_phone, review_sent_at, review_rating, scheduled_at, is_deleted"
     )
     .eq("is_demo", showDemo)
-    .eq("is_deleted", false)
+    .eq("is_deleted", showDeleted)
     .order("created_at", { ascending: false })
     .limit(200);
   if (filterTenantId) casesQuery = casesQuery.eq("tenant_id", filterTenantId);
@@ -256,6 +257,7 @@ export default async function OpsCasesPage({
       staffName={currentStaffName}
       staffRole={currentStaffRole}
       googleReviewCount={googleReviewCount}
+      showDeleted={showDeleted}
     />
   );
 }

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -39,6 +39,7 @@ export interface LeitzentraleCase {
   review_sent_at?: string | null;
   review_rating?: number | null;
   scheduled_at?: string | null;
+  is_deleted?: boolean;
 }
 
 export interface LeitzentraleProps {
@@ -54,6 +55,7 @@ export interface LeitzentraleProps {
   staffName?: string | null;
   staffRole?: "admin" | "techniker";
   googleReviewCount?: number | null;
+  showDeleted?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -236,6 +238,7 @@ export function LeitzentraleView({
   staffName,
   staffRole,
   googleReviewCount,
+  showDeleted,
 }: LeitzentraleProps) {
   const router = useRouter();
   const [activeNode, setActiveNode] = useState<string | null>(null);
@@ -520,6 +523,17 @@ export function LeitzentraleView({
         </button>
       </div>
 
+      {/* Deleted-cases banner */}
+      {showDeleted && (
+        <div className="flex items-center gap-2 px-4 py-2.5 bg-red-50 border border-red-200 rounded-xl text-sm text-red-700">
+          <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+          </svg>
+          <span className="font-medium">Papierkorb</span>
+          <span className="text-red-600">— {filteredCases.length} gelöschte {filteredCases.length === 1 ? "Fall" : "Fälle"}. Klicke auf einen Fall, um ihn wiederherzustellen.</span>
+        </div>
+      )}
+
       {/* Case Table v2 */}
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
         {/* Desktop table */}
@@ -741,28 +755,54 @@ export function LeitzentraleView({
         </div>
       </div>
 
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-3">
+      {/* Pagination + Trash toggle */}
+      <div className="flex items-center justify-center gap-3">
+        {totalPages > 1 && (
+          <>
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              disabled={safePage <= 1}
+              className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              &lt;
+            </button>
+            <span className="text-sm text-gray-500">
+              Seite {safePage} von {totalPages}
+            </span>
+            <button
+              onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+              disabled={safePage >= totalPages}
+              className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              &gt;
+            </button>
+          </>
+        )}
+        {/* Spacer to push trash icon right */}
+        <div className="flex-1" />
+        {showDeleted ? (
           <button
-            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-            disabled={safePage <= 1}
-            className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            onClick={() => router.push("/ops/cases")}
+            className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-500 hover:bg-gray-50 transition-colors flex items-center gap-1.5"
+            title="Zurück zur Fallübersicht"
           >
-            &lt;
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
+            </svg>
+            Zurück
           </button>
-          <span className="text-sm text-gray-500">
-            Seite {safePage} von {totalPages}
-          </span>
+        ) : (
           <button
-            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-            disabled={safePage >= totalPages}
-            className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            onClick={() => router.push("/ops/cases?deleted=true")}
+            className="rounded-lg border border-gray-200 p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+            title="Gelöschte Fälle anzeigen"
           >
-            &gt;
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+            </svg>
           </button>
-        </div>
-      )}
+        )}
+      </div>
 
       <CreateCaseModal open={modalOpen} onClose={() => setModalOpen(false)} />
     </div>


### PR DESCRIPTION
## Summary
- **Papierkorb-Ansicht (FB98):** Trash icon unten rechts in der Pagination → `?deleted=true` zeigt gelöschte Fälle mit rotem Banner + Restore via Falldetail
- **Staff Email Safety Gate (KRITISCH):** Assignment-Notifications nur noch wenn `notification_email` gesetzt (Phase B) oder explizites Opt-in. Dörfler + Leuthold Staff-Emails in DB auf NULL gesetzt. Verhindert versehentliche E-Mails an Prospect-Mitarbeiter während Phase A.
- **Grosse Projekte im Seed:** 3 neue Kategorien (Badsanierung, Heizungsersatz, Komplettrenovation) mit realistischen Beschreibungen und CHF-Beträgen. Min 2 auf Seite 1 garantiert. Dörfler + Leuthold re-seeded (70 Cases je).

## Test plan
- [ ] Leitzentrale öffnen → Papierkorb-Icon unten rechts sichtbar
- [ ] Fall löschen → Papierkorb klicken → gelöschter Fall sichtbar → Klick → Wiederherstellen
- [ ] Dörfler AG Einstellungen → Staff-Emails = leer (NULL)
- [ ] Fall zuweisen → KEINE E-Mail an Staff (Phase A, kein notification_email)
- [ ] Dörfler AG Fallübersicht → Badsanierung + Heizungsersatz auf Seite 1 sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)