### PR TITLE
fix: case detail header redesign (FB102)

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -875,7 +875,6 @@ export function CaseDetailForm({
             ) : (
               <div className="flex-1 flex flex-col">
                 <SectionHead title="Beschreibung" onEdit={() => startEdit("beschreibung")} canEdit={canEditSection("beschreibung")} />
-                <p className="text-sm font-semibold text-gray-800 mb-2">{category}</p>
                 {description ? (
                   <div className="overflow-hidden flex-1">
                     <p className={`text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-words ${!descExpanded ? "line-clamp-2 sm:line-clamp-3" : ""}`} style={{ hyphens: "auto", WebkitHyphens: "auto" }} lang="de">{description}</p>

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -145,34 +145,29 @@ export default async function CaseDetailPage({
 
   return (
     <>
-      {/* Header: back + category + meta + actions */}
-      <div className="flex items-center justify-between mb-5">
-        <div className="min-w-0">
-          <div className="flex items-center gap-3">
-            <Link href="/ops/cases" className="group flex items-center gap-1.5 text-gray-500 hover:text-gray-900 transition-colors flex-shrink-0 rounded-lg px-2 py-1.5 -ml-2 hover:bg-gray-100">
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
-              </svg>
-              <span className="text-sm font-medium">Zurück</span>
-            </Link>
-            <div className="flex items-baseline gap-2.5 min-w-0">
-              <h1 className="text-xl font-bold text-gray-900 whitespace-nowrap">{caseData.category}</h1>
-              <span className="text-sm text-gray-400 whitespace-nowrap hidden sm:inline">
-                {SOURCE_LABELS[caseData.source] ?? caseData.source} · {formatDate(caseData.created_at)}
-              </span>
-            </div>
+      {/* Header: compact — back + case ID + actions on one line, category below */}
+      <div className="mb-4">
+        {/* Row 1: Navigation + Case ID + Actions */}
+        <div className="flex items-center justify-between">
+          <Link href="/ops/cases" className="group flex items-center gap-1 text-gray-500 hover:text-gray-900 transition-colors flex-shrink-0 rounded-lg px-2 py-1.5 -ml-2 hover:bg-gray-100">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+            </svg>
+            <span className="text-sm font-medium">Zurück</span>
+          </Link>
+          <div className="flex items-center gap-2">
+            <PrintButton />
+            <DeleteButton caseId={caseData.id} isDeleted={!!caseData.is_deleted} />
+            <span className="bg-gray-900 text-white px-3 py-1 rounded-lg text-sm font-bold tracking-wide">
+              {caseId}
+            </span>
           </div>
-          <p className="text-xs text-gray-400 ml-[52px] mt-0.5 sm:hidden">
-            {SOURCE_LABELS[caseData.source] ?? caseData.source} · {formatDate(caseData.created_at)}
-          </p>
         </div>
-        <div className="flex items-center gap-2.5 flex-shrink-0">
-          <PrintButton />
-          <DeleteButton caseId={caseData.id} isDeleted={!!caseData.is_deleted} />
-          <span className="bg-gray-900 text-white px-3.5 py-1.5 rounded-lg text-sm font-bold tracking-wide">
-            {caseId}
-          </span>
-        </div>
+        {/* Row 2: Category (full width, wraps naturally) */}
+        <h1 className="text-lg font-bold text-gray-900 mt-2 leading-snug">{caseData.category}</h1>
+        <p className="text-xs text-gray-400 mt-0.5">
+          {SOURCE_LABELS[caseData.source] ?? caseData.source} · {formatDate(caseData.created_at)}
+        </p>
       </div>
 
       {/* Tenant auto-switched via cookie when admin opens a foreign-tenant case */}


### PR DESCRIPTION
## Summary
**FB102:** Langer Kategorie-Name ("Sanierung ohne Badewanne mit Dusche") hat Header gesprengt. Neues 2-Zeilen-Layout:

**Vorher:** `← Zurück` + `Kategorie` + `DA-0072` alles auf einer Zeile → Overflow bei langen Namen
**Nachher:**
- **Zeile 1:** `← Zurück` (links) | Print + Papierkorb + Case-ID (rechts) — passt immer
- **Zeile 2:** Kategorie als h1 (volle Breite, bricht natürlich um)
- **Zeile 3:** Quelle + Datum (kompakt)
- **Redundanz entfernt:** Kategorie stand doppelt (Header + Beschreibung-Section) — jetzt nur noch im Header

## Test plan
- [ ] Fall "Sanierung ohne Badewanne mit Dusche" öffnen → sauberer Umbruch
- [ ] Kurze Kategorie ("Leck") → kompakt, kein unnötiger Leerraum
- [ ] Beschreibung-Section → keine Kategorie-Zeile mehr (nur noch Freitext)
- [ ] Desktop + Mobile testen

🤖 Generated with [Claude Code](https://claude.com/claude-code)