### PR TITLE
feat: website v3 Phase A — Kill-Test (3 Handschriften, kein shared ServiceCard)

### DIFF
--- a/src/web/app/kunden/[slug]/layouts/LayoutEditorial.tsx
+++ b/src/web/app/kunden/[slug]/layouts/LayoutEditorial.tsx
@@ -1,71 +1,45 @@
 /**
- * LayoutEditorial — System A: SUBSTANZ / TRADITION
+ * LayoutEditorial — System A: SUBSTANZ
  *
- * Magazine-style, vertical, image-dominant, lots of whitespace.
- * Like an architecture monograph, not a business website.
- *
- * Used for: Generationsbetriebe (>40 Jahre), Familientradition, Handwerks-Stolz
- * Example: Dörfler AG (seit 1926, 3. Generation)
+ * HANDSCHRIFT: Eckig, grosszügig, Serif, keine Schatten, nur Borders.
+ * KEINE shared ServiceCard. Eigene Service-Darstellung.
+ * KEINE generischen Phrasen.
  */
 
-import { ServiceCard } from "../ServiceCard";
 import { AnimatedSection } from "../AnimatedSection";
 import { StickyMobileCTA } from "../StickyMobileCTA";
-import type { CustomerSite, ServiceIcon } from "@/src/lib/customers/types";
+import type { CustomerSite } from "@/src/lib/customers/types";
 
-// ── Service Icon (shared SVG helper, duplicated to keep layouts self-contained) ──
-function SvcIcon({ icon }: { icon?: ServiceIcon }) {
-  const d: Record<string, string> = {
-    bath: "M7 21h10a2 2 0 002-2v-3H5v3a2 2 0 002 2zm-2-8h14M5 7a4 4 0 014-4h.01M5 7v4h14V7",
-    flame: "M12 2c1 4-2 6-2 9a4 4 0 008 0c0-3-3-5-2-9M12 18a2 2 0 01-2-2c0-1 2-3 2-3s2 2 2 3a2 2 0 01-2 2z",
-    heating: "M12 3v18m-6-6l6 6 6-6M6 9a6 6 0 0112 0",
-    roof: "M3 21h18M5 21V11l7-7 7 7v10",
-    tool: "M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z",
-    water: "M12 2.69l5.66 5.66a8 8 0 11-11.31 0z",
-    pipe: "M4 14h6m-6 4h6m4-8v12m0-12l4-4m-4 4l-4-4",
-    solar: "M12 3v1m0 16v1m-8-9H3m18 0h-1m-2.636-6.364l-.707.707M6.343 17.657l-.707.707m0-12.728l.707.707m11.314 11.314l.707.707M12 8a4 4 0 100 8 4 4 0 000-8z",
-  };
-  return (
-    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d={d[icon ?? "tool"] ?? d.tool} />
-    </svg>
-  );
-}
-
-// ── Laurel Wreath Badge (for "100 Jahre" etc.) ──
+// ── Laurel Wreath ──
 function LaurelBadge({ number, label }: { number: string; label: string }) {
   return (
     <div className="flex flex-col items-center">
-      <div className="relative flex h-32 w-32 items-center justify-center sm:h-40 sm:w-40">
-        {/* Left laurel branch */}
-        <svg className="absolute left-0 top-0 h-full w-1/2 text-amber-600/70" viewBox="0 0 60 120" fill="none">
+      <div className="relative flex h-28 w-28 items-center justify-center sm:h-36 sm:w-36">
+        <svg className="absolute left-0 top-0 h-full w-1/2 text-amber-600/60" viewBox="0 0 60 120" fill="none">
           <path d="M50 110 C45 95, 20 90, 25 75 C30 60, 15 55, 20 40 C25 25, 12 20, 18 8" stroke="currentColor" strokeWidth="1.5" fill="none" />
-          <ellipse cx="22" cy="20" rx="8" ry="14" transform="rotate(-20 22 20)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
-          <ellipse cx="18" cy="42" rx="8" ry="13" transform="rotate(-30 18 42)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
-          <ellipse cx="22" cy="62" rx="8" ry="13" transform="rotate(-20 22 62)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
-          <ellipse cx="28" cy="80" rx="7" ry="12" transform="rotate(-10 28 80)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
-          <ellipse cx="38" cy="96" rx="7" ry="11" transform="rotate(5 38 96)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
+          <ellipse cx="22" cy="20" rx="8" ry="14" transform="rotate(-20 22 20)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
+          <ellipse cx="18" cy="42" rx="8" ry="13" transform="rotate(-30 18 42)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
+          <ellipse cx="22" cy="62" rx="8" ry="13" transform="rotate(-20 22 62)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
+          <ellipse cx="28" cy="80" rx="7" ry="12" transform="rotate(-10 28 80)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
+          <ellipse cx="38" cy="96" rx="7" ry="11" transform="rotate(5 38 96)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
         </svg>
-        {/* Right laurel branch (mirrored) */}
-        <svg className="absolute right-0 top-0 h-full w-1/2 text-amber-600/70" viewBox="0 0 60 120" fill="none" style={{ transform: "scaleX(-1)" }}>
+        <svg className="absolute right-0 top-0 h-full w-1/2 text-amber-600/60" viewBox="0 0 60 120" fill="none" style={{ transform: "scaleX(-1)" }}>
           <path d="M50 110 C45 95, 20 90, 25 75 C30 60, 15 55, 20 40 C25 25, 12 20, 18 8" stroke="currentColor" strokeWidth="1.5" fill="none" />
-          <ellipse cx="22" cy="20" rx="8" ry="14" transform="rotate(-20 22 20)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
-          <ellipse cx="18" cy="42" rx="8" ry="13" transform="rotate(-30 18 42)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
-          <ellipse cx="22" cy="62" rx="8" ry="13" transform="rotate(-20 22 62)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
-          <ellipse cx="28" cy="80" rx="7" ry="12" transform="rotate(-10 28 80)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
-          <ellipse cx="38" cy="96" rx="7" ry="11" transform="rotate(5 38 96)" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="0.8" />
+          <ellipse cx="22" cy="20" rx="8" ry="14" transform="rotate(-20 22 20)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
+          <ellipse cx="18" cy="42" rx="8" ry="13" transform="rotate(-30 18 42)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
+          <ellipse cx="22" cy="62" rx="8" ry="13" transform="rotate(-20 22 62)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
+          <ellipse cx="28" cy="80" rx="7" ry="12" transform="rotate(-10 28 80)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
+          <ellipse cx="38" cy="96" rx="7" ry="11" transform="rotate(5 38 96)" fill="currentColor" opacity="0.12" stroke="currentColor" strokeWidth="0.7" />
         </svg>
-        {/* Number */}
-        <span className="relative z-10 text-4xl font-bold text-gray-900 sm:text-5xl" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
+        <span className="relative z-10 text-3xl font-bold text-gray-900 sm:text-4xl" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
           {number}
         </span>
       </div>
-      <p className="mt-1 text-sm font-medium tracking-wide text-gray-500 uppercase">{label}</p>
+      <p className="mt-1 text-xs tracking-widest text-gray-400 uppercase">{label}</p>
     </div>
   );
 }
 
-// ── Main Layout ──
 export function LayoutEditorial({ company: c }: { company: CustomerSite }) {
   const accent = c.brandColor ?? "#2b6cb0";
   const wizardUrl = `/kunden/${c.slug}/meldung`;
@@ -73,73 +47,62 @@ export function LayoutEditorial({ company: c }: { company: CustomerSite }) {
   const foundedYear = c.history?.[0]?.year;
   const yearsActive = foundedYear ? new Date().getFullYear() - foundedYear : null;
   const galleryMap = new Map((c.gallery ?? []).map((g) => [g.slug, g.images]));
+  const serif = "var(--font-source-serif), Georgia, serif";
 
   return (
-    <div className="min-h-screen cs-font-source-serif" data-color-mode="warm" style={{ backgroundColor: "var(--cs-surface, #faf8f5)" }}>
+    <div className="min-h-screen" style={{ backgroundColor: "#faf8f5", fontFamily: "var(--font-geist-sans), system-ui, sans-serif" }}>
 
-      {/* ── Nav: Minimal ─────────────────────────────────────── */}
-      <nav className="sticky top-0 z-50 backdrop-blur-sm" style={{ backgroundColor: "var(--cs-surface, #faf8f5)" }}>
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-          <span className="text-lg font-bold text-gray-900" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
-            {c.companyName}
-          </span>
-          <a href={`tel:${c.contact.phoneRaw}`} className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">
-            {c.contact.phone}
-          </a>
+      {/* ── Nav ───────────────────────────────────────────── */}
+      <nav className="sticky top-0 z-50 backdrop-blur-sm" style={{ backgroundColor: "rgba(250,248,245,0.95)" }}>
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-5">
+          <span className="text-base font-semibold text-gray-800" style={{ fontFamily: serif }}>{c.companyName}</span>
+          <a href={`tel:${c.contact.phoneRaw}`} className="text-sm text-gray-500 hover:text-gray-800 transition-colors">{c.contact.phone}</a>
         </div>
       </nav>
 
-      {/* ── Hero: Editorial ──────────────────────────────────── */}
+      {/* ── Hero ─────────────────────────────────────────── */}
       <AnimatedSection animation="fade">
-        <section className="mx-auto max-w-5xl px-6 pt-12 pb-8 sm:pt-20 sm:pb-12">
+        <section className="mx-auto max-w-4xl px-6 pt-16 pb-8 sm:pt-24">
           <div className="flex flex-col items-center text-center">
-            {/* Laurel Wreath */}
             {yearsActive && yearsActive >= 20 && (
               <LaurelBadge
                 number={yearsActive >= 100 ? "100" : String(Math.floor(yearsActive / 10) * 10)}
                 label={yearsActive >= 100 ? "Jahre Tradition" : "Jahre Erfahrung"}
               />
             )}
-
-            <h1 className="mt-6 text-4xl font-bold leading-tight text-gray-900 sm:text-5xl lg:text-6xl" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
+            <h1 className="mt-8 text-4xl font-bold leading-tight text-gray-900 sm:text-5xl lg:text-[3.5rem]" style={{ fontFamily: serif }}>
               {c.companyName}
             </h1>
-            <p className="mt-4 max-w-xl text-lg text-gray-500">{c.tagline}</p>
-
-            <div className="mt-8 flex gap-4">
-              <a href={wizardUrl} className="rounded-2xl px-7 py-3.5 text-base font-semibold text-white transition-opacity hover:opacity-90" style={{ backgroundColor: accent }}>
+            <p className="mt-5 max-w-lg text-lg leading-relaxed text-gray-500" style={{ fontSize: "1.125rem" }}>{c.tagline}</p>
+            <div className="mt-10 flex gap-5">
+              <a href={wizardUrl} className="border-2 px-8 py-3 text-sm font-semibold tracking-wide text-white transition-opacity hover:opacity-90" style={{ backgroundColor: accent, borderColor: accent }}>
                 Anliegen melden
               </a>
-              <a href={`tel:${c.contact.phoneRaw}`} className="rounded-2xl border px-7 py-3.5 text-base font-semibold transition-colors hover:bg-gray-50" style={{ borderColor: accent, color: accent }}>
+              <a href={`tel:${c.contact.phoneRaw}`} className="border-2 px-8 py-3 text-sm font-semibold tracking-wide transition-colors hover:bg-gray-50" style={{ borderColor: "#d1ccc4", color: "#6b6560" }}>
                 Anrufen
               </a>
             </div>
           </div>
-
-          {/* Hero Image — below text, with rounded corners, breathing room */}
-          <div className="mt-12 overflow-hidden rounded-2xl">
+          <div className="mt-16 overflow-hidden rounded-lg">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={heroImg} alt={c.companyName} className="w-full h-64 sm:h-80 lg:h-[28rem] object-cover" />
+            <img src={heroImg} alt={c.companyName} className="w-full h-56 sm:h-72 lg:h-[26rem] object-cover" />
           </div>
         </section>
       </AnimatedSection>
 
-      {/* ── Geschichte (wenn vorhanden, als Herzstück) ──────── */}
+      {/* ── Geschichte ───────────────────────────────────── */}
       {c.history && c.history.length >= 2 && (
         <AnimatedSection animation="fade">
-          <section className="mx-auto max-w-4xl px-6 py-16">
-            <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
-              Unsere Geschichte
-            </h2>
-            <div className="mt-10 space-y-8">
+          <section className="mx-auto max-w-3xl px-6 py-24">
+            <div className="space-y-10">
               {c.history.map((h) => (
-                <div key={h.year} className="flex gap-6">
-                  <div className="flex-shrink-0 w-16 text-right">
-                    <span className="text-lg font-bold" style={{ color: accent }}>{h.year}</span>
+                <div key={h.year} className="flex gap-8">
+                  <div className="flex-shrink-0 w-20 text-right pt-1">
+                    <span className="text-lg font-bold" style={{ color: accent, fontFamily: serif }}>{h.year}</span>
                   </div>
-                  <div className="border-l-2 pl-6 pb-2" style={{ borderColor: `${accent}30` }}>
-                    <h3 className="font-semibold text-gray-900">{h.title}</h3>
-                    {h.description && <p className="mt-1 text-sm text-gray-500 leading-relaxed">{h.description}</p>}
+                  <div className="border-l pl-8 pb-2" style={{ borderColor: "#e0d8cf" }}>
+                    <h3 className="text-lg font-semibold text-gray-900" style={{ fontFamily: serif }}>{h.title}</h3>
+                    {h.description && <p className="mt-2 text-base leading-relaxed text-gray-500">{h.description}</p>}
                   </div>
                 </div>
               ))}
@@ -148,105 +111,85 @@ export function LayoutEditorial({ company: c }: { company: CustomerSite }) {
         </AnimatedSection>
       )}
 
-      {/* ── Services: Vertikal, Bild-dominiert ──────────────── */}
+      {/* ── Services: Bild + Fliessttext, KEIN ServiceCard ── */}
       <AnimatedSection animation="fade">
-        <section id="leistungen" className="mx-auto max-w-5xl px-6 py-16">
-          <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
-            Unsere Leistungen
-          </h2>
-          <div className="mt-10 space-y-16">
-            {c.services.map((s, i) => {
+        <section id="leistungen" className="mx-auto max-w-4xl px-6 py-24">
+          <div className="space-y-24">
+            {c.services.map((s) => {
               const imgs = galleryMap.get(s.slug) ?? [];
               const firstImg = imgs[0]?.src;
               return (
-                <div key={s.slug}>
+                <article key={s.slug}>
                   {firstImg && (
-                    <div className="overflow-hidden rounded-2xl">
+                    <div className="overflow-hidden rounded-lg">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img src={firstImg} alt={s.name} className="w-full h-48 sm:h-64 lg:h-80 object-cover" />
+                      <img src={firstImg} alt={s.name} className="w-full h-48 sm:h-64 lg:h-72 object-cover" />
                     </div>
                   )}
-                  <div className="mt-5 flex items-start gap-4">
-                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl text-white" style={{ backgroundColor: accent }}>
-                      <SvcIcon icon={s.icon} />
-                    </div>
-                    <div>
-                      <h3 className="text-xl font-bold text-gray-900">{s.name}</h3>
-                      <p className="mt-2 text-gray-500 leading-relaxed">{s.summary}</p>
-                      {s.description && (
-                        <ServiceCard
-                          name={s.name}
-                          summary=""
-                          description={s.description}
-                          bullets={s.bullets}
-                          icon={<SvcIcon icon={s.icon} />}
-                          images={imgs}
-                          accent={accent}
-                        />
-                      )}
-                    </div>
-                  </div>
-                </div>
+                  <h3 className="mt-8 text-2xl font-bold text-gray-900" style={{ fontFamily: serif }}>{s.name}</h3>
+                  <p className="mt-4 text-base leading-relaxed text-gray-500" style={{ fontSize: "1.0625rem" }}>{s.summary}</p>
+                  {s.description && (
+                    <p className="mt-3 text-base leading-relaxed text-gray-400">{s.description}</p>
+                  )}
+                  {s.bullets && s.bullets.length > 0 && (
+                    <ul className="mt-5 space-y-2">
+                      {s.bullets.map((b, i) => (
+                        <li key={i} className="flex items-start gap-3 text-sm text-gray-500">
+                          <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full" style={{ backgroundColor: accent }} />
+                          {b}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </article>
               );
             })}
           </div>
         </section>
       </AnimatedSection>
 
-      {/* ── Reviews: 1 grosses Zitat ────────────────────────── */}
+      {/* ── Bewertungen: 1 Zitat ─────────────────────────── */}
       {c.reviews && c.reviews.highlights.length > 0 && (
         <AnimatedSection animation="fade">
-          <section id="bewertungen" className="py-16" style={{ backgroundColor: "var(--cs-section-alt, #f5f0ea)" }}>
-            <div className="mx-auto max-w-3xl px-6 text-center">
+          <section className="py-24" style={{ backgroundColor: "#f3ede5" }}>
+            <div className="mx-auto max-w-2xl px-6 text-center">
+              <blockquote className="text-xl leading-relaxed text-gray-700 italic sm:text-2xl" style={{ fontFamily: serif }}>
+                &ldquo;{c.reviews.highlights[0].text}&rdquo;
+              </blockquote>
+              <p className="mt-6 text-sm text-gray-400">{c.reviews.highlights[0].author}</p>
               {c.reviews.averageRating >= 4.0 && (
-                <div className="mb-4 flex items-center justify-center gap-1">
+                <div className="mt-4 flex items-center justify-center gap-1">
                   {Array.from({ length: 5 }).map((_, i) => (
-                    <svg key={i} className={`h-6 w-6 ${i < Math.round(c.reviews!.averageRating) ? "text-amber-400" : "text-gray-300"}`} fill="currentColor" viewBox="0 0 20 20">
+                    <svg key={i} className={`h-4 w-4 ${i < Math.round(c.reviews!.averageRating) ? "text-amber-500" : "text-gray-300"}`} fill="currentColor" viewBox="0 0 20 20">
                       <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                     </svg>
                   ))}
+                  <span className="ml-2 text-xs text-gray-400">{c.reviews.totalReviews} Bewertungen</span>
                 </div>
-              )}
-              <blockquote className="text-xl leading-relaxed text-gray-700 italic sm:text-2xl" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
-                &ldquo;{c.reviews.highlights[0].text}&rdquo;
-              </blockquote>
-              <p className="mt-4 text-sm font-medium text-gray-500">{c.reviews.highlights[0].author}</p>
-              {c.reviews.totalReviews > 1 && (
-                <p className="mt-6 text-sm text-gray-400">
-                  {c.reviews.googleUrl ? (
-                    <a href={c.reviews.googleUrl} target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">
-                      {c.reviews.totalReviews} Bewertungen auf Google &rarr;
-                    </a>
-                  ) : `${c.reviews.totalReviews} Bewertungen`}
-                </p>
               )}
             </div>
           </section>
         </AnimatedSection>
       )}
 
-      {/* ── Team (nur wenn 2+ Mitglieder) ───────────────────── */}
+      {/* ── Team ─────────────────────────────────────────── */}
       {c.team.length > 1 && (
         <AnimatedSection animation="fade">
-          <section className="mx-auto max-w-4xl px-6 py-16">
-            <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
-              Unser Team
-            </h2>
-            <div className="mt-10 grid gap-8 sm:grid-cols-2">
+          <section className="mx-auto max-w-3xl px-6 py-24">
+            <div className="grid gap-12 sm:grid-cols-2">
               {c.team.map((m) => (
-                <div key={m.name} className="flex items-center gap-5">
+                <div key={m.name} className="flex items-center gap-6">
                   {m.image ? (
                     // eslint-disable-next-line @next/next/no-img-element
-                    <img src={m.image} alt={m.name} className="h-20 w-20 rounded-full object-cover" />
+                    <img src={m.image} alt={m.name} className="h-20 w-20 rounded-lg object-cover" />
                   ) : (
-                    <div className="flex h-20 w-20 items-center justify-center rounded-full text-2xl font-bold text-white" style={{ backgroundColor: accent }}>
+                    <div className="flex h-20 w-20 items-center justify-center rounded-lg text-xl font-bold text-white" style={{ backgroundColor: accent }}>
                       {m.name.split(" ").map(n => n[0]).join("")}
                     </div>
                   )}
                   <div>
-                    <p className="text-lg font-semibold text-gray-900">{m.name}</p>
-                    <p className="text-sm text-gray-500">{m.role}</p>
-                    {m.bio && <p className="mt-1 text-sm text-gray-400">{m.bio}</p>}
+                    <p className="text-lg font-semibold text-gray-900" style={{ fontFamily: serif }}>{m.name}</p>
+                    <p className="text-sm text-gray-400">{m.role}</p>
                   </div>
                 </div>
               ))}
@@ -255,86 +198,64 @@ export function LayoutEditorial({ company: c }: { company: CustomerSite }) {
         </AnimatedSection>
       )}
 
-      {/* ── Trust (Zertifikate + Partner) ───────────────────── */}
+      {/* ── Partner + Zertifikate ────────────────────────── */}
       {(c.certifications || c.brandPartners) && (
         <AnimatedSection animation="fade">
-          <section className="mx-auto max-w-5xl px-6 py-16">
+          <section className="mx-auto max-w-4xl px-6 py-16">
             {c.certifications && c.certifications.length > 0 && (
-              <div className="flex flex-wrap justify-center gap-6">
+              <div className="flex flex-wrap justify-center gap-5">
                 {c.certifications.map((cert) => (
-                  <div key={cert.name} className="flex items-center gap-3 rounded-xl border px-5 py-3" style={{ borderColor: "var(--cs-border, #e5e7eb)", backgroundColor: "var(--cs-card, #ffffff)" }}>
-                    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke={accent}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z" />
-                    </svg>
-                    <div>
-                      <p className="text-sm font-semibold text-gray-800">{cert.name}</p>
-                      {cert.issuer && <p className="text-xs text-gray-400">{cert.issuer}</p>}
-                    </div>
+                  <div key={cert.name} className="flex items-center gap-3 border px-5 py-3" style={{ borderColor: "#e0d8cf" }}>
+                    <span className="text-sm font-semibold text-gray-700">{cert.name}</span>
+                    {cert.issuer && <span className="text-xs text-gray-400">{cert.issuer}</span>}
                   </div>
                 ))}
               </div>
             )}
             {c.brandPartners && c.brandPartners.length > 0 && (
-              <div className="mt-10">
-                <p className="mb-4 text-center text-xs font-medium uppercase tracking-wider text-gray-400">Unsere Partner</p>
-                <div className="flex flex-wrap items-center justify-center gap-4">
-                  {c.brandPartners.map((p) => (
-                    <span key={p.name} className="rounded-lg border px-4 py-2 text-sm font-medium text-gray-600" style={{ borderColor: "var(--cs-border)" }}>
-                      {p.name}
-                    </span>
-                  ))}
-                </div>
+              <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+                {c.brandPartners.map((p) => (
+                  <span key={p.name} className="border px-4 py-2 text-sm text-gray-500" style={{ borderColor: "#e0d8cf" }}>
+                    {p.name}
+                  </span>
+                ))}
               </div>
             )}
           </section>
         </AnimatedSection>
       )}
 
-      {/* ── Einzugsgebiet ──────────────────────────────────── */}
+      {/* ── Einzugsgebiet ────────────────────────────────── */}
       <AnimatedSection animation="fade">
-        <section className="mx-auto max-w-4xl px-6 py-16">
-          <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
-            Unser Einzugsgebiet
-          </h2>
-          <p className="mt-3 text-gray-500">{c.serviceArea.region}{c.serviceArea.radiusDescription ? ` — ${c.serviceArea.radiusDescription}` : ""}</p>
+        <section className="mx-auto max-w-3xl px-6 py-24">
+          <p className="text-sm tracking-widest text-gray-400 uppercase">Einzugsgebiet</p>
+          <p className="mt-2 text-lg text-gray-700" style={{ fontFamily: serif }}>{c.serviceArea.region}</p>
           <div className="mt-6 flex flex-wrap gap-2">
             {c.serviceArea.gemeinden.map((g) => (
-              <span key={g} className="rounded-full border px-3 py-1 text-sm text-gray-600" style={{ borderColor: "var(--cs-border)", backgroundColor: "var(--cs-card)" }}>
+              <span key={g} className="border px-3 py-1 text-sm text-gray-500" style={{ borderColor: "#e0d8cf" }}>
                 {g}
               </span>
             ))}
           </div>
-          {c.contact.mapEmbedUrl && (
-            <div className="mt-8 overflow-hidden rounded-2xl">
-              <iframe src={c.contact.mapEmbedUrl} className="h-64 w-full border-0" loading="lazy" title="Standort" />
-            </div>
-          )}
         </section>
       </AnimatedSection>
 
-      {/* ── Kontakt ────────────────────────────────────────── */}
+      {/* ── Kontakt ──────────────────────────────────────── */}
       <AnimatedSection animation="fade">
-        <section id="kontakt" className="mx-auto max-w-4xl px-6 py-16">
-          <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl" style={{ fontFamily: "var(--font-source-serif), Georgia, serif" }}>
-            Kontakt
-          </h2>
-          <div className="mt-8 space-y-3 text-gray-600">
-            <p className="font-semibold text-gray-900">{c.companyName}</p>
-            <p>{c.contact.address.street}, {c.contact.address.zip} {c.contact.address.city}</p>
-            <p><a href={`tel:${c.contact.phoneRaw}`} className="hover:underline" style={{ color: accent }}>{c.contact.phone}</a></p>
-            {c.contact.email && <p><a href={`mailto:${c.contact.email}`} className="hover:underline" style={{ color: accent }}>{c.contact.email}</a></p>}
-          </div>
-          <div className="mt-8">
-            <a href={wizardUrl} className="inline-flex rounded-2xl px-7 py-3.5 text-base font-semibold text-white transition-opacity hover:opacity-90" style={{ backgroundColor: accent }}>
-              Anliegen melden
-            </a>
-          </div>
+        <section id="kontakt" className="mx-auto max-w-3xl px-6 py-24 border-t" style={{ borderColor: "#e0d8cf" }}>
+          <p className="text-lg font-semibold text-gray-900" style={{ fontFamily: serif }}>{c.companyName}</p>
+          <p className="mt-2 text-base text-gray-500">{c.contact.address.street}, {c.contact.address.zip} {c.contact.address.city}</p>
+          <p className="mt-1"><a href={`tel:${c.contact.phoneRaw}`} className="text-base hover:underline" style={{ color: accent }}>{c.contact.phone}</a></p>
+          {c.contact.email && <p className="mt-1"><a href={`mailto:${c.contact.email}`} className="text-base text-gray-500 hover:underline">{c.contact.email}</a></p>}
+          <a href={wizardUrl} className="mt-8 inline-block border-2 px-8 py-3 text-sm font-semibold tracking-wide text-white transition-opacity hover:opacity-90" style={{ backgroundColor: accent, borderColor: accent }}>
+            Anliegen melden
+          </a>
         </section>
       </AnimatedSection>
 
-      {/* ── Footer ─────────────────────────────────────────── */}
-      <footer className="border-t py-8" style={{ borderColor: "var(--cs-border)" }}>
-        <div className="mx-auto flex max-w-5xl flex-col items-center gap-2 px-6 text-xs text-gray-400 sm:flex-row sm:justify-between">
+      {/* ── Footer ───────────────────────────────────────── */}
+      <footer className="border-t py-8" style={{ borderColor: "#e0d8cf" }}>
+        <div className="mx-auto flex max-w-4xl flex-col items-center gap-2 px-6 text-xs text-gray-400 sm:flex-row sm:justify-between">
           <span>&copy; {new Date().getFullYear()} {c.companyName}</span>
           <div className="flex gap-4">
             <a href={`/kunden/${c.slug}/impressum`} className="hover:text-gray-600">Impressum</a>

--- a/src/web/app/kunden/[slug]/layouts/LayoutKompakt.tsx
+++ b/src/web/app/kunden/[slug]/layouts/LayoutKompakt.tsx
@@ -1,110 +1,81 @@
 /**
- * LayoutKompakt — System B: VERTRAUEN / NÄHE
+ * LayoutKompakt — System B: VERTRAUEN
  *
- * App-like, mobile-first, review-driven, compact.
- * Everything important above-the-fold. Minimal scroll needed.
- *
- * Used for: Kleine Betriebe (1-5 MA), starke Reviews, lokal verankert
- * Example: Walter Leuthold (Solo, 4.9★, 44 Reviews)
+ * HANDSCHRIFT: Rund, kompakt, weiche Schatten, DM Sans, App-artig.
+ * KEINE shared ServiceCard. Services als Aufzählung.
+ * KEINE generischen Phrasen.
  */
 
-import { ServiceCard } from "../ServiceCard";
 import { AnimatedSection } from "../AnimatedSection";
 import { StickyMobileCTA } from "../StickyMobileCTA";
-import type { CustomerSite, ServiceIcon } from "@/src/lib/customers/types";
-
-function SvcIcon({ icon }: { icon?: ServiceIcon }) {
-  const d: Record<string, string> = {
-    bath: "M7 21h10a2 2 0 002-2v-3H5v3a2 2 0 002 2zm-2-8h14M5 7a4 4 0 014-4h.01M5 7v4h14V7",
-    flame: "M12 2c1 4-2 6-2 9a4 4 0 008 0c0-3-3-5-2-9M12 18a2 2 0 01-2-2c0-1 2-3 2-3s2 2 2 3a2 2 0 01-2 2z",
-    heating: "M12 3v18m-6-6l6 6 6-6M6 9a6 6 0 0112 0",
-    roof: "M3 21h18M5 21V11l7-7 7 7v10",
-    facade: "M3 21V3h18v18M9 7h6M9 11h6M9 15h6",
-    tool: "M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z",
-    water: "M12 2.69l5.66 5.66a8 8 0 11-11.31 0z",
-    pipe: "M4 14h6m-6 4h6m4-8v12m0-12l4-4m-4 4l-4-4",
-  };
-  return (
-    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d={d[icon ?? "tool"] ?? d.tool} />
-    </svg>
-  );
-}
+import type { CustomerSite } from "@/src/lib/customers/types";
 
 export function LayoutKompakt({ company: c }: { company: CustomerSite }) {
   const accent = c.brandColor ?? "#203784";
   const wizardUrl = `/kunden/${c.slug}/meldung`;
   const heroImg = `/kunden/${c.slug}/hero.jpg`;
-  const galleryMap = new Map((c.gallery ?? []).map((g) => [g.slug, g.images]));
 
   return (
-    <div className="min-h-screen cs-font-dm-sans" data-color-mode="warm" style={{ backgroundColor: "var(--cs-surface, #faf8f5)" }}>
+    <div className="min-h-screen bg-white" style={{ fontFamily: "var(--font-dm-sans), system-ui, sans-serif" }}>
 
-      {/* ── Nav: Ultra-minimal ─────────────────────────────── */}
-      <nav className="sticky top-0 z-50 backdrop-blur-sm border-b" style={{ backgroundColor: "var(--cs-surface, #faf8f5)", borderColor: "var(--cs-border)" }}>
-        <div className="mx-auto flex max-w-lg items-center justify-between px-4 py-3">
+      {/* ── Nav ───────────────────────────────────────────── */}
+      <nav className="sticky top-0 z-50 bg-white/95 backdrop-blur-sm shadow-sm">
+        <div className="mx-auto flex max-w-md items-center justify-between px-4 py-3">
           <span className="text-base font-bold text-gray-900">{c.companyName}</span>
-          <a href={`tel:${c.contact.phoneRaw}`} className="rounded-full px-4 py-1.5 text-sm font-semibold text-white" style={{ backgroundColor: accent }}>
+          <a href={`tel:${c.contact.phoneRaw}`} className="rounded-full px-4 py-1.5 text-sm font-bold text-white shadow-md" style={{ backgroundColor: accent }}>
             Anrufen
           </a>
         </div>
       </nav>
 
-      {/* ── Hero: Review-first, Bild + Overlay ──────────────── */}
+      {/* ── Hero: Review-first ───────────────────────────── */}
       <section className="relative overflow-hidden text-white">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src={heroImg} alt={c.companyName} className="absolute inset-0 h-full w-full object-cover" />
         <div className="absolute inset-0 bg-gray-900/85" />
-        <div className="relative mx-auto flex min-h-[60vh] max-w-lg flex-col items-center justify-center px-6 py-16 text-center">
-          {/* Review badge — THE dominant element */}
+        <div className="relative mx-auto flex min-h-[55vh] max-w-md flex-col items-center justify-center px-5 py-14 text-center">
           {c.reviews && c.reviews.averageRating >= 4.0 && (
-            <div className="mb-6">
-              <div className="flex items-center justify-center gap-1">
+            <div className="mb-5">
+              <div className="flex items-center justify-center gap-0.5">
                 {Array.from({ length: 5 }).map((_, i) => (
-                  <svg key={i} className={`h-8 w-8 ${i < Math.round(c.reviews!.averageRating) ? "text-amber-400" : "text-white/30"}`} fill="currentColor" viewBox="0 0 20 20">
+                  <svg key={i} className={`h-7 w-7 ${i < Math.round(c.reviews!.averageRating) ? "text-amber-400" : "text-white/20"}`} fill="currentColor" viewBox="0 0 20 20">
                     <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                   </svg>
                 ))}
               </div>
-              <p className="mt-2 text-3xl font-bold">{c.reviews.averageRating}</p>
-              <p className="text-sm text-white/70">aus {c.reviews.totalReviews} Bewertungen</p>
+              <p className="mt-1 text-2xl font-bold">{c.reviews.averageRating}</p>
+              <p className="text-sm text-white/60">aus {c.reviews.totalReviews} Bewertungen</p>
             </div>
           )}
-
-          <h1 className="text-2xl font-bold leading-tight sm:text-4xl">{c.companyName}</h1>
-          <p className="mt-2 text-base text-white/70">{c.contact.address.city} · {c.serviceArea.region}</p>
-
-          <div className="mt-8 flex w-full max-w-xs flex-col gap-3">
-            <a href={`tel:${c.contact.phoneRaw}`} className="flex items-center justify-center gap-2 rounded-full py-3.5 text-base font-semibold text-white" style={{ backgroundColor: accent }}>
-              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z" />
-              </svg>
+          <h1 className="text-2xl font-bold sm:text-3xl">{c.companyName}</h1>
+          <p className="mt-1 text-sm text-white/60">{c.contact.address.city} · {c.serviceArea.region}</p>
+          <div className="mt-7 flex w-full max-w-xs flex-col gap-2.5">
+            <a href={`tel:${c.contact.phoneRaw}`} className="flex items-center justify-center gap-2 rounded-full py-3 text-sm font-bold text-white shadow-lg" style={{ backgroundColor: accent }}>
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z" /></svg>
               Jetzt anrufen
             </a>
-            <a href={wizardUrl} className="flex items-center justify-center rounded-full border border-white/30 py-3.5 text-base font-semibold text-white backdrop-blur-sm transition-colors hover:bg-white/10">
+            <a href={wizardUrl} className="flex items-center justify-center rounded-full border border-white/20 py-3 text-sm font-bold text-white transition-colors hover:bg-white/10">
               Online melden
             </a>
           </div>
         </div>
       </section>
 
-      {/* ── Reviews: 3 grosse lesbare Karten ────────────────── */}
+      {/* ── Bewertungen: 3 grosse Karten ─────────────────── */}
       {c.reviews && c.reviews.highlights.length > 0 && (
         <AnimatedSection animation="slide">
-          <section className="mx-auto max-w-lg px-4 py-12">
-            <h2 className="text-lg font-bold text-gray-900 mb-6">Was Kunden sagen</h2>
-            <div className="space-y-4">
+          <section className="mx-auto max-w-md px-4 py-10">
+            <p className="text-sm font-bold text-gray-900 mb-4">Was Kunden sagen</p>
+            <div className="space-y-3">
               {c.reviews.highlights.slice(0, 3).map((r, i) => (
-                <div key={i} className="rounded-2xl border p-5" style={{ borderColor: "var(--cs-border)", backgroundColor: "var(--cs-card)" }}>
+                <div key={i} className="rounded-3xl bg-gray-50 p-5 shadow-sm">
                   <div className="flex gap-0.5 mb-2">
                     {Array.from({ length: r.rating }).map((_, j) => (
-                      <svg key={j} className="h-4 w-4 text-amber-400" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                      </svg>
+                      <svg key={j} className="h-3.5 w-3.5 text-amber-400" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" /></svg>
                     ))}
                   </div>
-                  <p className="text-sm leading-relaxed text-gray-700">&ldquo;{r.text}&rdquo;</p>
-                  <p className="mt-3 text-xs font-medium text-gray-500">{r.author}</p>
+                  <p className="text-sm leading-relaxed text-gray-600">&ldquo;{r.text}&rdquo;</p>
+                  <p className="mt-2 text-xs font-medium text-gray-400">{r.author}</p>
                 </div>
               ))}
             </div>
@@ -112,73 +83,56 @@ export function LayoutKompakt({ company: c }: { company: CustomerSite }) {
         </AnimatedSection>
       )}
 
-      {/* ── Einzugsgebiet ──────────────────────────────────── */}
+      {/* ── Einsatzgebiet ────────────────────────────────── */}
       <AnimatedSection animation="slide">
-        <section className="mx-auto max-w-lg px-4 py-12">
-          <h2 className="text-lg font-bold text-gray-900 mb-2">Einsatzgebiet</h2>
-          <p className="text-sm text-gray-500 mb-4">{c.serviceArea.region}</p>
-          <div className="flex flex-wrap gap-2">
+        <section className="mx-auto max-w-md px-4 py-10">
+          <p className="text-sm font-bold text-gray-900 mb-3">Einsatzgebiet</p>
+          <div className="flex flex-wrap gap-1.5">
             {c.serviceArea.gemeinden.map((g) => (
-              <span key={g} className="rounded-full px-3 py-1 text-sm font-medium" style={{ backgroundColor: `${accent}10`, color: accent }}>
+              <span key={g} className="rounded-full px-3 py-1 text-xs font-medium shadow-sm" style={{ backgroundColor: `${accent}08`, color: accent, border: `1px solid ${accent}20` }}>
                 {g}
               </span>
             ))}
           </div>
-          {c.contact.mapEmbedUrl && (
-            <div className="mt-6 overflow-hidden rounded-2xl">
-              <iframe src={c.contact.mapEmbedUrl} className="h-48 w-full border-0" loading="lazy" title="Standort" />
-            </div>
-          )}
         </section>
       </AnimatedSection>
 
-      {/* ── Services: Kompakte Chips ────────────────────────── */}
+      {/* ── Leistungen: Aufzählung, KEIN ServiceCard ─────── */}
       <AnimatedSection animation="slide">
-        <section id="leistungen" className="mx-auto max-w-lg px-4 py-12">
-          <h2 className="text-lg font-bold text-gray-900 mb-6">Leistungen</h2>
-          <div className="space-y-3">
-            {c.services.map((s) => {
-              const imgs = galleryMap.get(s.slug) ?? [];
-              return (
-                <ServiceCard
-                  key={s.slug}
-                  name={s.name}
-                  summary={s.summary}
-                  description={s.description}
-                  bullets={s.bullets}
-                  icon={<SvcIcon icon={s.icon} />}
-                  images={imgs}
-                  accent={accent}
-                />
-              );
-            })}
+        <section id="leistungen" className="mx-auto max-w-md px-4 py-10">
+          <p className="text-sm font-bold text-gray-900 mb-4">Leistungen</p>
+          <div className="space-y-2">
+            {c.services.map((s) => (
+              <div key={s.slug} className="rounded-2xl bg-gray-50 px-4 py-3 shadow-sm">
+                <p className="text-sm font-semibold text-gray-800">{s.name}</p>
+                <p className="mt-0.5 text-xs text-gray-500 leading-relaxed">{s.summary}</p>
+              </div>
+            ))}
           </div>
         </section>
       </AnimatedSection>
 
-      {/* ── Kontakt ────────────────────────────────────────── */}
+      {/* ── Kontakt ──────────────────────────────────────── */}
       <AnimatedSection animation="slide">
-        <section id="kontakt" className="mx-auto max-w-lg px-4 py-12">
-          <div className="rounded-2xl p-6 text-center text-white" style={{ backgroundColor: accent }}>
-            <h2 className="text-xl font-bold">Kontakt</h2>
-            <p className="mt-2 text-white/80">{c.contact.address.street}, {c.contact.address.zip} {c.contact.address.city}</p>
-            <a href={`tel:${c.contact.phoneRaw}`} className="mt-4 inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-base font-bold transition-opacity hover:opacity-90" style={{ color: accent }}>
-              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z" />
-              </svg>
+        <section id="kontakt" className="mx-auto max-w-md px-4 py-10">
+          <div className="rounded-3xl p-6 text-center text-white shadow-lg" style={{ backgroundColor: accent }}>
+            <p className="text-lg font-bold">{c.companyName}</p>
+            <p className="mt-1 text-sm text-white/70">{c.contact.address.street}, {c.contact.address.zip} {c.contact.address.city}</p>
+            <a href={`tel:${c.contact.phoneRaw}`} className="mt-5 inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-bold shadow-md" style={{ color: accent }}>
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z" /></svg>
               {c.contact.phone}
             </a>
           </div>
         </section>
       </AnimatedSection>
 
-      {/* ── Footer ─────────────────────────────────────────── */}
-      <footer className="border-t py-6" style={{ borderColor: "var(--cs-border)" }}>
-        <div className="mx-auto flex max-w-lg flex-col items-center gap-2 px-4 text-xs text-gray-400 sm:flex-row sm:justify-between">
+      {/* ── Footer ───────────────────────────────────────── */}
+      <footer className="py-6">
+        <div className="mx-auto flex max-w-md flex-col items-center gap-1 px-4 text-[10px] text-gray-300 sm:flex-row sm:justify-between">
           <span>&copy; {new Date().getFullYear()} {c.companyName}</span>
-          <div className="flex gap-4">
-            <a href={`/kunden/${c.slug}/impressum`} className="hover:text-gray-600">Impressum</a>
-            <a href={`/kunden/${c.slug}/datenschutz`} className="hover:text-gray-600">Datenschutz</a>
+          <div className="flex gap-3">
+            <a href={`/kunden/${c.slug}/impressum`} className="hover:text-gray-500">Impressum</a>
+            <a href={`/kunden/${c.slug}/datenschutz`} className="hover:text-gray-500">Datenschutz</a>
           </div>
         </div>
       </footer>

--- a/src/web/app/kunden/[slug]/layouts/LayoutSystematisch.tsx
+++ b/src/web/app/kunden/[slug]/layouts/LayoutSystematisch.tsx
@@ -1,14 +1,12 @@
 /**
- * LayoutSystematisch — System C: PRÄZISION / KOMPETENZ
+ * LayoutSystematisch — System C: PRÄZISION
  *
- * Structured, grid-based, partner-driven, technical excellence.
- * Like an engineering firm's website. Information > emotion.
- *
- * Used for: Grössere Betriebe (5+ MA), breites Spektrum, viele Partner/Zertifikate
- * Example: Orlandini (17 Markenpartner, 5 Fachbereiche)
+ * HANDSCHRIFT: Scharf, eckig (rounded-md), keine Schatten, scharfe Borders,
+ * Inter Font, Navy-Akzente, strukturiert, Grid-basiert.
+ * KEINE shared ServiceCard. Eigene Service-Grid-Karten.
+ * KEINE generischen Phrasen.
  */
 
-import { ServiceCard } from "../ServiceCard";
 import { AnimatedSection } from "../AnimatedSection";
 import { StickyMobileCTA } from "../StickyMobileCTA";
 import type { CustomerSite, ServiceIcon } from "@/src/lib/customers/types";
@@ -26,7 +24,7 @@ function SvcIcon({ icon }: { icon?: ServiceIcon }) {
     pump: "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z",
   };
   return (
-    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" d={d[icon ?? "tool"] ?? d.tool} />
     </svg>
   );
@@ -38,115 +36,105 @@ export function LayoutSystematisch({ company: c }: { company: CustomerSite }) {
   const heroImg = `/kunden/${c.slug}/hero.jpg`;
   const foundedYear = c.history?.[0]?.year;
   const yearsActive = foundedYear ? new Date().getFullYear() - foundedYear : null;
-  const galleryMap = new Map((c.gallery ?? []).map((g) => [g.slug, g.images]));
 
-  // Key facts for hero cards
-  const keyFacts: { value: string; label: string }[] = [];
-  if (c.services.length > 0) keyFacts.push({ value: String(c.services.length), label: "Fachbereiche" });
-  if (c.brandPartners && c.brandPartners.length > 0) keyFacts.push({ value: String(c.brandPartners.length), label: "Partner" });
-  if (yearsActive && yearsActive >= 5) keyFacts.push({ value: `${yearsActive}+`, label: "Jahre" });
-  if (c.emergency?.enabled) keyFacts.push({ value: "24h", label: "Notdienst" });
+  const facts: { value: string; label: string }[] = [];
+  if (c.services.length > 0) facts.push({ value: String(c.services.length), label: "Fachbereiche" });
+  if (c.brandPartners && c.brandPartners.length > 0) facts.push({ value: String(c.brandPartners.length), label: "Partner" });
+  if (yearsActive && yearsActive >= 5) facts.push({ value: `${yearsActive}+`, label: "Jahre" });
+  if (c.emergency?.enabled) facts.push({ value: "24h", label: "Notdienst" });
 
   return (
-    <div className="min-h-screen cs-font-inter" data-color-mode="cool" style={{ backgroundColor: "var(--cs-surface, #ffffff)" }}>
+    <div className="min-h-screen bg-white" style={{ fontFamily: "var(--font-inter), system-ui, sans-serif" }}>
 
-      {/* ── Nav: Full with links ────────────────────────────── */}
-      <nav className="sticky top-0 z-50 bg-white/95 backdrop-blur-sm shadow-sm">
-        <div className="h-0.5" style={{ backgroundColor: accent }} />
+      {/* ── Nav ───────────────────────────────────────────── */}
+      <nav className="sticky top-0 z-50 bg-white border-b border-gray-200">
+        <div className="h-[3px]" style={{ backgroundColor: accent }} />
         <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-3">
-          <span className="text-lg font-bold" style={{ color: accent }}>{c.companyName}</span>
-          <div className="hidden items-center gap-6 md:flex">
-            <a href="#leistungen" className="text-sm text-gray-600 hover:text-gray-900 transition-colors">Leistungen</a>
+          <span className="text-base font-bold" style={{ color: accent }}>{c.companyName}</span>
+          <div className="hidden items-center gap-5 md:flex">
+            <a href="#fachbereiche" className="text-xs font-medium text-gray-500 hover:text-gray-900 uppercase tracking-wider transition-colors">Fachbereiche</a>
             {c.brandPartners && c.brandPartners.length > 0 && (
-              <a href="#partner" className="text-sm text-gray-600 hover:text-gray-900 transition-colors">Partner</a>
+              <a href="#partner" className="text-xs font-medium text-gray-500 hover:text-gray-900 uppercase tracking-wider transition-colors">Partner</a>
             )}
-            {c.reviews && <a href="#bewertungen" className="text-sm text-gray-600 hover:text-gray-900 transition-colors">Bewertungen</a>}
-            <a href="#kontakt" className="text-sm text-gray-600 hover:text-gray-900 transition-colors">Kontakt</a>
+            <a href="#kontakt" className="text-xs font-medium text-gray-500 hover:text-gray-900 uppercase tracking-wider transition-colors">Kontakt</a>
             <a href={`tel:${c.contact.phoneRaw}`} className="text-sm font-semibold text-gray-700">{c.contact.phone}</a>
-            <a href={wizardUrl} className="rounded-lg px-4 py-2 text-sm font-bold text-white" style={{ backgroundColor: accent }}>
+            <a href={wizardUrl} className="rounded-md px-4 py-2 text-xs font-bold text-white uppercase tracking-wider" style={{ backgroundColor: accent }}>
               Anliegen melden
             </a>
           </div>
-          <a href={`tel:${c.contact.phoneRaw}`} className="rounded-lg px-4 py-2 text-sm font-bold text-white md:hidden" style={{ backgroundColor: accent }}>
+          <a href={`tel:${c.contact.phoneRaw}`} className="rounded-md px-3 py-1.5 text-xs font-bold text-white md:hidden" style={{ backgroundColor: accent }}>
             {c.contact.phone}
           </a>
         </div>
       </nav>
 
-      {/* ── Hero: Vollbild + Key-Fact-Karten ────────────────── */}
-      <section className="relative overflow-hidden text-white" style={{ minHeight: "70vh" }}>
+      {/* ── Hero: Dunkel + Fakten-Karten ─────────────────── */}
+      <section className="relative overflow-hidden text-white" style={{ minHeight: "65vh" }}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src={heroImg} alt={c.companyName} className="absolute inset-0 h-full w-full object-cover" />
-        <div className="absolute inset-0" style={{ background: `linear-gradient(135deg, ${accent}ee 0%, ${accent}cc 40%, ${accent}88 100%)` }} />
-        <div className="relative mx-auto flex min-h-[70vh] max-w-6xl items-center px-6 py-20">
-          <div className="max-w-xl">
-            <h1 className="text-3xl font-bold leading-tight sm:text-4xl lg:text-5xl">{c.companyName}</h1>
-            <p className="mt-4 text-lg text-white/80">{c.tagline}</p>
-            <div className="mt-8 flex gap-4">
-              <a href={wizardUrl} className="rounded-lg px-7 py-3.5 text-base font-semibold text-white transition-opacity hover:opacity-90" style={{ backgroundColor: "rgba(255,255,255,0.2)", backdropFilter: "blur(8px)" }}>
+        <div className="absolute inset-0" style={{ background: `linear-gradient(160deg, ${accent}ee 0%, ${accent}bb 50%, ${accent}77 100%)` }} />
+        <div className="relative mx-auto flex min-h-[65vh] max-w-6xl items-end px-6 pb-12 pt-20 sm:items-center sm:pb-20">
+          <div className="max-w-lg">
+            <h1 className="text-2xl font-bold leading-tight sm:text-4xl lg:text-5xl">{c.companyName}</h1>
+            <p className="mt-3 text-sm text-white/70 leading-relaxed sm:text-base">{c.tagline}</p>
+            <div className="mt-6 flex gap-3">
+              <a href={wizardUrl} className="rounded-md bg-white/15 px-5 py-2.5 text-xs font-bold uppercase tracking-wider text-white backdrop-blur-sm border border-white/20 transition-colors hover:bg-white/25">
                 Anliegen melden
               </a>
-              <a href={`tel:${c.contact.phoneRaw}`} className="rounded-lg border border-white/30 px-7 py-3.5 text-base font-semibold text-white transition-colors hover:bg-white/10">
+              <a href={`tel:${c.contact.phoneRaw}`} className="rounded-md border border-white/20 px-5 py-2.5 text-xs font-bold uppercase tracking-wider text-white transition-colors hover:bg-white/10">
                 Anrufen
               </a>
             </div>
           </div>
-          {/* Key Fact Cards — right side on desktop, below on mobile */}
-          {keyFacts.length > 0 && (
-            <div className="absolute bottom-8 right-6 hidden gap-3 lg:flex">
-              {keyFacts.map((f) => (
-                <div key={f.label} className="rounded-xl bg-white/10 px-5 py-4 text-center backdrop-blur-sm border border-white/10">
-                  <p className="text-2xl font-bold">{f.value}</p>
-                  <p className="text-xs text-white/70">{f.label}</p>
+        </div>
+        {/* Fact-Cards am unteren Rand */}
+        {facts.length > 0 && (
+          <div className="absolute bottom-0 left-0 right-0">
+            <div className="mx-auto flex max-w-6xl gap-px px-6">
+              {facts.map((f) => (
+                <div key={f.label} className="flex-1 bg-white/10 px-4 py-4 text-center backdrop-blur-sm first:rounded-tl-md last:rounded-tr-md border-t border-white/10">
+                  <p className="text-xl font-bold sm:text-2xl">{f.value}</p>
+                  <p className="text-[10px] font-medium uppercase tracking-wider text-white/60">{f.label}</p>
                 </div>
               ))}
             </div>
-          )}
-        </div>
-        {/* Mobile key facts */}
-        {keyFacts.length > 0 && (
-          <div className="flex gap-2 overflow-x-auto px-4 pb-6 lg:hidden">
-            {keyFacts.map((f) => (
-              <div key={f.label} className="flex-shrink-0 rounded-xl bg-white/10 px-4 py-3 text-center backdrop-blur-sm border border-white/10">
-                <p className="text-lg font-bold">{f.value}</p>
-                <p className="text-[10px] text-white/70">{f.label}</p>
-              </div>
-            ))}
           </div>
         )}
       </section>
 
-      {/* ── Services: 3-Col Grid mit Hover ──────────────────── */}
+      {/* ── Fachbereiche: Eigene Grid-Karten, KEIN ServiceCard ── */}
       <AnimatedSection animation="scale">
-        <section id="leistungen" className="py-16">
+        <section id="fachbereiche" className="py-16">
           <div className="mx-auto max-w-6xl px-6">
-            <div className="text-center">
-              <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">Unsere Fachbereiche</h2>
-              <p className="mt-2 text-gray-500">Kompetenz aus einer Hand</p>
-            </div>
-            <div className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-              {c.services.map((s) => {
-                const imgs = galleryMap.get(s.slug) ?? [];
-                return (
-                  <ServiceCard key={s.slug} name={s.name} summary={s.summary} description={s.description} bullets={s.bullets} icon={<SvcIcon icon={s.icon} />} images={imgs} accent={accent} />
-                );
-              })}
+            <p className="text-xs font-bold uppercase tracking-widest text-gray-400">Fachbereiche</p>
+            <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {c.services.map((s) => (
+                <div key={s.slug} className="group border border-gray-200 rounded-md p-5 transition-all hover:border-gray-400 hover:shadow-sm">
+                  <div className="flex items-center gap-3 mb-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-md text-white" style={{ backgroundColor: accent }}>
+                      <SvcIcon icon={s.icon} />
+                    </div>
+                    <h3 className="text-sm font-bold text-gray-900 uppercase tracking-wide">{s.name}</h3>
+                  </div>
+                  <p className="text-sm text-gray-500 leading-relaxed">{s.summary}</p>
+                </div>
+              ))}
             </div>
           </div>
         </section>
       </AnimatedSection>
 
-      {/* ── Partner-Leiste (prominent!) ──────────────────────── */}
+      {/* ── Partner ──────────────────────────────────────── */}
       {c.brandPartners && c.brandPartners.length > 0 && (
         <AnimatedSection animation="scale">
-          <section id="partner" className="border-y py-12" style={{ borderColor: "var(--cs-border)", backgroundColor: "var(--cs-section-alt)" }}>
+          <section id="partner" className="border-y border-gray-200 py-10" style={{ backgroundColor: "#f8fafb" }}>
             <div className="mx-auto max-w-6xl px-6">
-              <p className="mb-6 text-center text-xs font-bold uppercase tracking-widest text-gray-400">Unsere Partner & Marken</p>
-              <div className="flex flex-wrap items-center justify-center gap-4">
+              <p className="text-xs font-bold uppercase tracking-widest text-gray-400 text-center mb-6">Partner & Marken</p>
+              <div className="flex flex-wrap items-center justify-center gap-3">
                 {c.brandPartners.map((p) => (
-                  <a key={p.name} href={p.url ?? "#"} target={p.url ? "_blank" : undefined} rel={p.url ? "noopener noreferrer" : undefined} className="rounded-lg border px-5 py-3 text-sm font-semibold text-gray-700 transition-all hover:shadow-md hover:border-gray-300" style={{ borderColor: "var(--cs-border)", backgroundColor: "var(--cs-card)" }}>
+                  <span key={p.name} className="rounded-md border border-gray-200 bg-white px-4 py-2 text-xs font-semibold text-gray-600 uppercase tracking-wider">
                     {p.name}
-                  </a>
+                  </span>
                 ))}
               </div>
             </div>
@@ -154,43 +142,38 @@ export function LayoutSystematisch({ company: c }: { company: CustomerSite }) {
         </AnimatedSection>
       )}
 
-      {/* ── Zertifikate ────────────────────────────────────── */}
+      {/* ── Zertifikate ──────────────────────────────────── */}
       {c.certifications && c.certifications.length > 0 && (
         <AnimatedSection animation="scale">
-          <section className="py-12">
-            <div className="mx-auto max-w-6xl px-6">
-              <div className="flex flex-wrap justify-center gap-6">
-                {c.certifications.map((cert) => (
-                  <div key={cert.name} className="flex items-center gap-3 rounded-lg border px-5 py-3" style={{ borderColor: "var(--cs-border)" }}>
-                    <svg className="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke={accent}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z" />
-                    </svg>
-                    <div>
-                      <p className="text-sm font-semibold text-gray-800">{cert.name}</p>
-                      {cert.issuer && <p className="text-xs text-gray-400">{cert.issuer}</p>}
-                    </div>
-                  </div>
-                ))}
-              </div>
+          <section className="py-10">
+            <div className="mx-auto max-w-6xl px-6 flex flex-wrap justify-center gap-4">
+              {c.certifications.map((cert) => (
+                <div key={cert.name} className="flex items-center gap-2 rounded-md border border-gray-200 px-4 py-2">
+                  <svg className="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke={accent}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <span className="text-xs font-semibold text-gray-700">{cert.name}</span>
+                </div>
+              ))}
             </div>
           </section>
         </AnimatedSection>
       )}
 
-      {/* ── Karriere ───────────────────────────────────────── */}
+      {/* ── Karriere ─────────────────────────────────────── */}
       {c.careers && c.careers.length > 0 && (
         <AnimatedSection animation="scale">
-          <section className="py-12" style={{ backgroundColor: "var(--cs-section-alt)" }}>
+          <section className="border-t border-gray-200 py-12" style={{ backgroundColor: "#f8fafb" }}>
             <div className="mx-auto max-w-4xl px-6">
-              <h2 className="text-center text-2xl font-bold text-gray-900">Karriere bei {c.companyName}</h2>
-              <div className="mt-8 grid gap-4 sm:grid-cols-2">
+              <p className="text-xs font-bold uppercase tracking-widest text-gray-400 mb-6">Karriere</p>
+              <div className="grid gap-3 sm:grid-cols-2">
                 {c.careers.map((job) => (
-                  <div key={job.title} className="rounded-xl border p-5" style={{ borderColor: "var(--cs-border)", backgroundColor: "var(--cs-card)" }}>
-                    <h3 className="font-semibold text-gray-900">{job.title}</h3>
-                    <span className="mt-1 inline-block rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                  <div key={job.title} className="rounded-md border border-gray-200 bg-white p-4">
+                    <p className="text-sm font-bold text-gray-900">{job.title}</p>
+                    <span className="mt-1 inline-block rounded-md bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 uppercase">
                       {job.type === "fulltime" ? "Vollzeit" : job.type === "apprentice" ? "Lehrstelle" : "Teilzeit"}
                     </span>
-                    <p className="mt-2 text-sm text-gray-500">{job.description}</p>
+                    <p className="mt-2 text-xs text-gray-500">{job.description}</p>
                   </div>
                 ))}
               </div>
@@ -199,38 +182,31 @@ export function LayoutSystematisch({ company: c }: { company: CustomerSite }) {
         </AnimatedSection>
       )}
 
-      {/* ── Reviews ────────────────────────────────────────── */}
+      {/* ── Bewertungen ──────────────────────────────────── */}
       {c.reviews && c.reviews.highlights.length > 0 && (
         <AnimatedSection animation="scale">
-          <section id="bewertungen" className="py-16">
+          <section id="bewertungen" className="py-14">
             <div className="mx-auto max-w-6xl px-6">
-              <div className="text-center">
-                {c.reviews.averageRating >= 4.0 && (
-                  <>
-                    <div className="mb-2 flex items-center justify-center gap-1">
-                      {Array.from({ length: 5 }).map((_, i) => (
-                        <svg key={i} className={`h-6 w-6 ${i < Math.round(c.reviews!.averageRating) ? "text-amber-400" : "text-gray-300"}`} fill="currentColor" viewBox="0 0 20 20">
-                          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                        </svg>
-                      ))}
-                    </div>
-                    <p className="text-xl font-bold text-gray-900">{c.reviews.averageRating} von 5</p>
-                    <p className="text-sm text-gray-500">{c.reviews.totalReviews} Bewertungen</p>
-                  </>
-                )}
-              </div>
-              <div className="mx-auto mt-10 grid max-w-5xl gap-5 sm:grid-cols-2 lg:grid-cols-3">
+              {c.reviews.averageRating >= 4.0 && (
+                <div className="text-center mb-8">
+                  <div className="flex items-center justify-center gap-0.5">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <svg key={i} className={`h-5 w-5 ${i < Math.round(c.reviews!.averageRating) ? "text-amber-400" : "text-gray-200"}`} fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" /></svg>
+                    ))}
+                  </div>
+                  <p className="mt-1 text-sm font-bold text-gray-900">{c.reviews.averageRating} / 5 · {c.reviews.totalReviews} Bewertungen</p>
+                </div>
+              )}
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {c.reviews.highlights.map((r, i) => (
-                  <div key={i} className="rounded-xl border p-5" style={{ borderColor: "var(--cs-border)", backgroundColor: "var(--cs-card)" }}>
-                    <div className="mb-2 flex gap-0.5">
+                  <div key={i} className="rounded-md border border-gray-200 p-4">
+                    <div className="flex gap-0.5 mb-2">
                       {Array.from({ length: r.rating }).map((_, j) => (
-                        <svg key={j} className="h-4 w-4 text-amber-400" fill="currentColor" viewBox="0 0 20 20">
-                          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                        </svg>
+                        <svg key={j} className="h-3 w-3 text-amber-400" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" /></svg>
                       ))}
                     </div>
-                    <p className="text-sm leading-relaxed text-gray-700">&ldquo;{r.text}&rdquo;</p>
-                    <p className="mt-3 text-xs font-medium text-gray-500">{r.author}</p>
+                    <p className="text-xs text-gray-600 leading-relaxed">&ldquo;{r.text}&rdquo;</p>
+                    <p className="mt-2 text-[10px] font-medium text-gray-400">{r.author}</p>
                   </div>
                 ))}
               </div>
@@ -239,25 +215,23 @@ export function LayoutSystematisch({ company: c }: { company: CustomerSite }) {
         </AnimatedSection>
       )}
 
-      {/* ── Einzugsgebiet ──────────────────────────────────── */}
+      {/* ── Einzugsgebiet ────────────────────────────────── */}
       <AnimatedSection animation="scale">
-        <section className="py-12" style={{ backgroundColor: "var(--cs-section-alt)" }}>
+        <section className="border-t border-gray-200 py-12" style={{ backgroundColor: "#f8fafb" }}>
           <div className="mx-auto max-w-6xl px-6">
             <div className="grid gap-8 lg:grid-cols-2">
               <div>
-                <h2 className="text-2xl font-bold text-gray-900">Einzugsgebiet</h2>
-                <p className="mt-2 text-gray-500">{c.serviceArea.region}</p>
-                <div className="mt-4 flex flex-wrap gap-2">
+                <p className="text-xs font-bold uppercase tracking-widest text-gray-400 mb-3">Einzugsgebiet</p>
+                <p className="text-sm text-gray-600">{c.serviceArea.region}</p>
+                <div className="mt-4 flex flex-wrap gap-1.5">
                   {c.serviceArea.gemeinden.map((g) => (
-                    <span key={g} className="rounded-full border px-3 py-1 text-sm text-gray-600" style={{ borderColor: "var(--cs-border)" }}>
-                      {g}
-                    </span>
+                    <span key={g} className="rounded-md border border-gray-200 px-2.5 py-1 text-xs text-gray-500">{g}</span>
                   ))}
                 </div>
               </div>
               {c.contact.mapEmbedUrl && (
-                <div className="overflow-hidden rounded-xl">
-                  <iframe src={c.contact.mapEmbedUrl} className="h-56 w-full border-0" loading="lazy" title="Standort" />
+                <div className="overflow-hidden rounded-md border border-gray-200">
+                  <iframe src={c.contact.mapEmbedUrl} className="h-48 w-full border-0" loading="lazy" title="Standort" />
                 </div>
               )}
             </div>
@@ -265,32 +239,24 @@ export function LayoutSystematisch({ company: c }: { company: CustomerSite }) {
         </section>
       </AnimatedSection>
 
-      {/* ── Kontakt ────────────────────────────────────────── */}
+      {/* ── Kontakt ──────────────────────────────────────── */}
       <AnimatedSection animation="scale">
         <section id="kontakt" className="py-16">
           <div className="mx-auto max-w-6xl px-6">
             <div className="grid gap-8 lg:grid-cols-2">
               <div>
-                <h2 className="text-2xl font-bold text-gray-900">Kontakt</h2>
-                <div className="mt-6 space-y-3">
-                  <p className="font-semibold text-gray-900">{c.companyName}</p>
-                  <p className="text-gray-600">{c.contact.address.street}, {c.contact.address.zip} {c.contact.address.city}</p>
-                  <p><a href={`tel:${c.contact.phoneRaw}`} className="font-medium hover:underline" style={{ color: accent }}>{c.contact.phone}</a></p>
-                  {c.contact.email && <p><a href={`mailto:${c.contact.email}`} className="hover:underline" style={{ color: accent }}>{c.contact.email}</a></p>}
-                  {c.contact.openingHours && c.contact.openingHours.length > 0 && (
-                    <div className="mt-4">
-                      <p className="text-xs font-bold uppercase tracking-wider text-gray-400 mb-1">Öffnungszeiten</p>
-                      {c.contact.openingHours.map((h, i) => <p key={i} className="text-sm text-gray-600">{h}</p>)}
-                    </div>
-                  )}
-                </div>
+                <p className="text-xs font-bold uppercase tracking-widest text-gray-400 mb-4">Kontakt</p>
+                <p className="text-sm font-bold text-gray-900">{c.companyName}</p>
+                <p className="mt-1 text-sm text-gray-500">{c.contact.address.street}, {c.contact.address.zip} {c.contact.address.city}</p>
+                <p className="mt-2"><a href={`tel:${c.contact.phoneRaw}`} className="text-sm font-medium hover:underline" style={{ color: accent }}>{c.contact.phone}</a></p>
+                {c.contact.email && <p className="mt-1"><a href={`mailto:${c.contact.email}`} className="text-sm text-gray-500 hover:underline">{c.contact.email}</a></p>}
               </div>
-              <div className="flex flex-col items-start justify-center gap-4">
-                <a href={wizardUrl} className="w-full rounded-lg py-4 text-center text-base font-semibold text-white transition-opacity hover:opacity-90 sm:w-auto sm:px-8" style={{ backgroundColor: accent }}>
+              <div className="flex flex-col gap-3 justify-center">
+                <a href={wizardUrl} className="rounded-md py-3 text-center text-xs font-bold uppercase tracking-wider text-white" style={{ backgroundColor: accent }}>
                   Anliegen melden
                 </a>
-                <a href={`tel:${c.contact.phoneRaw}`} className="w-full rounded-lg border py-4 text-center text-base font-semibold transition-colors hover:bg-gray-50 sm:w-auto sm:px-8" style={{ borderColor: accent, color: accent }}>
-                  {c.contact.phone}
+                <a href={`tel:${c.contact.phoneRaw}`} className="rounded-md border py-3 text-center text-xs font-bold uppercase tracking-wider" style={{ borderColor: accent, color: accent }}>
+                  Anrufen: {c.contact.phone}
                 </a>
               </div>
             </div>
@@ -298,9 +264,9 @@ export function LayoutSystematisch({ company: c }: { company: CustomerSite }) {
         </section>
       </AnimatedSection>
 
-      {/* ── Footer ─────────────────────────────────────────── */}
-      <footer className="border-t py-8" style={{ borderColor: "var(--cs-border)", backgroundColor: "var(--cs-section-alt)" }}>
-        <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-6 text-xs text-gray-400 sm:flex-row sm:justify-between">
+      {/* ── Footer ───────────────────────────────────────── */}
+      <footer className="border-t border-gray-200 py-6" style={{ backgroundColor: "#f8fafb" }}>
+        <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-6 text-[10px] text-gray-400 uppercase tracking-wider sm:flex-row sm:justify-between">
           <span>&copy; {new Date().getFullYear()} {c.companyName}</span>
           <div className="flex gap-4">
             <a href={`/kunden/${c.slug}/impressum`} className="hover:text-gray-600">Impressum</a>


### PR DESCRIPTION
## Summary
**Letzter ehrlicher Test für Modul 1.** Wenn dieser Proof nicht besteht → Modul 1 in Maschinenform einstellen.

**3 Hebel, nichts anderes:**

1. **ServiceCard.tsx eliminiert** — jedes Layout hat eigene Service-Darstellung
   - Editorial: Bild + Fliessttext (kein Icon, kein "Mehr", kein Overlay)
   - Kompakt: Name + 1 Satz (kein Bild, kein Overlay, rounded-3xl Card)
   - Systematisch: Grid-Card mit Icon + Hover-Border (eigene Implementation)

2. **3 CSS-Handschriften** — keine shared Tailwind-Defaults mehr
   - Editorial: ECKIG, keine Schatten, Serif, py-24, #e0d8cf Borders
   - Kompakt: RUND, weiche Schatten, DM Sans, max-w-md, bg-gray-50
   - Systematisch: SCHARF, scharfe Borders, Inter, uppercase Labels, Navy-Gradient

3. **Generische Phrasen eliminiert** — kein identischer Text auf 2+ Sites

## Kill-Test (Founder)
| # | Frage | PASS | FAIL |
|---|---|---|---|
| K1 | Erkenne ich FlowSight? | Nein | Ja |
| K2 | Fühlen sich die 3 wie eine Familie an? | Nein | Ja |
| K3 | Gleiche Service-DNA? | Nein | Ja |
| K4 | Wirkt eine Site wie UI statt Betrieb? | Nein | Ja |
| K5 | Stammtisch-Test? | Keiner erkennt Verwandtschaft | Mindestens einer |

**5/5 PASS → Modul 1 absegnungsfähig**
**3/5 oder weniger → Modul 1 einstellen**

🤖 Generated with [Claude Code](https://claude.com/claude-code)