### PR TITLE
fix: scroll to top on case detail open (FB103/104)

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/[id]/ScrollToTop.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/ScrollToTop.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ScrollToTop() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+  return null;
+}

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -9,6 +9,7 @@ import { formatCaseId } from "@/src/lib/cases/formatCaseId";
 import { CaseDetailForm } from "./CaseDetailForm";
 import { PrintButton } from "./PrintButton";
 import { DeleteButton } from "./DeleteButton";
+import { ScrollToTop } from "./ScrollToTop";
 import type { CaseEvent } from "@/src/components/ops/CaseTimeline";
 
 // ---------------------------------------------------------------------------
@@ -145,6 +146,7 @@ export default async function CaseDetailPage({
 
   return (
     <>
+      <ScrollToTop />
       {/* Header: compact — back + case ID + actions on one line, category below */}
       <div className="mb-4">
         {/* Row 1: Navigation + Case ID + Actions */}


### PR DESCRIPTION
## Summary
**FB103/104:** Falldetail öffnete sich auf Scroll-Position der Leitzentrale — Header war nicht sichtbar, Nutzer musste nach oben scrollen. Jetzt: `ScrollToTop` Component scrollt beim Mount automatisch nach oben.

## Test plan
- [ ] Leitzentrale → auf Fall klicken → Header sofort sichtbar (wie FB104)
- [ ] Zurück → Leitzentrale → anderer Fall → wieder oben

🤖 Generated with [Claude Code](https://claude.com/claude-code)