### PR TITLE
feat: Bewertungen v2 — 10 Go-Live fixes (Review Surface, Stammkunden, Negative Alerts, Toggles)

### DIFF
--- a/docs/redesign/leitstand/plan_bewertungen_v2.md
+++ b/docs/redesign/leitstand/plan_bewertungen_v2.md
@@ -1,0 +1,263 @@
+# Bewertungen v2 — Fundierte Analyse + Plan
+
+**Datum:** 2026-04-15
+**Anlass:** Founder-Test DA-0073 + DA-0071. Mehrere Luecken entdeckt. Thema ist business-kritisch — jeder Fehler hier faellt auf den Founder zurueck.
+**Feedback:** FB15-FB21
+
+---
+
+## 1. Ist-Zustand (was funktioniert, was nicht)
+
+### Was FUNKTIONIERT (bestaetigt durch Founder-Test)
+
+- **Review Surface** (FB15 + FB18): Sieht gut aus. Doerfler AG gebrandet, Auftragsblock (Leck, 8942 Oberrieden, 14.04.2026), 5 Sterne klickbar, 4 Chips, Freitextfeld, "Jetzt auf Google bewerten" Button. Das ist solide.
+- **Bewertungsanfrage-Button** (FB19): Im Verlauf sichtbar mit "Noch Bewertung moeglich" Badge. Betrieb sieht WANN er anfragen kann. Das ist besser als ich dachte.
+- **E-Mail kommt an** (FB16): Doerfler AG E-Mail in Outlook sichtbar. Betreff "Wie war unser Service? — Doerfler AG". Gebrandete HTML-Karte mit CTA-Button.
+- **KPIs** (FB21): FlowBar zeigt Bewertungen (Ø 4.7, erhalten/angefragt). Das reicht analytisch.
+- **Pre-Filter**: ≥4★ zeigt Google-Link, ≤3★ zeigt nur Feedback-Textarea. Funktioniert.
+
+### Was NICHT funktioniert (Founder-Test beweist es)
+
+| # | Problem | Schwere | Beweis |
+|---|---------|---------|--------|
+| **B1** | **24h Termin-Reminder kommt nicht** | HOCH | DA-0073: Termin 16.04. 08:30 gesetzt am 15.04. 08:25. Kein SMS/E-Mail an Kunden nach 14 Min. |
+| **B2** | **SMS-Bestaetigung bei Wizard-Fall fehlt** | HOCH | DA-0073: Wizard-Fall erstellt, E-Mail kam, aber KEIN SMS obwohl Toggle aktiv (FB17) |
+| **B3** | **Push-Notification bei Bewertungseingang fehlt** | MITTEL | FB18: Bewertung abgeschickt, kein Push an Betrieb |
+| **B4** | **Google-Uebergang holprig** | MITTEL | FB15: Text auf FlowSight geschrieben → Google oeffnet leer → Kunde muss neu schreiben |
+| **B5** | **Kein Google-Konto = Sackgasse** | MITTEL | Button "Jetzt auf Google bewerten" setzt Google-Login voraus. Was wenn Kunde keines hat? |
+| **B6** | **Stammkunden-Schutz fehlt** | HOCH | Wenn Kunde 3x/Jahr beim Betrieb ist, bekommt er 3x Bewertungsanfrage. Das nervt und fuehrt zum Betriebswechsel. |
+| **B7** | **Negative Bewertungen unsichtbar** | MITTEL | ≤3★ Feedback landet in DB, aber Betrieb sieht es nicht proaktiv (kein Alert, kein Badge) |
+| **B8** | **E-Mail vs. SMS: Welcher Kanal?** | KLAERUNGS-BEDARF | FB16 zeigt E-Mail. SMS noch nicht getestet. Was bevorzugt der Kunde? |
+
+---
+
+## 2. Die zwei Perspektiven die wir PERFEKT verstehen muessen
+
+### Perspektive KUNDE (Endkunde des Betriebs)
+
+**Situation:** Hat gerade einen Sanitaer-Einsatz hinter sich. Dichtung repariert, Leck behoben, Heizung gewartet. Ist zufrieden (oder nicht).
+
+**Was der Kunde WILL:**
+- In Ruhe gelassen werden, ausser der Service war wirklich gut
+- Wenn er bewertet: schnell, unkompliziert, 30 Sekunden maximal
+- Nicht genervt werden mit wiederholten Anfragen
+- Kein Account erstellen muessen (kein Google-Login-Zwang)
+- Wissen dass sein Feedback ankommt (nicht ins Leere schreiben)
+
+**Was den Kunden NERVT:**
+- Bewertungsanfrage fuer einen Miniauftrag (Dichtung wechseln = 5 Min = keine Bewertung wert)
+- Mehrfache Anfragen im selben Jahr ("Schon wieder die?")
+- Google-Login als Pflicht ("Ich hab kein Google-Konto / will mich nicht einloggen")
+- Unpersoenliche E-Mail ("Wer ist das? Spam?")
+- Kein Bezug zum konkreten Einsatz ("Welcher Service?")
+
+**Emotionale Kette (ideal):**
+```
+Einsatz erledigt → 1-2 Tage spaeter persoenliche SMS/E-Mail
+→ "Frau Mueller, wie war unser Einsatz bei Ihnen in der Seestrasse?"
+→ Klick → 5 Sterne → "Schnell & zuverlaessig" klicken → fertig (30 Sek)
+→ Optional: "Moechten Sie das auch auf Google teilen?" (KEIN Zwang)
+```
+
+### Perspektive BETRIEB (Inhaber / Geschaeftsfuehrer)
+
+**Situation:** Hat 10-50 Faelle pro Monat. Will gute Google-Bewertungen weil die direkt zu Neukunden fuehren. Hat aber keine Zeit fuer manuelles Nachfassen.
+
+**Was der Betrieb WILL:**
+- Automatisch die richtigen Kunden zur richtigen Zeit fragen
+- NIE einen unzufriedenen Kunden auf Google schicken
+- Sofort wissen wenn eine negative Bewertung reinkommt
+- Sehen wieviele Bewertungen er hat und wie der Trend ist
+- Keine Reibung mit Stammkunden (die sollen NICHT genervt werden)
+
+**Was den Betrieb SCHADET:**
+- Stammkunde wird 3x/Jahr gefragt → wechselt den Betrieb
+- Unzufriedener Kunde bekommt Google-Link → 1-Stern-Bewertung oeffentlich
+- Betrieb weiss nicht dass Kunde negatives Feedback gegeben hat → kein Follow-up
+- Bewertungsanfrage geht raus ohne dass Betrieb es wollte (Auto-Trigger)
+
+---
+
+## 3. Konkrete Probleme + Loesungen
+
+### B1: 24h Termin-Reminder kommt nicht
+
+**Problem:** Toggle "24h Erinnerung an Kunden per SMS" ist aktiv (FB17), aber es passiert nichts.
+
+**Root Cause:** Der Reminder braucht einen Cron-Job der taeglich alle Termine der naechsten 24h prueft und SMS/E-Mails versendet. Dieser Cron-Job existiert NICHT. Der Toggle in den Einstellungen ist ein UI-Element ohne Backend.
+
+**Loesung:** GH Actions Cron (taeglich 07:00 UTC) → API-Route `/api/lifecycle/termin-reminder` → prueft alle Termine morgen → sendet SMS/E-Mail an Kunden mit Kontaktdaten.
+
+**Aufwand:** 3-4h
+
+### B2: SMS-Bestaetigung bei Wizard-Fall fehlt
+
+**Problem:** Wizard-Fall erstellt, E-Mail kam, aber keine SMS. FB17 zeigt "SMS Bestaetigung an Kunden" ist aktiviert.
+
+**Root Cause pruefen:** Wizard-Route (`/api/cases`) sendet E-Mail (Resend), aber moeglicherweise keine SMS. SMS wird nur bei Voice-Faellen gesendet (Post-Call SMS). Toggle in Einstellungen existiert aber Backend ignoriert ihn fuer Wizard.
+
+**Loesung:** In `/api/cases` Route bei Wizard-Faellen pruefen ob `notify_termin_sms` aktiv ist → wenn ja, SMS-Bestaetigung senden.
+
+**Aufwand:** 1-2h
+
+### B3: Push bei Bewertungseingang
+
+**Problem:** Bewertung abgeschickt (FB18), kein Push an Betrieb.
+
+**Root Cause pruefen:** `rate/route.ts` ruft `sendOpsPush()` auf (fire-and-forget). Entweder Push nicht registriert oder Event-Type nicht korrekt.
+
+**Loesung:** Pruefen ob Push-Subscription fuer Doerfler existiert. Wenn nicht: Push-Onboarding-Banner aktivieren. Wenn ja: Debugging des Push-Versands.
+
+**Aufwand:** 1h
+
+### B4: Google-Uebergang (Text nicht kopiert)
+
+**Problem:** Kunde schreibt auf FlowSight-Surface → klickt "Jetzt auf Google bewerten" → Google oeffnet LEER → Kunde muss nochmal schreiben.
+
+**Loesung:** Beim Klick auf "Jetzt auf Google bewerten":
+1. Text aus Textarea + ausgewaehlte Chips in Clipboard kopieren (navigator.clipboard.writeText)
+2. Kurze Bestaetigung: "Text in Zwischenablage kopiert! Einfach auf Google einfuegen."
+3. DANN Google-Link oeffnen
+
+**Aufwand:** 30 Min
+
+### B5: Kein Google-Konto
+
+**Problem:** "Jetzt auf Google bewerten" fuehrt zu Google → Login erforderlich. Nicht jeder hat ein Google-Konto (aeltere Kunden, Firmenkunden).
+
+**Loesung:** Button-Text aendern zu: "Auf Google teilen (optional)". Darunter: "Ihre Bewertung wurde bereits gespeichert. Vielen Dank!" → klarstellen dass die interne Bewertung REICHT. Google ist ein Bonus, kein Pflicht.
+
+**Aufwand:** 15 Min
+
+### B6: Stammkunden-Schutz (KRITISCH)
+
+**Problem:** Kunde hat 3 Faelle/Jahr beim selben Betrieb. Aktuell: 3x Bewertungsanfrage moeglich. Das nervt und schadet der Beziehung.
+
+**Loesung — Stammkunden-Erkennung:**
+1. Bei "Bewertung anfragen" pruefen: Hat dieser Kunde (contact_phone ODER contact_email) in den letzten 6 Monaten schon eine Bewertungsanfrage erhalten?
+2. Wenn JA → Warnung an Betrieb: "Dieser Kunde wurde am [Datum] bereits um eine Bewertung gebeten. Trotzdem senden?"
+3. Empfehlung im UI: "Bei Stammkunden empfehlen wir maximal 1 Bewertungsanfrage pro Jahr."
+
+**Technisch:** Bei `request-review` API-Route: Query auf `case_events` WHERE `event_type = 'review_requested'` AND (`contact_phone = X` OR `contact_email = X`) AND `created_at > now() - 6 months` AND `tenant_id = Y`.
+
+**Aufwand:** 2h
+
+### B7: Negative Bewertungen sichtbar machen
+
+**Problem:** ≤3★ Feedback landet in `review_text`, aber Betrieb sieht es nicht proaktiv.
+
+**Loesung:**
+1. Bei ≤3★: Rotes Badge im Falldetail ("Negatives Feedback erhalten")
+2. Push-Notification: "Achtung: Negative Bewertung (2★) fuer Fall DA-0071"
+3. In FlowBar: Negative Bewertungen als eigene Kennzahl (z.B. "1 negativ" in rot)
+
+**Aufwand:** 2h
+
+### B8: E-Mail vs. SMS Kanal
+
+**Frage:** Was ist der bevorzugte Kanal fuer Bewertungsanfragen?
+
+**Analyse:**
+- **E-Mail:** Laenger, kann HTML (huebsch), Kunde kann spaeter lesen, weniger aufdringlich
+- **SMS:** Kuerzer, sofort gelesen (98% Open Rate), persoenlicher, aber teurer (CHF 0.10/SMS)
+
+**Empfehlung:** E-Mail als DEFAULT, SMS als FALLBACK (wenn keine E-Mail vorhanden). Grund:
+- Bewertungsanfrage ist NICHT dringend (anders als SMS nach Voice-Call)
+- E-Mail erlaubt huebschere Darstellung (Auftragsblock, CTA-Button)
+- SMS-Kosten bei 50 Faellen/Monat = CHF 5/Mo extra
+
+**Das ist bereits so implementiert.** E-Mail zuerst, SMS nur wenn E-Mail fehlt.
+
+---
+
+## 4. Priorisierter Umsetzungsplan
+
+### SOFORT (blocking fuer Take 4 + Demo)
+
+| # | Fix | Aufwand | Warum jetzt |
+|---|-----|---------|-------------|
+| **B4** | Google-Uebergang: Text in Clipboard kopieren | 30 Min | Take 4 zeigt Review-Flow E2E |
+| **B5** | Google-Button: "optional" klarstellen | 15 Min | Vermeidet Sackgasse in der Demo |
+| **B3** | Push bei Bewertungseingang debuggen | 1h | Take 4 Proof: "Betrieb sieht Bewertung sofort" |
+| **B6** | Stammkunden-Schutz (6-Monate-Check + Warnung) | 2h | Geschaeftskritisch, muss von Tag 1 funktionieren |
+
+### BALD (vor erstem echten Kunden-Trial)
+
+| # | Fix | Aufwand | Warum |
+|---|-----|---------|-------|
+| **B7** | Negative Bewertungen: Rotes Badge + Push + KPI | 2h | Betrieb muss reagieren koennen |
+| **B1** | 24h Termin-Reminder Cron | 3-4h | Versprechen einloesen (Take 4 erwaehnt es) |
+| **B2** | SMS-Bestaetigung bei Wizard-Faellen | 1-2h | Einstellungen-Toggle muss funktionieren |
+
+### SOFORT ERGAENZT (nach Founder-Review FB22 + Toggle-Audit)
+
+| # | Fix | Aufwand | Warum |
+|---|-----|---------|-------|
+| **B9** | **Sterne aenderbar** — nach Klick auf 2★ (negative Phase) muessen Sterne weiterhin klickbar sein. Kunde kann von 2★ auf 5★ wechseln. Phase wechselt dynamisch. | 30 Min | FB22: Kunde hat sich verklickt, keine Rueckweg-Moeglichkeit |
+| **B10** | **"Technologie-Partner: flowsight.ch" entfernen** — Identity Contract R4 Verletzung | 5 Min | FlowSight darf NICHT sichtbar sein fuer Endkunden |
+| **B1a** | **Termin-Reminder Timing-Bug** — Cron laeuft 07:00 UTC (09:00 CH). Termine am naechsten Tag VOR 09:00 fallen durch. Fix: Cron auf 05:00 UTC (07:00 CH) vorziehen ODER Fenster auf 30h statt 24h erweitern. | 30 Min | DA-0073 beweist: Termin 08:30 wurde nicht reminded |
+| **B11** | **Alle Settings-Toggles pruefen** — FB17 zeigt 8 Toggles. Welche funktionieren wirklich? | 2h | Jedes Toggle das nicht funktioniert = leeres Versprechen |
+
+### SPAETER (nach Go-Live)
+
+| # | Fix | Aufwand | Warum |
+|---|-----|---------|-------|
+| — | Google Places API Integration (automatischer Review-Sync) | 6-8h | Phase 2, Founder muss Google Cloud einrichten |
+| — | Review-Conversion-Analytics (gesendet → geoeffnet → bewertet → Google) | 3h | Optimierung, nicht blocking |
+
+---
+
+## 5. Nicht-Verhandelbare Regeln (fuer alle Betriebe)
+
+| Regel | Warum |
+|-------|-------|
+| **Bewertungsanfrage NUR manuell** — kein Auto-Trigger bei status=done | Betrieb entscheidet bewusst, nicht das System |
+| **Max 2 Anfragen pro Fall, 7 Tage Cooldown** | Kunde nicht nerven |
+| **Stammkunden-Schutz: Max 1 Anfrage pro Kontakt pro 6 Monate** | Stammkunden-Beziehung schuetzen |
+| **≤3★ = KEIN Google-Link** | Negative Reviews intern halten |
+| **≥4★ = Google optional, nicht Pflicht** | Kunde soll sich nicht gezwungen fuehlen |
+| **Text wird in Clipboard kopiert vor Google-Weiterleitung** | Reibungslosen Uebergang sicherstellen |
+| **Negative Bewertung = sofortiger Alert an Betrieb** | Chance zur Service-Recovery |
+| **Kein "[FlowSight]" in E-Mail/SMS** — nur Betriebsname | Identity Contract |
+| **Sterne IMMER aenderbar** — auch nach erstem Klick | Verklicker-Schutz |
+| **"Technologie-Partner: flowsight.ch" ENTFERNEN** | Identity Contract R4 |
+
+---
+
+## 6. Go-Live Checkliste (ALLES muss funktionieren fuer Take 4)
+
+### Kundenseite (was der Endkunde erlebt)
+
+- [ ] E-Mail kommt an mit Betriebsname im Betreff (NICHT FlowSight)
+- [ ] E-Mail zeigt Auftragsblock (Kategorie, Ort, Datum)
+- [ ] Review-Surface zeigt Betriebsname + Auftragsblock
+- [ ] Sterne sind klickbar UND AENDERBAR (auch nach erstem Klick)
+- [ ] ≥4★: Chips + Freitext + "Auf Google teilen (optional)" + Clipboard-Copy
+- [ ] ≤3★: Feedback-Textarea + "Feedback senden" (KEIN Google-Link)
+- [ ] Kein "FlowSight" sichtbar (kein Footer, kein Betreff, kein Text)
+- [ ] Google-Button: Text vorher in Clipboard kopiert + Hinweis
+- [ ] Ohne Google-Konto: "Ihre Bewertung wurde bereits gespeichert" sichtbar
+
+### Betriebsseite (was der Inhaber erlebt)
+
+- [ ] "Noch Bewertung moeglich" Badge sichtbar bei erledigten Faellen
+- [ ] Button "Bewertung anfragen" funktioniert E2E
+- [ ] Fehlermeldung spezifisch wenn nicht moeglich (Status, Kontakt, Cooldown, Max)
+- [ ] Stammkunden-Warnung wenn Kontakt in letzten 6 Monaten schon gefragt
+- [ ] Push-Notification wenn Bewertung eingeht (positiv UND negativ)
+- [ ] Rotes Badge/Alert bei ≤3★ Bewertung
+- [ ] KPIs: Ø Rating + erhalten/angefragt Zahlen stimmen
+- [ ] Max 2 Anfragen pro Fall, 7 Tage Cooldown
+
+### Termin + Benachrichtigungen
+
+- [ ] 24h Termin-Reminder kommt an (SMS und/oder E-Mail je nach Toggle)
+- [ ] Timing: auch Termine vor 09:00 werden reminded
+- [ ] Alle Settings-Toggles funktionieren wie beschriftet:
+  - E-Mail Bestaetigung an Kunden
+  - SMS Bestaetigung an Kunden
+  - E-Mail Terminbestaetigung an Kunden
+  - SMS Terminbestaetigung an Kunden
+  - E-Mail Terminbestaetigung an Mitarbeiter
+  - SMS Terminbestaetigung an Mitarbeiter
+  - 24h Erinnerung an Kunden per SMS

--- a/src/web/app/api/cases/route.ts
+++ b/src/web/app/api/cases/route.ts
@@ -278,9 +278,12 @@ export async function POST(request: NextRequest) {
       ).catch(() => {});
     }
 
-    // Reporter confirmation (no log — result merged into notification log below)
+    // Reporter confirmation — respects tenant toggles (B11)
     let reporterEmailSent: boolean | undefined;
-    if (data.contact_email) {
+    const reporterEmailEnabled = casesModules?.notify_reporter_email !== false;
+    const reporterSmsEnabled = casesModules?.notify_reporter_sms === true;
+
+    if (data.contact_email && reporterEmailEnabled) {
       reporterEmailSent = await sendReporterConfirmation({
         caseId: row.id,
         seqNumber: row.seq_number,
@@ -290,6 +293,21 @@ export async function POST(request: NextRequest) {
         contactEmail: data.contact_email,
         category: data.category,
       });
+    }
+
+    // B2: SMS confirmation to reporter (if toggle active + phone available)
+    if (data.contact_phone && reporterSmsEnabled) {
+      try {
+        const smsConfig = await import("@/src/lib/tenants/getTenantSmsConfig").then(m => m.getTenantSmsConfig(tenantId));
+        if (smsConfig) {
+          const { sendSms } = await import("@/src/lib/sms/sendSms");
+          await sendSms(
+            data.contact_phone,
+            `${tenantDisplayName}: Ihre Meldung wurde aufgenommen (${data.category}). Wir melden uns bei Ihnen.`,
+            smsConfig.senderName ?? tenantDisplayName,
+          );
+        }
+      } catch { /* SMS best-effort */ }
     }
 
     // MUST await — fire-and-forget causes Vercel to kill the invocation

--- a/src/web/app/api/lifecycle/tick/route.ts
+++ b/src/web/app/api/lifecycle/tick/route.ts
@@ -281,13 +281,16 @@ async function processTerminReminders(
 ): Promise<ReminderResult[]> {
   const results: ReminderResult[] = [];
 
-  // Cases with scheduled_at in next 36h (handles cron timing variance)
+  // Cases with scheduled_at in window: -3h to +36h from now.
+  // The -3h lookback catches early-morning appointments (e.g., 08:30 MESZ = 06:30 UTC)
+  // that would otherwise be "past" when the cron runs at 07:00 UTC.
+  const windowStart = new Date(now.getTime() - 3 * 60 * 60 * 1000);
   const windowEnd = new Date(now.getTime() + 36 * 60 * 60 * 1000);
 
   const { data: cases } = await supabase
     .from("cases")
     .select("id, tenant_id, seq_number, scheduled_at, scheduled_end_at, category, contact_phone, reporter_name")
-    .gte("scheduled_at", now.toISOString())
+    .gte("scheduled_at", windowStart.toISOString())
     .lte("scheduled_at", windowEnd.toISOString())
     .in("status", ["scheduled", "in_arbeit"])
     .not("contact_phone", "is", null);

--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -87,6 +87,49 @@ export async function POST(
     }
   }
 
+  // ── B6: Stammkunden-Schutz — max 1 review request per contact per 6 months
+  // Prevents nagging repeat customers who visit multiple times per year.
+  const contactIdentifiers: string[] = [];
+  if (row.contact_email) contactIdentifiers.push(row.contact_email);
+  if (row.contact_phone) contactIdentifiers.push(row.contact_phone);
+
+  if (contactIdentifiers.length > 0) {
+    const sixMonthsAgo = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000).toISOString();
+
+    // Find OTHER cases for this tenant with same contact that already got a review request
+    let recentRequestQuery = supabase
+      .from("cases")
+      .select("id, review_sent_at, contact_email, contact_phone")
+      .eq("tenant_id", row.tenant_id)
+      .neq("id", id) // exclude current case
+      .not("review_sent_at", "is", null)
+      .gte("review_sent_at", sixMonthsAgo);
+
+    // Check by email OR phone
+    if (row.contact_email && row.contact_phone) {
+      recentRequestQuery = recentRequestQuery.or(`contact_email.eq.${row.contact_email},contact_phone.eq.${row.contact_phone}`);
+    } else if (row.contact_email) {
+      recentRequestQuery = recentRequestQuery.eq("contact_email", row.contact_email);
+    } else {
+      recentRequestQuery = recentRequestQuery.eq("contact_phone", row.contact_phone!);
+    }
+
+    const { data: recentRequests } = await recentRequestQuery;
+
+    if (recentRequests && recentRequests.length > 0) {
+      const lastRequest = recentRequests[0];
+      const lastDate = new Date(lastRequest.review_sent_at!).toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric" });
+      return NextResponse.json(
+        {
+          error: "repeat_customer",
+          message: `Dieser Kunde wurde am ${lastDate} bereits um eine Bewertung gebeten. Stammkunden maximal 1x pro 6 Monate anfragen.`,
+          last_request_date: lastRequest.review_sent_at,
+        },
+        { status: 409 },
+      );
+    }
+  }
+
   // Check for explicit skip
   const { data: skipEvents } = await supabase
     .from("case_events")

--- a/src/web/app/api/review/[caseId]/rate/route.ts
+++ b/src/web/app/api/review/[caseId]/rate/route.ts
@@ -49,26 +49,37 @@ export async function POST(
     return NextResponse.json({ error: "Failed to save rating" }, { status: 500 });
   }
 
-  // Track event
+  // Track event (B7: negative reviews flagged)
+  const isNegativeReview = rating <= 3;
   await supabase.from("case_events").insert({
     case_id: caseId,
     event_type: "review_rated",
-    title: `Kundenbewertung: ${rating} Stern${rating !== 1 ? "e" : ""}`,
-    ...(text ? { metadata: { text_preview: text.slice(0, 200) } } : {}),
+    title: isNegativeReview
+      ? `⚠️ Negatives Feedback: ${rating} Stern${rating !== 1 ? "e" : ""}`
+      : `Kundenbewertung: ${rating} Stern${rating !== 1 ? "e" : ""}`,
+    metadata: {
+      ...(text ? { text_preview: text.slice(0, 200) } : {}),
+      is_negative: isNegativeReview,
+    },
   });
 
   // Push notification to tenant staff (best-effort)
+  // B7: Negative reviews (≤3★) get urgent title to alert the business immediately
   if (caseRow?.tenant_id) {
     const stars = "★".repeat(rating) + "☆".repeat(5 - rating);
     const name = caseRow.reporter_name ?? "Kunde";
+    const isNegative = rating <= 3;
+    const title = isNegative
+      ? `⚠️ Negatives Feedback (${rating}★)`
+      : `Bewertung erhalten: ${stars}`;
     const bodyText = text
       ? `${name}: ${text.slice(0, 80)}${text.length > 80 ? "…" : ""}`
       : `${name} hat ${rating} Sterne vergeben`;
     import("@/src/lib/push/sendOpsPush").then(({ sendOpsPush }) =>
       sendOpsPush({
         tenantId: caseRow.tenant_id,
-        eventType: "review",
-        title: `Bewertung erhalten: ${stars}`,
+        eventType: isNegative ? "notfall" : "review", // Negative = urgent event type for louder push
+        title,
         body: bodyText,
         url: `/ops/cases/${caseId}`,
         tag: `review-${caseId}`,

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -525,6 +525,7 @@ export function CaseDetailForm({
           no_contact_info: "Keine E-Mail oder Telefonnummer beim Kunden hinterlegt.",
           max_reviews_reached: "Maximale Anzahl Bewertungsanfragen erreicht (2).",
           cooldown_active: "Bitte 7 Tage warten bis zur nächsten Anfrage.",
+          repeat_customer: data?.message ?? "Dieser Kunde wurde kürzlich bereits um eine Bewertung gebeten.",
         };
         throw new Error(MSG[code ?? ""] ?? `Senden fehlgeschlagen (${code ?? res.status}).`);
       }

--- a/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
+++ b/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
@@ -23,8 +23,6 @@ const REVIEW_CHIPS = [
   "Jederzeit wieder",
 ];
 
-type Phase = "rating" | "positive" | "negative" | "done";
-
 export function ReviewSurfaceClient({
   companyName,
   brandColor,
@@ -35,10 +33,10 @@ export function ReviewSurfaceClient({
   trackUrl,
   caseId,
 }: Props) {
-  const [phase, setPhase] = useState<Phase>("rating");
   const [rating, setRating] = useState<number>(0);
   const [hoverRating, setHoverRating] = useState<number>(0);
   const [saving, setSaving] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   // Positive path
   const [selectedChips, setSelectedChips] = useState<Set<string>>(new Set());
@@ -47,6 +45,13 @@ export function ReviewSurfaceClient({
   // Negative path
   const [feedbackText, setFeedbackText] = useState("");
   const [feedbackSent, setFeedbackSent] = useState(false);
+
+  // Done state (after Google click or explicit feedback send)
+  const [done, setDone] = useState(false);
+
+  // B9: Phase is DERIVED from rating, not locked after click.
+  // Customer can always change stars — phase updates dynamically.
+  const phase = done ? "done" : rating === 0 ? "rating" : rating >= 4 ? "positive" : "negative";
 
   const assembledText = useMemo(() => {
     const chips = Array.from(selectedChips).join(". ");
@@ -67,10 +72,19 @@ export function ReviewSurfaceClient({
     setSaving(false);
   }
 
+  // B9: Stars are ALWAYS clickable. Rating changes dynamically.
   function handleStarClick(n: number) {
     setRating(n);
     saveReview(n);
-    setPhase(n >= 4 ? "positive" : "negative");
+    // Reset chips/text when switching between positive/negative
+    if (n >= 4 && rating < 4) {
+      setFeedbackText("");
+      setFeedbackSent(false);
+    }
+    if (n < 4 && rating >= 4) {
+      setSelectedChips(new Set());
+      setFreeText("");
+    }
   }
 
   function toggleChip(chip: string) {
@@ -82,31 +96,33 @@ export function ReviewSurfaceClient({
     });
   }
 
+  // B4: Copy text to clipboard BEFORE opening Google
   async function handleGoogleReview() {
-    // Save text first
     if (assembledText) {
       await saveReview(rating, assembledText);
     }
     // Copy to clipboard
     try {
       await navigator.clipboard.writeText(assembledText);
-    } catch { /* mobile fallback: text is still assembled */ }
+      setCopied(true);
+      // Wait briefly so user sees "Copied!" before Google opens
+      await new Promise((r) => setTimeout(r, 800));
+    } catch { /* mobile fallback */ }
     // Track CTA click
     if (trackUrl) {
       fetch(trackUrl, { method: "POST" }).catch(() => {});
     }
-    // Open Google
     if (googleReviewUrl) {
       window.open(googleReviewUrl, "_blank", "noopener,noreferrer");
     }
-    setPhase("done");
+    setDone(true);
   }
 
   async function handlePositiveFeedback() {
     if (assembledText) {
       await saveReview(rating, assembledText);
     }
-    setPhase("done");
+    setDone(true);
   }
 
   async function handleNegativeFeedback() {
@@ -118,18 +134,28 @@ export function ReviewSurfaceClient({
 
   const displayRating = hoverRating || rating;
 
-  // Read-only mini stars
-  const MiniStars = () => (
-    <div className="flex items-center justify-center gap-1 mb-3">
+  // B9: Interactive stars — shown in ALL phases (except done), always clickable
+  const InteractiveStars = ({ size = "w-12 h-12" }: { size?: string }) => (
+    <div className="flex items-center justify-center gap-2 mb-3">
       {[1, 2, 3, 4, 5].map((n) => (
-        <svg
+        <button
           key={n}
-          className={`w-6 h-6 ${n <= rating ? "text-amber-400" : "text-gray-200"}`}
-          fill="currentColor"
-          viewBox="0 0 20 20"
+          onClick={() => handleStarClick(n)}
+          onMouseEnter={() => setHoverRating(n)}
+          onMouseLeave={() => setHoverRating(0)}
+          className="p-0.5 transition-all duration-200 hover:scale-110 active:scale-95"
+          disabled={saving}
         >
-          <path d={STAR_PATH} />
-        </svg>
+          <svg
+            className={`${size} transition-colors duration-150 ${
+              n <= displayRating ? "text-amber-400" : "text-gray-200"
+            }`}
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path d={STAR_PATH} />
+          </svg>
+        </button>
       ))}
     </div>
   );
@@ -164,41 +190,21 @@ export function ReviewSurfaceClient({
             </div>
           </div>
 
-          {/* ── Phase: Rating (star picker) ──────────────────────────── */}
+          {/* ── Phase: Rating (initial — no stars clicked yet) ──────── */}
           {phase === "rating" && (
             <div className="px-6 pb-6">
               <p className="text-sm text-gray-600 mb-3 text-center">
                 Wie zufrieden waren Sie mit unserem Einsatz?
               </p>
-              <div className="flex items-center justify-center gap-2">
-                {[1, 2, 3, 4, 5].map((n) => (
-                  <button
-                    key={n}
-                    onClick={() => handleStarClick(n)}
-                    onMouseEnter={() => setHoverRating(n)}
-                    onMouseLeave={() => setHoverRating(0)}
-                    className="p-1 transition-all duration-200 hover:scale-125 active:scale-95"
-                    disabled={saving}
-                  >
-                    <svg
-                      className={`w-12 h-12 transition-colors duration-150 ${
-                        n <= displayRating ? "text-amber-400" : "text-gray-200"
-                      }`}
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                    >
-                      <path d={STAR_PATH} />
-                    </svg>
-                  </button>
-                ))}
-              </div>
+              <InteractiveStars />
             </div>
           )}
 
           {/* ── Phase: Positive (4-5 stars) ──────────────────────────── */}
           {phase === "positive" && (
             <div className="px-6 pb-5">
-              <MiniStars />
+              {/* B9: Stars still clickable — customer can change rating */}
+              <InteractiveStars size="w-8 h-8" />
 
               <p className="text-center text-sm text-emerald-700 font-medium mb-4">
                 Vielen Dank für Ihre tolle Bewertung!
@@ -236,20 +242,33 @@ export function ReviewSurfaceClient({
                 />
               </div>
 
-              {/* CTA */}
+              {/* B4 + B5: Google CTA with clipboard copy + "optional" messaging */}
               {googleReviewUrl ? (
-                <button
-                  type="button"
-                  onClick={handleGoogleReview}
-                  disabled={saving}
-                  className="flex w-full items-center justify-center gap-2 rounded-lg px-6 py-3.5 text-[15px] font-semibold text-white transition-all hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
-                  style={{ backgroundColor: brandColor }}
-                >
-                  <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-                  </svg>
-                  Jetzt auf Google bewerten
-                </button>
+                <>
+                  <button
+                    type="button"
+                    onClick={handleGoogleReview}
+                    disabled={saving}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg px-6 py-3.5 text-[15px] font-semibold text-white transition-all hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
+                    style={{ backgroundColor: brandColor }}
+                  >
+                    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+                    </svg>
+                    {copied ? "Text kopiert — Google öffnet sich..." : "Auf Google teilen (optional)"}
+                  </button>
+                  {/* B5: Clarify that internal review is already saved */}
+                  <p className="mt-2 text-center text-xs text-emerald-600 font-medium">
+                    ✓ Ihre Bewertung wurde bereits gespeichert.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={handlePositiveFeedback}
+                    className="mt-2 w-full text-center text-xs text-gray-400 hover:text-gray-600 transition-colors py-1"
+                  >
+                    Kein Google-Konto? Kein Problem — einfach hier fertig.
+                  </button>
+                </>
               ) : (
                 <button
                   type="button"
@@ -258,22 +277,17 @@ export function ReviewSurfaceClient({
                   className="flex w-full items-center justify-center gap-2 rounded-lg px-6 py-3.5 text-[15px] font-semibold text-white transition-all hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
                   style={{ backgroundColor: brandColor }}
                 >
-                  Feedback senden
+                  Bewertung abschliessen
                 </button>
               )}
-
-              <div className="pt-4 pb-1">
-                <p className="text-center text-xs text-gray-400">
-                  Kein Interesse? Sie müssen nichts tun.
-                </p>
-              </div>
             </div>
           )}
 
           {/* ── Phase: Negative (1-3 stars) ──────────────────────────── */}
           {phase === "negative" && (
             <div className="px-6 pb-5">
-              <MiniStars />
+              {/* B9: Stars still clickable — customer can upgrade to 4-5★ */}
+              <InteractiveStars size="w-8 h-8" />
 
               {!feedbackSent ? (
                 <>
@@ -328,7 +342,7 @@ export function ReviewSurfaceClient({
             </div>
           )}
 
-          {/* ── Phase: Done (after Google click or positive feedback) ── */}
+          {/* ── Phase: Done (after Google click or explicit finish) ── */}
           {phase === "done" && (
             <div className="px-6 pb-6">
               <div className="flex items-center justify-center mb-3">
@@ -348,13 +362,7 @@ export function ReviewSurfaceClient({
           )}
         </div>
 
-        {/* Footer — Identity Contract R4 */}
-        <p className="mt-4 text-center text-xs text-gray-400">
-          Technologie-Partner:{" "}
-          <a href="https://flowsight.ch" className="text-gray-500 hover:text-gray-600">
-            flowsight.ch
-          </a>
-        </p>
+        {/* B10: Footer removed — Identity Contract R4: FlowSight invisible to end customers */}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
10 Fixes für Go-Live + Take 4. Alles was der Kunde, der Betrieb und das System brauchen.

**Review Surface:**
- B9: Sterne IMMER änderbar (kein Dead-End nach Klick)
- B10: "Technologie-Partner: flowsight.ch" Footer entfernt
- B4: Google-Text in Clipboard kopiert + Hinweis-Text auf Button
- B5: Google = optional, "Bewertung bereits gespeichert", "Kein Google-Konto? Kein Problem"

**Backend:**
- B6: Stammkunden-Schutz (6-Monate-Check, Warnung mit Datum)
- B7: Negative Reviews ≤3★ = ⚠️ Push + "notfall" Event-Type
- B1a: Termin-Reminder Timing-Fix (-3h Lookback für Frühtermine)
- B11: notify_reporter_email Toggle wird jetzt geprüft
- B2: notify_reporter_sms Toggle FUNKTIONIERT jetzt (SMS an Melder bei Wizard-Fall)

## Test plan
- [ ] Review Surface: 2★ klicken → Sterne weiterhin klickbar → auf 5★ ändern → positive Phase
- [ ] Review Surface: kein "flowsight.ch" Footer sichtbar
- [ ] Review Surface: "Auf Google teilen (optional)" + "Bewertung bereits gespeichert"
- [ ] Review Surface: Google-Klick → "Text kopiert" → Google öffnet
- [ ] Stammkunden: 2x Review anfragen für gleichen Kunden → 2. Mal Warnung
- [ ] Negative Bewertung: ≤3★ → Push mit "⚠️ Negatives Feedback"
- [ ] Termin-Reminder: Termin 08:30 → Reminder kommt (nicht mehr verschluckt)
- [ ] Wizard-Fall mit SMS-Toggle aktiv → SMS Bestätigung an Melder

🤖 Generated with [Claude Code](https://claude.com/claude-code)