### PR TITLE
fix: trash banner text + category header nowrap (FB100/101)

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -156,7 +156,7 @@ export default async function CaseDetailPage({
               <span className="text-sm font-medium">Zurück</span>
             </Link>
             <div className="flex items-baseline gap-2.5 min-w-0">
-              <h1 className="text-xl font-bold text-gray-900">{caseData.category}</h1>
+              <h1 className="text-xl font-bold text-gray-900 whitespace-nowrap">{caseData.category}</h1>
               <span className="text-sm text-gray-400 whitespace-nowrap hidden sm:inline">
                 {SOURCE_LABELS[caseData.source] ?? caseData.source} · {formatDate(caseData.created_at)}
               </span>

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -527,12 +527,11 @@ export function LeitzentraleView({
       {showDeleted && (
         <div className="px-4 py-2.5 bg-red-50 border border-red-200 rounded-xl text-sm text-red-700">
           <p>{filteredCases.length} gelöschte {filteredCases.length === 1 ? "Fall" : "Fälle"}.</p>
-          <p className="mt-0.5 flex items-center gap-1.5">
-            Klicke auf einen Fall und dann auf
-            <svg className="w-4 h-4 inline-block text-green-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <p className="mt-0.5 inline-flex items-center gap-1 flex-wrap">
+            <span>Klicke auf einen Fall und dann auf</span>
+            <svg className="w-4 h-4 inline-block text-green-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
             </svg>
-            <span className="font-medium text-green-700">Wiederherstellen</span>
           </p>
         </div>
       )}


### PR DESCRIPTION
## Summary
- **FB100:** "Wiederherstellen" Text entfernt — nur grüner Pfeil direkt nach "und dann auf"
- **FB101:** Kategorie-Überschrift im Falldetail mit `whitespace-nowrap` — kein hässlicher Umbruch bei "Sanitär allgemein" etc.

## Test plan
- [ ] Papierkorb öffnen → Text endet mit "und dann auf" + grüner Pfeil (kein "Wiederherstellen")
- [ ] Fall "Sanitär allgemein" öffnen → Überschrift auf einer Zeile

🤖 Generated with [Claude Code](https://claude.com/claude-code)