### PR TITLE
feat: BigBen Pub Phase 1+2 — events + reservations + management UI

### DIFF
--- a/docs/customers/bigben-pub/onboarding_plan.md
+++ b/docs/customers/bigben-pub/onboarding_plan.md
@@ -1,0 +1,257 @@
+# BigBen Pub — Onboarding-Plan (Erster Kunde)
+
+**Datum:** 2026-04-14
+**Owner:** CC + Founder
+**Kunde:** Paul (BigBen Pub, Oberrieden)
+**Status:** Founder-Go erteilt. Erster zahlender Kunde. Barter-Deal: Freidrinks + Food (~CHF 300/Mo Wert, 3 Jahre).
+**Deadline:** Naechstes Treffen mit Paul (Datum TBD)
+
+---
+
+## Was dieses Onboarding besonders macht
+
+1. **Erster Kunde ueberhaupt** → alles was wir hier lernen, wird zum Standard
+2. **Erste Nicht-Sanitaer-Branche** → beweist Branchen-Flexibilitaet
+3. **Event-Management = neues Produkt-Feature** → existiert noch nicht im System
+4. **Paul kennt uns persoenlich** → weniger Sales-Reibung, mehr Ehrlichkeit im Feedback
+5. **Im Dorf** → spricht sich sofort rum ("Paul hat eine App fuer sein Pub")
+
+---
+
+## Lessons-Learned-Protokoll (wird laufend ergaenzt)
+
+> Jede Entscheidung, jeder Fehler, jede Ueberraschung wird hier dokumentiert.
+> Ziel: Beim zweiten Gastro-Kunden geht alles doppelt so schnell.
+
+| # | Datum | Erkenntnis | Konsequenz |
+|---|-------|-----------|-----------|
+| L1 | 14.04. | Erster Kunde = Barter, nicht Cash. Funktioniert bei persoenlicher Beziehung. | Barter-Modell als Option fuer Referenz-Kunden dokumentieren. |
+| L2 | 14.04. | Gastro braucht Event-Management. Sanitaer nicht. Feature muss modular sein. | pub_events Tabelle = tenant-scoped, nicht global. |
+| L3 | 14.04. | Paul ist faul → Pflege MUSS auf dem Handy passieren, maximal 3 Taps. | Event-Formular: Titel + Datum + Kategorie. Fertig. Kein CMS. |
+| | | | |
+
+---
+
+## Gesamtplan (4 Phasen, parallel zum Founder-Scriptwork)
+
+### Phase 1: Infrastruktur (Tag 1-2)
+
+**1.1 Supabase: Events-Tabelle**
+
+```sql
+CREATE TABLE pub_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id),
+  category TEXT NOT NULL CHECK (category IN ('sport', 'event')),
+  title TEXT NOT NULL,
+  description TEXT,
+  event_date DATE NOT NULL,
+  event_time TIME,
+  end_time TIME,
+  recurring TEXT CHECK (recurring IN ('weekly', 'biweekly', 'monthly', NULL)),
+  recurring_day INTEGER, -- 0=Sun, 1=Mon, ..., 6=Sat (for recurring events)
+  image_url TEXT,
+  is_active BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- RLS: tenant-scoped
+ALTER TABLE pub_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "tenant_isolation" ON pub_events
+  USING (tenant_id = current_setting('app.tenant_id')::UUID);
+```
+
+**1.2 Supabase: Reservierungen-Tabelle**
+
+```sql
+CREATE TABLE pub_reservations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id),
+  guest_name TEXT NOT NULL,
+  guest_phone TEXT NOT NULL,
+  guest_email TEXT,
+  reservation_date DATE NOT NULL,
+  reservation_time TIME NOT NULL,
+  party_size INTEGER NOT NULL DEFAULT 2,
+  note TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'declined', 'cancelled')),
+  confirmed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE pub_reservations ENABLE ROW LEVEL SECURITY;
+```
+
+**1.3 Tenant-Setup**
+
+- BigBen Pub ist bereits als Tenant vorhanden (Demo-Status)
+- Status aendern: DEMO → LIVE
+- Module aktivieren: voice, ops, reviews, sms + NEU: events, reservations
+- notification_email setzen (Pauls E-Mail)
+- OTP-Zugang fuer Paul erstellen
+
+### Phase 2: Event-Pflege-App (Tag 2-3)
+
+**2.1 Neue Leitsystem-Seite: `/ops/events`**
+
+Paul oeffnet seine App → sieht 2 Tabs: "Sport" + "Events"
+
+```
+SPORT-TAB:
+  [+ Neues Spiel]
+  ---
+  Sa 19.04. 17:30  Premier League: Arsenal vs. Chelsea    🗑️
+  So 20.04. 14:00  Rugby: England vs. Ireland             🗑️
+  Mi 23.04. 21:00  Champions League: Halbfinale           🗑️
+
+EVENTS-TAB:
+  [+ Neues Event]
+  ---
+  Mi 16.04.  Quiz Night (wöchentlich)                     🗑️
+  Fr 18.04.  Karaoke Night (wöchentlich)                  🗑️
+  Sa 19.04.  Live Music: The Dublin Boys                  🗑️
+```
+
+**"+ Neues Spiel/Event" Button:**
+- Titel (Pflicht)
+- Datum (Pflicht) — Date-Picker
+- Uhrzeit (Optional) — Time-Picker
+- Beschreibung (Optional) — 1 Zeile
+- Wiederkehrend? (Toggle: woechentlich/einmalig)
+- Speichern → sofort in DB → Website aktualisiert sich
+
+**Maximal 3 Taps fuer ein neues Event:** [+] → Titel tippen → Datum waehlen → Speichern.
+
+**2.2 Reservierungen-Ansicht: `/ops/reservations`**
+
+Paul sieht eingehende Reservierungen:
+
+```
+HEUTE (Sa 19.04.):
+  ✅ 18:00  Markus K. · 4 Pers.  "Geburtstag"
+  ⏳ 19:30  Sarah L.  · 2 Pers.
+  ⏳ 20:00  Tim W.    · 6 Pers.  "Quiz Night table"
+
+[✅ Bestätigen]  [❌ Ablehnen]
+```
+
+Bei Bestaetigung: SMS an Gast ("Your table at BigBen Pub is confirmed for 19:30!")
+Bei Ablehnung: SMS an Gast ("Sorry, we're fully booked. Try calling us at...")
+
+### Phase 3: Voice Agent (Tag 3-4)
+
+**3.1 Agent-Konfiguration**
+
+- **Sprache:** Englisch (Default)
+- **Stimme:** Retell English voice (maennlich, warm, British accent ideal)
+- **Sprachgate:** EN → DE/FR/IT Transfer (wie bei Sanitaer-Agents)
+- **Persona:** "Hi, this is BigBen Pub, Oberrieden. How can I help you?"
+
+**3.2 Use Cases (Prompt-Design)**
+
+| Use Case | Beispiel | Agent-Verhalten |
+|----------|---------|----------------|
+| **Reservierung** | "Table for 4, Saturday 7pm" | Nimmt auf: Name, Telefon, Datum, Zeit, Personen → DB + SMS an Paul |
+| **Events heute** | "What's on tonight?" | Liest aus pub_events (heutiges Datum) → antwortet |
+| **Events diese Woche** | "Any live music this week?" | Liest pub_events (naechste 7 Tage, category=event) → antwortet |
+| **Sport** | "Is there a match on Saturday?" | Liest pub_events (category=sport) → antwortet |
+| **Oeffnungszeiten** | "What time do you open?" | Aus Prompt (hardcoded) |
+| **Speisekarte** | "Do you have food?" | "Yes! We serve proper pub food — burgers, wings, fish & chips. Check our menu on the website." |
+| **Standort** | "Where are you?" | "We're at [Adresse], Oberrieden, right by the lake." |
+| **Preise** | "How much is a Guinness?" | Deflect: "Our drinks start at CHF 5 — best to check at the bar!" |
+| **Sprachswitch** | "Sprechen Sie Deutsch?" | Transfer zu DE-Agent |
+
+**3.3 Retell-Setup**
+
+- Neues Agent-Paar: bigben-pub_agent.json (EN) + bigben-pub_agent_de.json (DE)
+- Webhook: /api/retell/webhook (gleicher wie Sanitaer, tenant-routed)
+- Twilio-Nummer: Neue Schweizer Nummer fuer BigBen
+- retell_sync.mjs → publish
+
+**3.4 Event-Daten im Voice Agent**
+
+Der Agent braucht AKTUELLE Event-Daten. Loesung:
+- Webhook enrichment: Wenn Agent nach Events gefragt wird → API-Call an /api/bigben-pub/events → aktuelle Events aus DB
+- ODER: Agent-Prompt wird taeglich aktualisiert (Cron) mit den naechsten 7 Tagen Events
+- Empfehlung: **Taeglich aktualisierter Prompt** (einfacher, zuverlaessiger als Live-API im Call)
+
+### Phase 4: Website dynamisch + Reservierung E2E (Tag 4-5)
+
+**4.1 Events auf der Website dynamisch laden**
+
+Aktuell: Events sind hardcoded in BigBenContent.tsx
+Neu: Events kommen aus Supabase via API-Route
+
+```
+/api/bigben-pub/events → GET → aktuelle + kommende Events aus pub_events
+```
+
+Website-Darstellung:
+- **Desktop:** 2 Spalten nebeneinander (Sport links, Events rechts)
+- **Mobile:** Sport oben, Events unten
+- Nur zukuenftige Events anzeigen (vergangene automatisch ausblenden)
+- Wiederkehrende Events: naechstes Datum berechnen
+
+**4.2 Reservierungs-API**
+
+```
+POST /api/bigben-pub/reserve
+  → Speichert in pub_reservations (status=pending)
+  → Push-Notification an Paul
+  → SMS an Paul: "Neue Reservierung: {name}, {datum} {zeit}, {personen} Pers."
+  → Response an Gast: "Your reservation request has been received. We'll confirm shortly!"
+
+PATCH /api/ops/reservations/[id]
+  → Paul bestaetigt/ablehnt
+  → SMS an Gast: "Confirmed!" / "Sorry, fully booked."
+```
+
+**4.3 Website Redesign (kennedys.ch Richtung)**
+
+Aenderungen an BigBenContent.tsx:
+- Dunkleres Farbschema (Holz/Braun statt helles Beige)
+- Events-Section: 2-Spalten (Sport | Events) mit Datumsanzeige
+- Reservierungs-CTA prominenter
+- Menu als eigene Section (nicht nur Text)
+- Gallery groesser
+- Insgesamt waermer, Pub-atmosphaerischer
+
+---
+
+## Checkliste vor Treffen mit Paul
+
+- [ ] Events-Tabelle in Supabase erstellt
+- [ ] Event-Pflege (/ops/events) funktioniert auf dem Handy
+- [ ] 5-10 Test-Events eingetragen (Sport + Events der naechsten 2 Wochen)
+- [ ] Voice Agent (EN) antwortet auf "What's on tonight?"
+- [ ] Reservierungs-Flow funktioniert E2E (Form → DB → SMS an Paul)
+- [ ] Website zeigt Events dynamisch (nicht mehr hardcoded)
+- [ ] Paul hat OTP-Zugang (Login per E-Mail-Code)
+- [ ] PWA installierbar auf Pauls Handy
+
+---
+
+## Risiken + Gegenmassnahmen
+
+| Risiko | Wahrscheinlichkeit | Gegenmassnahme |
+|--------|-------------------|---------------|
+| Paul pflegt Events nicht regelmaessig | HOCH (Paul ist faul) | Event-Pflege maximal vereinfachen: 3 Taps. Wiederkehrende Events (Quiz=Mi, Karaoke=Fr) einmal anlegen, dann laeuft es. |
+| Voice Agent versteht Schweizer Akzent schlecht | MITTEL | Retell EN-Agent auf "international English" einstellen, nicht British-strict. Schweizer sprechen "Swiss English". |
+| Reservierungs-No-Shows | MITTEL | Bestaetigungs-SMS mit "Reply CANCEL to cancel". Paul sieht No-Show-Rate in der App. |
+| Sport-Events aendern sich kurzfristig (Verlegung, Absage) | HOCH | Paul muss einzelne Sport-Events loeschen/aendern koennen. App braucht Edit + Delete. |
+| Gaeste erwarten sofortige Reservierungs-Bestaetigung | MITTEL | SMS an Gast: "Received! Paul will confirm within 30 minutes." Nicht "confirmed" — erst nach Paul-Approval. |
+
+---
+
+## Definition of Done (Wann ist Paul LIVE?)
+
+| # | Kriterium | Check |
+|---|----------|-------|
+| 1 | Paul kann Events auf dem Handy pflegen (Sport + Events getrennt) | |
+| 2 | Website zeigt aktuelle Events dynamisch | |
+| 3 | Voice Agent beantwortet "What's on tonight?" korrekt | |
+| 4 | Reservierung E2E funktioniert (Form → Paul-SMS → Gast-SMS) | |
+| 5 | Paul hat seine App auf dem Homescreen (PWA) | |
+| 6 | 10+ Events fuer die naechsten 2 Wochen eingetragen | |
+| 7 | Paul sagt: "Das ist genau was ich brauche" | |

--- a/docs/customers/bigben-pub/projekt_briefing.md
+++ b/docs/customers/bigben-pub/projekt_briefing.md
@@ -1,0 +1,112 @@
+# BigBen Pub — Projekt-Briefing (Paul)
+
+**Datum:** 2026-04-14
+**Status:** Paul hat sich gemeldet. Angetan von der bisherigen Website. Will Voice Agent + Event-System + App.
+**Referenz:** kennedys.ch (Pauls frueherer Arbeitgeber, findet die Website klasse)
+**Prioritaet:** Erster zahlender Nicht-Sanitaer-Kunde? → Founder-Entscheid noetig.
+
+---
+
+## Was Paul will
+
+### 1. Voice Agent (EN default)
+- **Sprache:** Englisch als Default (Pub-Publikum = international)
+- **Switch:** DE, FR, IT on demand (wie bei Sanitaer-Agents, Sprachgate)
+- **Use Cases:**
+  - Reservierungen: "I'd like to book a table for 4 on Saturday at 7pm"
+  - Events-Info: "What's on this weekend?", "Is there a match tonight?"
+  - Oeffnungszeiten: "What time do you open?"
+  - Allgemeine Fragen: "Do you have Guinness on tap?", "Where exactly are you?"
+- **NICHT:** Bestellungen aufnehmen, Preise nennen, Speisekarte vorlesen
+
+### 2. Event-Management (das Kernproblem)
+- **2 Kategorien:** Sport (Fussball, Rugby, etc.) + Events (Quiz, Karaoke, Live Music)
+- **Website-Darstellung:** Links/rechts auf Laptop, oben/unten auf Handy
+- **Pflege:** Paul muss Events NUR ueber sein Handy pflegen koennen
+- **Paul ist faul** → muss maximal einfach sein (kein Login in ein CMS, kein Backend-Dashboard)
+- **Dynamisch:** Wenn Paul ein Event hinzufuegt, aktualisiert sich die Website sofort
+
+**Strukturelles Problem:** Aktuell sind Events hardcoded im React-Code (BigBenContent.tsx). Keine Datenbank, keine Pflege-Moeglichkeit. Muss komplett neu gebaut werden.
+
+**Loesungsansatz:**
+- Events in Supabase (Tabelle: `pub_events`)
+- Felder: `id, tenant_id, category (sport|event), title, date, time, description, recurring (boolean), image_url`
+- PWA-App fuer Paul: `/ops/events` (eigene Seite im Leitsystem, Handy-optimiert)
+- Website liest Events via API (ISR oder client-side fetch)
+
+### 3. Website Richtung kennedys.ch
+- **Was Paul an kennedys.ch gefaellt:**
+  - Dunkles, warmes Farbschema (braun/holz, Pub-Atmosphaere)
+  - Prominente Event/Sport-Anzeige
+  - Professionelle Interior-Fotos
+  - Separate Menuekarte (PDF oder eigene Seite)
+  - Reservierungs-CTA prominent
+- **Was wir schon haben:**
+  - BigBenContent.tsx: Hero, About, Events (hardcoded), Menu, Reviews, Gallery, Reservation, Hours
+  - ReservationForm.tsx: Datum/Zeit/Personen → API (aktuell nur Frontend)
+  - i18n (EN + DE)
+  - Bilder in `/images/kunden/bigben-pub/`
+
+### 4. Reservierungs-E2E
+- **Aktuell:** ReservationForm.tsx existiert, aber KEIN Backend. Form submitted → nichts passiert.
+- **Ziel:** Gast reserviert → Paul bekommt Push/SMS → Paul bestaetigt/ablehnt → Gast bekommt Bestaetigung
+- **Kanaele:**
+  - Gast: Website-Formular ODER Voice Agent ("I'd like to book a table")
+  - Paul: Push-Notification in seiner App + optional SMS
+  - Bestaetigung: SMS an Gast ODER E-Mail
+
+### 5. Paul's App (PWA)
+- **Was Paul auf dem Handy braucht:**
+  - Events hinzufuegen/bearbeiten/loeschen (Sport + Events getrennt)
+  - Reservierungen sehen + bestaetigen/ablehnen
+  - Tagesansicht: "Was ist heute los?" (Events + Reservierungen)
+- **Technisch:** Erweiterung des bestehenden Leitsystems (/ops) mit Pub-spezifischen Seiten
+- **Login:** OTP per E-Mail (wie bei Sanitaer-Kunden)
+
+---
+
+## Strategische Ueberlegung
+
+### Ist BigBen Pub ein FlowSight-Kunde?
+
+**Pro:**
+- Erster zahlender Nicht-Sanitaer-Kunde → beweist Branchen-Flexibilitaet
+- Paul ist begeistert → warmer Lead, kein Kaltakquise-Aufwand
+- Pub im Dorf → spricht sich rum ("Paul hat eine App fuer sein Pub")
+- Gastronomie = geplante Branchen-Erweiterung (laut business_briefing.md)
+
+**Contra:**
+- Komplett neues Produkt (Event-Management, Reservierungen) → Development-Aufwand hoch
+- Voice Agent auf Englisch = neues Territory (Prompts, TTS-Stimme)
+- Website-Redesign = genau das was wir gerade als Maschinenprodukt aufgegeben haben
+- Ablenkt von Doerfler/Leuthold Outreach (die eigentliche Sales-Pipeline)
+
+### Aufwand-Schaetzung (grob)
+
+| Komponente | Aufwand | Prioritaet |
+|-----------|---------|-----------|
+| Voice Agent (EN + Sprachgate) | 4-6h | HOCH (Kernprodukt) |
+| Supabase Events-Tabelle + API | 2-3h | HOCH (Grundlage fuer alles) |
+| Events-Pflege im Leitsystem (/ops/events) | 6-8h | HOCH (Paul braucht das) |
+| Website Events dynamisch (ISR/fetch) | 3-4h | MITTEL |
+| Website Redesign Richtung kennedys.ch | 8-12h | NIEDRIG (Kosmetik, nicht Kernprodukt) |
+| Reservierungs-Backend (DB + Notifications) | 4-6h | MITTEL |
+| **Total** | **~30-40h** | |
+
+### Empfehlung
+
+**Founder-Entscheid noetig.** Das ist kein Quick-Win. 30-40h Development fuer einen einzelnen Pub-Kunden. ABER: wenn Paul zahlt (CHF 299/Mo) und das Wort im Dorf verbreitet, ist es ein strategischer Investment.
+
+**Vorschlag: Phased approach.**
+- **Phase 1 (1 Woche):** Voice Agent + Events-Tabelle + Events-Pflege → Paul kann sofort Events pflegen und Anrufe werden beantwortet
+- **Phase 2 (1 Woche):** Reservierungs-Backend + Website Events dynamisch → E2E-Flow funktioniert
+- **Phase 3 (bei Bedarf):** Website-Redesign Richtung kennedys.ch → nur wenn Paul es explizit will und zahlt
+
+---
+
+## Naechste Schritte (Founder-Entscheid)
+
+1. Will Founder Paul als Kunden aufnehmen? (JA/NEIN)
+2. Wenn JA: Welches Pricing? (CHF 299 Standard? Oder Custom weil Gastronomie?)
+3. Wenn JA: Phased approach oder alles auf einmal?
+4. Wann starten? (Nach Doerfler-Outreach oder parallel?)

--- a/src/web/app/api/bigben-pub/events/[id]/route.ts
+++ b/src/web/app/api/bigben-pub/events/[id]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceClient } from "@/src/lib/supabase/server";
+import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
+
+// ---------------------------------------------------------------------------
+// PATCH /api/bigben-pub/events/[id] — Update event
+// ---------------------------------------------------------------------------
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const scope = await resolveTenantScope();
+  if (!scope || scope.isProspect) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const supabase = getServiceClient();
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const allowed = ["title", "description", "event_date", "event_time", "end_time", "category", "image_url", "is_active"];
+  const update: Record<string, unknown> = {};
+  for (const key of allowed) {
+    if (key in body) update[key] = body[key];
+  }
+  update.updated_at = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from("pub_events")
+    .update(update)
+    .eq("id", id)
+    .select("id, category, title, event_date, event_time, is_active")
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data);
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/bigben-pub/events/[id] — Soft-delete (is_active = false)
+// ---------------------------------------------------------------------------
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const scope = await resolveTenantScope();
+  if (!scope || scope.isProspect) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const supabase = getServiceClient();
+
+  const { error } = await supabase
+    .from("pub_events")
+    .update({ is_active: false, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ deleted: true });
+}

--- a/src/web/app/api/bigben-pub/events/route.ts
+++ b/src/web/app/api/bigben-pub/events/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceClient } from "@/src/lib/supabase/server";
+import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
+
+// ---------------------------------------------------------------------------
+// GET /api/bigben-pub/events — Public: returns upcoming events (next 21 days)
+// ---------------------------------------------------------------------------
+export async function GET(request: NextRequest) {
+  const supabase = getServiceClient();
+  const url = new URL(request.url);
+  const days = parseInt(url.searchParams.get("days") ?? "21", 10);
+  const category = url.searchParams.get("category"); // "sport" | "event" | null (all)
+
+  const today = new Date().toISOString().split("T")[0];
+  const future = new Date(Date.now() + days * 86400000).toISOString().split("T")[0];
+
+  // Find BigBen Pub tenant
+  const { data: tenant } = await supabase
+    .from("tenants")
+    .select("id")
+    .eq("slug", "bigben-pub")
+    .single();
+
+  if (!tenant) {
+    return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+  }
+
+  let query = supabase
+    .from("pub_events")
+    .select("id, category, title, description, event_date, event_time, end_time, image_url")
+    .eq("tenant_id", tenant.id)
+    .eq("is_active", true)
+    .gte("event_date", today)
+    .lte("event_date", future)
+    .order("event_date")
+    .order("event_time");
+
+  if (category) {
+    query = query.eq("category", category);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ events: data ?? [] });
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/bigben-pub/events — Auth required: create a new event
+// ---------------------------------------------------------------------------
+export async function POST(request: NextRequest) {
+  const scope = await resolveTenantScope();
+  if (!scope || scope.isProspect) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = getServiceClient();
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { category, title, event_date, event_time, end_time, description, image_url } = body as {
+    category?: string;
+    title?: string;
+    event_date?: string;
+    event_time?: string;
+    end_time?: string;
+    description?: string;
+    image_url?: string;
+  };
+
+  if (!category || !title || !event_date) {
+    return NextResponse.json({ error: "category, title, event_date required" }, { status: 400 });
+  }
+
+  if (!["sport", "event"].includes(category)) {
+    return NextResponse.json({ error: "category must be 'sport' or 'event'" }, { status: 400 });
+  }
+
+  // Resolve tenant — use BigBen Pub tenant
+  const { data: tenant } = await supabase
+    .from("tenants")
+    .select("id")
+    .eq("slug", "bigben-pub")
+    .single();
+
+  if (!tenant) {
+    return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+  }
+
+  const { data, error } = await supabase
+    .from("pub_events")
+    .insert({
+      tenant_id: tenant.id,
+      category,
+      title,
+      event_date,
+      event_time: event_time || null,
+      end_time: end_time || null,
+      description: description || null,
+      image_url: image_url || null,
+      is_active: true,
+    })
+    .select("id, category, title, event_date, event_time")
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/web/app/api/bigben-pub/reserve/route.ts
+++ b/src/web/app/api/bigben-pub/reserve/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
+import { getServiceClient } from "@/src/lib/supabase/server";
 import { sendSms } from "@/src/lib/sms/sendSms";
 
 /**
  * POST /api/bigben-pub/reserve — Table reservation for Big Ben Pub.
  *
- * Sends SMS confirmation to guest + notification SMS to Paul.
- * No DB write for now — Paul gets all info via SMS.
+ * 1. Saves to pub_reservations (status = pending)
+ * 2. SMS notification to Paul (owner)
+ * 3. SMS confirmation to guest ("received, we'll confirm shortly")
  */
 
 const PAUL_PHONE = process.env.BIGBEN_OWNER_PHONE ?? "";
@@ -22,12 +24,35 @@ export async function POST(req: Request) {
     const time = (body.time ?? "").trim();
     const guests = (body.guests ?? "").toString().trim();
     const note = (body.note ?? "").trim();
+    const source = (body.source ?? "website").trim();
 
     if (!name || !phone || !date || !time || !guests) {
       return NextResponse.json(
         { error: "All fields are required." },
         { status: 400 },
       );
+    }
+
+    // ── Save to DB ────────────────────────────────────────────────
+    const supabase = getServiceClient();
+    const { data: tenant } = await supabase
+      .from("tenants")
+      .select("id")
+      .eq("slug", "bigben-pub")
+      .single();
+
+    if (tenant) {
+      await supabase.from("pub_reservations").insert({
+        tenant_id: tenant.id,
+        guest_name: name,
+        guest_phone: phone,
+        reservation_date: date,
+        reservation_time: time,
+        party_size: parseInt(guests, 10) || 2,
+        note: note || null,
+        source,
+        status: "pending",
+      });
     }
 
     // Format date for display
@@ -38,37 +63,37 @@ export async function POST(req: Request) {
       month: "long",
     });
 
-    // ── SMS to guest ──────────────────────────────────────────────
+    // ── SMS to guest (received, not yet confirmed) ─────────────────
     const guestSms = [
-      `Hi ${name},`,
+      `Hi ${name}!`,
       ``,
-      `Your table at Big Ben Pub is reserved:`,
+      `Your reservation request at Big Ben Pub:`,
       `${dateStr} at ${time}, ${guests} ${Number(guests) === 1 ? "guest" : "guests"}.`,
-      note ? `Note: ${note}` : "",
       ``,
+      `Paul will confirm shortly.`,
       `Alte Landstrasse 20, 8942 Oberrieden`,
-      `See you there!`,
     ]
-      .filter(Boolean)
       .join("\n");
 
     const guestResult = await sendSms(phone, guestSms, "BigBenPub");
 
     // ── SMS to Paul (owner) ───────────────────────────────────────
-    const ownerSms = [
-      `NEW BOOKING`,
-      `${dateStr} at ${time}`,
-      `${guests} guests — ${name}`,
-      `Phone: ${phone}`,
-      note ? `Note: ${note}` : "",
-    ]
-      .filter(Boolean)
-      .join("\n");
-
-    // Send to Paul if configured
     if (PAUL_PHONE) {
+      const ownerSms = [
+        `NEW BOOKING`,
+        `${dateStr} at ${time}`,
+        `${guests} guests — ${name}`,
+        `Phone: ${phone}`,
+        note ? `Note: ${note}` : "",
+        ``,
+        `Open app to confirm or decline.`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
       await sendSms(PAUL_PHONE, ownerSms, "BigBenPub");
     }
+
     console.log(
       JSON.stringify({
         ...base,
@@ -77,7 +102,9 @@ export async function POST(req: Request) {
         date,
         time,
         guests,
+        source,
         sms_guest: guestResult.sent ? "sent" : guestResult.reason,
+        db: tenant ? "saved" : "no_tenant",
       }),
     );
 
@@ -86,13 +113,6 @@ export async function POST(req: Request) {
     Sentry.captureException(err, {
       tags: { _tag: "bigben_reservation", decision: "failed" },
     });
-    console.log(
-      JSON.stringify({
-        ...base,
-        decision: "failed",
-        error: err instanceof Error ? err.message : "unknown",
-      }),
-    );
     return NextResponse.json(
       { error: "Something went wrong. Please try again." },
       { status: 500 },

--- a/src/web/app/ops/(dashboard)/events/EventManager.tsx
+++ b/src/web/app/ops/(dashboard)/events/EventManager.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface PubEvent {
+  id: string;
+  category: string;
+  title: string;
+  description: string | null;
+  event_date: string;
+  event_time: string | null;
+  end_time: string | null;
+  is_active: boolean;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + "T12:00:00");
+  const day = d.toLocaleDateString("de-CH", { weekday: "short", timeZone: "Europe/Zurich" }).replace(/\.$/, "");
+  const date = d.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", timeZone: "Europe/Zurich" });
+  return `${day} ${date}`;
+}
+
+function formatTime(time: string | null): string {
+  if (!time) return "";
+  return time.substring(0, 5);
+}
+
+export function EventManager({ events }: { events: PubEvent[] }) {
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState<"sport" | "event">("sport");
+  const [showForm, setShowForm] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  // Form state
+  const [title, setTitle] = useState("");
+  const [eventDate, setEventDate] = useState("");
+  const [eventTime, setEventTime] = useState("");
+  const [description, setDescription] = useState("");
+
+  const sportEvents = events.filter((e) => e.category === "sport");
+  const pubEvents = events.filter((e) => e.category === "event");
+  const displayedEvents = activeTab === "sport" ? sportEvents : pubEvents;
+
+  async function handleSave() {
+    if (!title.trim() || !eventDate) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/bigben-pub/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          category: activeTab,
+          title: title.trim(),
+          event_date: eventDate,
+          event_time: eventTime || null,
+          description: description.trim() || null,
+        }),
+      });
+      if (res.ok) {
+        setTitle("");
+        setEventDate("");
+        setEventTime("");
+        setDescription("");
+        setShowForm(false);
+        router.refresh();
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setDeleting(id);
+    try {
+      await fetch(`/api/bigben-pub/events/${id}`, { method: "DELETE" });
+      router.refresh();
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-bold text-gray-900">Events</h1>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex rounded-xl bg-gray-100 p-1">
+        <button
+          onClick={() => { setActiveTab("sport"); setShowForm(false); }}
+          className={`flex-1 rounded-lg py-2.5 text-sm font-semibold transition-colors ${
+            activeTab === "sport" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500"
+          }`}
+        >
+          Sport ({sportEvents.length})
+        </button>
+        <button
+          onClick={() => { setActiveTab("event"); setShowForm(false); }}
+          className={`flex-1 rounded-lg py-2.5 text-sm font-semibold transition-colors ${
+            activeTab === "event" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500"
+          }`}
+        >
+          Events ({pubEvents.length})
+        </button>
+      </div>
+
+      {/* Add button */}
+      <button
+        onClick={() => setShowForm(!showForm)}
+        className="w-full rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
+      >
+        {showForm ? "Abbrechen" : activeTab === "sport" ? "+ Neues Spiel" : "+ Neues Event"}
+      </button>
+
+      {/* Add form */}
+      {showForm && (
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm space-y-3">
+          <input
+            type="text"
+            placeholder={activeTab === "sport" ? "z.B. Premier League: Arsenal vs. Chelsea" : "z.B. Quiz Night"}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:outline-none"
+            autoFocus
+          />
+          <div className="flex gap-2">
+            <input
+              type="date"
+              value={eventDate}
+              onChange={(e) => setEventDate(e.target.value)}
+              className="flex-1 rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-gray-400 focus:outline-none"
+            />
+            <input
+              type="time"
+              value={eventTime}
+              onChange={(e) => setEventTime(e.target.value)}
+              className="w-28 rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-gray-400 focus:outline-none"
+            />
+          </div>
+          <input
+            type="text"
+            placeholder="Kurze Beschreibung (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:outline-none"
+          />
+          <button
+            onClick={handleSave}
+            disabled={saving || !title.trim() || !eventDate}
+            className="w-full rounded-lg bg-gray-900 py-2.5 text-sm font-semibold text-white disabled:opacity-40 transition-colors hover:bg-gray-800"
+          >
+            {saving ? "Speichert..." : "Speichern"}
+          </button>
+        </div>
+      )}
+
+      {/* Event list */}
+      <div className="space-y-2">
+        {displayedEvents.length === 0 && (
+          <p className="py-8 text-center text-sm text-gray-400">
+            {activeTab === "sport" ? "Keine Spiele eingetragen." : "Keine Events eingetragen."}
+          </p>
+        )}
+        {displayedEvents.map((e) => (
+          <div
+            key={e.id}
+            className="flex items-center justify-between rounded-xl border border-gray-100 bg-white px-4 py-3 shadow-sm"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-semibold text-gray-400">{formatDate(e.event_date)}</span>
+                {e.event_time && (
+                  <span className="text-xs text-gray-400">{formatTime(e.event_time)}</span>
+                )}
+              </div>
+              <p className="mt-0.5 text-sm font-medium text-gray-900 truncate">{e.title}</p>
+              {e.description && (
+                <p className="mt-0.5 text-xs text-gray-500 truncate">{e.description}</p>
+              )}
+            </div>
+            <button
+              onClick={() => handleDelete(e.id)}
+              disabled={deleting === e.id}
+              className="ml-3 flex-shrink-0 rounded-lg p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors disabled:opacity-40"
+              title="Löschen"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+              </svg>
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/web/app/ops/(dashboard)/events/page.tsx
+++ b/src/web/app/ops/(dashboard)/events/page.tsx
@@ -1,0 +1,40 @@
+import { getServiceClient } from "@/src/lib/supabase/server";
+import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
+import { redirect } from "next/navigation";
+import { EventManager } from "./EventManager";
+
+export default async function EventsPage() {
+  const scope = await resolveTenantScope();
+  if (!scope) redirect("/ops/login");
+
+  const supabase = getServiceClient();
+
+  // Check if tenant has events module
+  const tenantId = scope.tenantId;
+  if (!tenantId) redirect("/ops/cases");
+
+  const { data: tenant } = await supabase
+    .from("tenants")
+    .select("modules")
+    .eq("id", tenantId)
+    .single();
+
+  const modules = (tenant?.modules ?? {}) as Record<string, unknown>;
+  if (!modules.events) redirect("/ops/cases");
+
+  // Load upcoming events (next 60 days)
+  const today = new Date().toISOString().split("T")[0];
+  const future = new Date(Date.now() + 60 * 86400000).toISOString().split("T")[0];
+
+  const { data: events } = await supabase
+    .from("pub_events")
+    .select("id, category, title, description, event_date, event_time, end_time, is_active")
+    .eq("tenant_id", tenantId)
+    .eq("is_active", true)
+    .gte("event_date", today)
+    .lte("event_date", future)
+    .order("event_date")
+    .order("event_time");
+
+  return <EventManager events={events ?? []} />;
+}

--- a/supabase/migrations/20260414000000_pub_events_and_reservations.sql
+++ b/supabase/migrations/20260414000000_pub_events_and_reservations.sql
@@ -1,0 +1,78 @@
+-- BigBen Pub: Events + Reservations tables
+-- Used by /ops/events (pub owner manages events) and /api/bigben-pub/ routes
+
+-- ── pub_events: Sport matches + pub events ──────────────────────
+CREATE TABLE IF NOT EXISTS pub_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  category TEXT NOT NULL CHECK (category IN ('sport', 'event')),
+  title TEXT NOT NULL,
+  description TEXT,
+  event_date DATE NOT NULL,
+  event_time TIME,
+  end_time TIME,
+  image_url TEXT,
+  is_active BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_pub_events_tenant_date ON pub_events (tenant_id, event_date);
+CREATE INDEX idx_pub_events_category ON pub_events (tenant_id, category, event_date);
+
+ALTER TABLE pub_events ENABLE ROW LEVEL SECURITY;
+
+-- Service role bypasses RLS; authenticated users see their tenant's events
+CREATE POLICY "pub_events_tenant_read" ON pub_events
+  FOR SELECT USING (true); -- Public read (events are shown on website)
+
+CREATE POLICY "pub_events_tenant_write" ON pub_events
+  FOR ALL USING (
+    tenant_id IN (
+      SELECT (raw_app_meta_data->>'tenant_id')::UUID
+      FROM auth.users
+      WHERE id = auth.uid()
+    )
+  );
+
+-- ── pub_reservations: Table bookings ────────────────────────────
+CREATE TABLE IF NOT EXISTS pub_reservations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  guest_name TEXT NOT NULL,
+  guest_phone TEXT NOT NULL,
+  guest_email TEXT,
+  reservation_date DATE NOT NULL,
+  reservation_time TIME NOT NULL,
+  party_size INTEGER NOT NULL DEFAULT 2,
+  note TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'declined', 'cancelled', 'no_show')),
+  source TEXT DEFAULT 'website' CHECK (source IN ('website', 'voice', 'manual', 'phone')),
+  confirmed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_pub_reservations_tenant_date ON pub_reservations (tenant_id, reservation_date);
+
+ALTER TABLE pub_reservations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "pub_reservations_insert" ON pub_reservations
+  FOR INSERT WITH CHECK (true); -- Anyone can make a reservation (website/voice)
+
+CREATE POLICY "pub_reservations_tenant_read" ON pub_reservations
+  FOR SELECT USING (
+    tenant_id IN (
+      SELECT (raw_app_meta_data->>'tenant_id')::UUID
+      FROM auth.users
+      WHERE id = auth.uid()
+    )
+  );
+
+CREATE POLICY "pub_reservations_tenant_update" ON pub_reservations
+  FOR UPDATE USING (
+    tenant_id IN (
+      SELECT (raw_app_meta_data->>'tenant_id')::UUID
+      FROM auth.users
+      WHERE id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
**Erster zahlender Kunde: Paul (BigBen Pub, Oberrieden).** Barter-Deal (Freidrinks).

**Phase 1: Infrastruktur**
- `pub_events` + `pub_reservations` Supabase-Tabellen mit RLS
- Tenant erstellt (bigben-pub, converted)
- 17 Seed-Events (7 Sport + 10 Pub Events, nächste 21 Tage)

**Phase 2: Event-Management + Reservierungen**
- `/ops/events` — Sport/Events Tabs, 3-Tap-Pflege, Mobile-first
- Events API (GET public, POST/PATCH/DELETE auth)
- Reservation API upgraded: DB-Speicherung + SMS an Paul + Gast

## Test plan
- [ ] /ops/events → Sport-Tab zeigt 7 Spiele, Events-Tab zeigt 10 Events
- [ ] Neues Event hinzufügen: Titel + Datum → Speichern → erscheint in Liste
- [ ] Event löschen → verschwindet
- [ ] GET /api/bigben-pub/events → JSON mit 17 Events
- [ ] POST /api/bigben-pub/reserve → Reservierung in DB + SMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)