### PR TITLE
fix: Bewertungen v2 — Stammkunden-Schutz, Star UX, Timeline text

### DIFF
--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -93,7 +93,16 @@ export async function POST(
   if (row.contact_email) contactIdentifiers.push(row.contact_email);
   if (row.contact_phone) contactIdentifiers.push(row.contact_phone);
 
-  if (contactIdentifiers.length > 0) {
+  // Founder test contacts — exempt from repeat-customer check
+  const WHITELISTED_CONTACTS = [
+    "gunnar.wende@flowsight.ch",
+    "+41764458942",
+    "0764458942",
+    "+41445520919",
+  ];
+  const isWhitelisted = contactIdentifiers.some(c => WHITELISTED_CONTACTS.includes(c));
+
+  if (contactIdentifiers.length > 0 && !isWhitelisted) {
     const sixMonthsAgo = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000).toISOString();
 
     // Find OTHER cases for this tenant with same contact that already got a review request
@@ -117,16 +126,26 @@ export async function POST(
     const { data: recentRequests } = await recentRequestQuery;
 
     if (recentRequests && recentRequests.length > 0) {
-      const lastRequest = recentRequests[0];
-      const lastDate = new Date(lastRequest.review_sent_at!).toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric" });
-      return NextResponse.json(
-        {
-          error: "repeat_customer",
-          message: `Dieser Kunde wurde am ${lastDate} bereits um eine Bewertung gebeten. Stammkunden maximal 1x pro 6 Monate anfragen.`,
-          last_request_date: lastRequest.review_sent_at,
-        },
-        { status: 409 },
-      );
+      // Check if force=true was passed (Betrieb explicitly chooses to send anyway)
+      let forceOverride = false;
+      try {
+        const body = await _request.json();
+        forceOverride = body?.force === true;
+      } catch { /* no body = no force */ }
+
+      if (!forceOverride) {
+        const lastRequest = recentRequests[0];
+        const lastDate = new Date(lastRequest.review_sent_at!).toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric" });
+        return NextResponse.json(
+          {
+            error: "repeat_customer",
+            message: `Dieser Kunde wurde am ${lastDate} bereits um eine Bewertung gebeten. Stammkunden maximal 1x pro 6 Monate anfragen.`,
+            last_request_date: lastRequest.review_sent_at,
+          },
+          { status: 409 },
+        );
+      }
+      // force=true → continue with sending (Betrieb takes responsibility)
     }
   }
 

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -223,6 +223,7 @@ export function CaseDetailForm({
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState("");
   const [reviewState, setReviewState] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [repeatWarning, setRepeatWarning] = useState<string | null>(null);
   const [reviewMsg, setReviewMsg] = useState("");
   const [localEvents, setLocalEvents] = useState(caseEvents);
   const [timelineExpanded, setTimelineExpanded] = useState(false);
@@ -512,24 +513,37 @@ export function CaseDetailForm({
   });
   const canRequestReview = reviewInfo.canRequest || reviewInfo.canResend;
 
-  async function handleRequestReview() {
+  async function handleRequestReview(force = false) {
     setReviewState("sending");
     setReviewMsg("");
+    setRepeatWarning(null);
     try {
-      const res = await fetch(`/api/ops/cases/${initialData.id}/request-review`, { method: "POST" });
+      const res = await fetch(`/api/ops/cases/${initialData.id}/request-review`, {
+        method: "POST",
+        headers: force ? { "Content-Type": "application/json" } : undefined,
+        body: force ? JSON.stringify({ force: true }) : undefined,
+      });
       if (!res.ok) {
         const data = await res.json().catch(() => null);
         const code = data?.error;
+
+        // Stammkunden-Warnung: show as warning with override option, not hard error
+        if (code === "repeat_customer") {
+          setRepeatWarning(data?.message ?? "Dieser Kunde wurde kürzlich bereits um eine Bewertung gebeten.");
+          setReviewState("idle");
+          return;
+        }
+
         const MSG: Record<string, string> = {
           case_not_done: "Der Fall muss zuerst als \"Erledigt\" gespeichert werden.",
           no_contact_info: "Keine E-Mail oder Telefonnummer beim Kunden hinterlegt.",
           max_reviews_reached: "Maximale Anzahl Bewertungsanfragen erreicht (2).",
           cooldown_active: "Bitte 7 Tage warten bis zur nächsten Anfrage.",
-          repeat_customer: data?.message ?? "Dieser Kunde wurde kürzlich bereits um eine Bewertung gebeten.",
         };
         throw new Error(MSG[code ?? ""] ?? `Senden fehlgeschlagen (${code ?? res.status}).`);
       }
       setReviewState("sent");
+      setRepeatWarning(null);
       setTimeout(() => setReviewState("idle"), 2000);
       setLocalEvents(prev => [...prev, {
         id: crypto.randomUUID(), event_type: "review_requested",
@@ -975,6 +989,8 @@ export function CaseDetailForm({
               reviewMsg={reviewMsg}
               onRequest={handleRequestReview}
               onSkip={handleSkipReview}
+              onForceRequest={() => handleRequestReview(true)}
+              repeatWarning={repeatWarning}
               brandColor={brandColor}
               hasEvents={localEvents.length > 0}
             />
@@ -1297,7 +1313,7 @@ function StarIcon({ filled, muted }: { filled: boolean; brandColor?: string; mut
 
 function BewertungEndCap({
   status, reviewInfo, canRequestReview, reviewState, reviewMsg,
-  onRequest, onSkip, brandColor, hasEvents,
+  onRequest, onSkip, onForceRequest, repeatWarning, brandColor, hasEvents,
 }: {
   status: string;
   reviewInfo: ReturnType<typeof deriveReviewStatus>;
@@ -1306,6 +1322,8 @@ function BewertungEndCap({
   reviewMsg: string;
   onRequest: () => void;
   onSkip: () => void;
+  onForceRequest: () => void;
+  repeatWarning: string | null;
   brandColor: string;
   hasEvents: boolean;
 }) {
@@ -1368,6 +1386,17 @@ function BewertungEndCap({
 
             {reviewState === "sent" && <span className="text-emerald-600 text-xs">Gesendet</span>}
             {reviewState === "error" && <span className="text-red-600 text-xs">{reviewMsg}</span>}
+            {repeatWarning && (
+              <div className="mt-2 rounded-lg bg-amber-50 border border-amber-200 px-3 py-2">
+                <p className="text-xs text-amber-800">{repeatWarning}</p>
+                <button
+                  onClick={onForceRequest}
+                  className="mt-1.5 rounded-md bg-amber-600 px-3 py-1 text-xs font-medium text-white hover:bg-amber-700 transition-colors"
+                >
+                  Trotzdem anfragen
+                </button>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
+++ b/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
@@ -73,9 +73,10 @@ export function ReviewSurfaceClient({
   }
 
   // B9: Stars are ALWAYS clickable. Rating changes dynamically.
+  // Rating is NOT saved on star click — only when customer explicitly submits.
+  // This prevents premature push notifications (e.g., 2★ push before customer changes to 5★).
   function handleStarClick(n: number) {
     setRating(n);
-    saveReview(n);
     // Reset chips/text when switching between positive/negative
     if (n >= 4 && rating < 4) {
       setFeedbackText("");
@@ -193,8 +194,11 @@ export function ReviewSurfaceClient({
           {/* ── Phase: Rating (initial — no stars clicked yet) ──────── */}
           {phase === "rating" && (
             <div className="px-6 pb-6">
-              <p className="text-sm text-gray-600 mb-3 text-center">
-                Wie zufrieden waren Sie mit unserem Einsatz?
+              <p className="text-sm text-gray-600 mb-1 text-center">
+                Wie zufrieden waren Sie?
+              </p>
+              <p className="text-xs text-gray-400 mb-4 text-center">
+                Tippen Sie einfach auf die Sterne — dauert nur 30 Sekunden.
               </p>
               <InteractiveStars />
             </div>

--- a/src/web/src/components/ops/CaseTimeline.tsx
+++ b/src/web/src/components/ops/CaseTimeline.tsx
@@ -55,6 +55,17 @@ export function CaseTimeline({ events, status }: { events: CaseEvent[]; status?:
               <p className="text-sm text-gray-700 leading-snug truncate">
                 {event.title}
               </p>
+              {/* Show review text for review_rated events */}
+              {event.event_type === "review_rated" && !!event.metadata?.text_preview && (
+                <p className="mt-1 text-xs text-gray-500 italic leading-relaxed">
+                  &ldquo;{String(event.metadata.text_preview)}&rdquo;
+                </p>
+              )}
+              {event.event_type === "review_rated" && !!event.metadata?.is_negative && (
+                <span className="inline-block mt-1 rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-medium text-red-700">
+                  Negatives Feedback
+                </span>
+              )}
               <p className="text-[11px] text-gray-400">
                 {formatEventDate(event.created_at)}
               </p>


### PR DESCRIPTION
## Summary
- **Stammkunden-Schutz (B6):** Max 1 review request per contact (email/phone) per 6 months across all tenant cases. Shows amber warning with "Trotzdem anfragen" force override in Leitstand.
- **Star UX (B9/FB22):** Rating NOT auto-saved on star click — only when customer explicitly submits. Prevents premature push notifications (e.g. 2★ push before customer changes to 5★).
- **Friendlier initial text:** "Tippen Sie einfach auf die Sterne — dauert nur 30 Sekunden"
- **Timeline text (FB25):** Review text + negative feedback badge now visible in CaseTimeline
- **Founder whitelist:** Test contacts exempt from Stammkunden check

Follows up on PR #469 (Bewertungen v2 Go-Live).

## Test plan
- [ ] Open case detail → click "Bewertung anfragen" for a contact that already received a review → amber warning appears
- [ ] Click "Trotzdem anfragen" → review sent despite warning
- [ ] Open review surface → click stars → stars change freely, no save triggered
- [ ] Submit via Google CTA or "Bewertung abschliessen" → rating saved
- [ ] Check CaseTimeline after review received → text + negative badge visible
- [ ] Verify founder contacts (+41764458942, gunnar.wende@flowsight.ch) bypass Stammkunden check

🤖 Generated with [Claude Code](https://claude.com/claude-code)