### PR TITLE
fix: Bewertungen Runde 1 — 8 Blocker für Go-Live

### DIFF
--- a/docs/redesign/leitstand/plan_bewertungen_abschluss.md
+++ b/docs/redesign/leitstand/plan_bewertungen_abschluss.md
@@ -1,0 +1,303 @@
+# Plan: Bewertungen Abschluss — High-End Review-System
+
+> Stand: 2026-04-15 | Owner: CC + Founder
+> Ziel: Bewertungen-System produktionsreif machen — von Anfrage bis KPI lückenlos.
+
+---
+
+## Kontext
+
+Founder hat den kompletten Review-Flow getestet (FB27–FB44). Zusätzlich: Deep-Audit
+aller beteiligten Dateien hat 7 weitere Probleme aufgedeckt. Dieses Dokument ist der
+vollständige, priorisierte Abschlussplan.
+
+---
+
+## Alle Punkte — priorisiert
+
+### Runde 1: "Nichts darf kaputt sein" (Blocker)
+
+| ID | Problem | Root Cause | Dateien | Aufwand |
+|----|---------|-----------|---------|---------|
+| **FB36** | Manuell erstellter Fall erscheint nicht | `CreateCaseModal` sendet keine `tenant_id` → fällt auf `FALLBACK_TENANT_ID` → falscher Tenant → RLS versteckt Fall | `CreateCaseModal.tsx`, `api/cases/route.ts` | M |
+| **FB27/39** | SMS geht nicht raus bei `076...` Format | `toEcallNumber()` konvertiert nur `+41→0041`, nicht `0xx→+41xx` | `sendSmsEcall.ts`, `CaseDetailForm.tsx` (Placeholder) | S |
+| **X1** | Stammkunden-Check matcht `076` nicht mit `+41 76` | Normalisierung fehlt vor Vergleich | `request-review/route.ts` | S (Teil von FB27) |
+| **FB41** | "Bewertung bereits gespeichert" — Lüge | Text erscheint bei 4+ Sternen, aber Save passiert erst bei Button-Klick | `ReviewSurfaceClient.tsx:265-267` | S |
+| **SEC-1** | `/api/review/[caseId]/rate` hat ZERO Auth | Kein Token-Check, kein Rate-Limit. Jeder kann Bewertungen spammen | `rate/route.ts` | M |
+| **SEC-2** | Review-Link läuft nie ab | HMAC basiert nur auf caseId+created_at, kein Timestamp | `verifySmsToken.ts`, `review/[caseId]/page.tsx` | S |
+| **BUG-1** | `deriveReviewStatus` kennt kein "bewertet" | Nach Kundenrating zeigt UI weiterhin "Geöffnet" statt "Bewertet" | `deriveReviewStatus.ts`, `CaseDetailForm.tsx` | M |
+
+### Runde 2: "Sieht professionell aus" (UX)
+
+| ID | Problem | Root Cause | Dateien | Aufwand |
+|----|---------|-----------|---------|---------|
+| **FB40** | SMS sieht grauenhaft aus | Volle Token-URL (~100 Zeichen) statt Short-Token. Sprengt 160-Zeichen-Limit | `request-review/route.ts:227`, `verifySmsToken.ts` | S |
+| **FB34** | Erledigt-Button: Bewertungs-Rand-Logik | Kein visuelles Feedback zu Bewertungsstatus auf Button | `SystemCard.tsx`, `FlowBar.tsx` | M |
+| **FB35** | Kategorien = Freitext statt Tenant-Dropdown | Wizard hat dynamische Kategorien, Leitstand hat `<input type="text">` | `CaseDetailForm.tsx`, `CreateCaseModal.tsx` | M |
+| **FB38** | E-Mail "Fall öffnen" → Login → Ziel-URL verloren | Auth-Guard leitet auf `/ops/login` ohne `?next=` Parameter | `layout.tsx`, `middleware.ts` | M |
+| **FB44** | Fehlermeldungen auf Englisch | `review_skipped`, `review_send_failed` nicht im deutschen Mapping | `CaseDetailForm.tsx:537-543` | S |
+| **X2** | `faelle` Seite filtert `is_deleted` nicht | Gelöschte Fälle bleiben sichtbar | `faelle/page.tsx` | S |
+| **X3** | "Voice Agent" in E-Mail = Englisch | SOURCE_LABELS hat englischen String | `resend.ts:52` | S |
+| **PUSH-1** | Negativ-Push: eigener Event-Type `negative_review` (immer aktiv, kein Opt-out) | `rate/route.ts:81`, `sendOpsPush.ts` | S |
+| **PUSH-2** | Push-Preferences UI in Einstellungen (Betrieb konfiguriert welche Pushes) | `settings/page.tsx`, `subscribe/route.ts` | M |
+| **PUSH-3** | Zuweisung-Push nur an zugewiesene Person (nicht broadcast) | `notify-assignees/route.ts` | S |
+| **BUG-3** | Double-Submit: Rating wird überschrieben | Zwei Klicks → zwei Events + zweite Push + Überschreibung | `rate/route.ts` | S |
+| **BUG-4** | `review_surface_opened` Event: keine Deduplizierung | Jeder Seitenaufruf = neues Event, verfälscht Analytics | `review/[caseId]/page.tsx` | S |
+| **BUG-5** | `review_sent_count` DB-Spalte wird nie inkrementiert | Totes Feld, Zählung nur über Events | `request-review/route.ts` | S |
+
+### Runde 3: "Nice to have" (Feature, nicht Go-Live-kritisch)
+
+| ID | Problem | Dateien | Aufwand |
+|----|---------|---------|---------|
+| **FB35b** | Foto-Upload bei manueller Fall-Erstellung | `CreateCaseModal.tsx` | L |
+| **FB34b** | KPI Bewertungen in SystemCard (Ø + n) | `SystemCard.tsx` | M |
+
+---
+
+## Detaillierte Lösungen
+
+### FB36 — CreateCaseModal: tenant_id fehlt
+
+**Problem:** Modal sendet keinen Tenant an API. Fällt auf `FALLBACK_TENANT_ID` zurück.
+
+**Lösung:**
+1. In `CreateCaseModal.tsx`: Active Tenant aus Cookie `fs_active_tenant` lesen
+2. Alternativ: Neuen API-Endpunkt `POST /api/ops/cases` (mit Auth-Scope) statt generischen `/api/cases`
+3. Empfehlung: `tenant_id` aus `resolveTenantScope()` Server-seitig ableiten — nicht vom Client senden (Sicherheit)
+
+**Ansatz:** CreateCaseModal ruft `/api/ops/cases` auf (neuer Endpunkt). Dieser nutzt `resolveTenantScope()` → garantiert korrekte tenant_id.
+
+### FB27/39/X1 — Telefon-Normalisierung
+
+**Problem:** `076 123 45 67` → wird 1:1 an eCall geschickt → scheitert.
+
+**Lösung:** Zentrale Normalisierungsfunktion:
+```
+normalizeSwissPhone(input: string): string | null
+  - Leerzeichen/Bindestriche entfernen
+  - 07x... → +417x...
+  - 004x... → +4x...
+  - +41... → unverändert
+  - Alles andere → null (ungültig)
+```
+
+**Anwenden an 3 Stellen:**
+1. `CaseDetailForm.tsx` — beim Speichern (`contactPhone.trim()` → `normalizeSwissPhone()`)
+2. `sendSmsEcall.ts` — `toEcallNumber()` erweitern als Safety Net
+3. `request-review/route.ts` — Stammkunden-Check: beide Nummern normalisieren vor Vergleich
+
+**Placeholder:** `076 123 45 67` statt `+41 79...`
+
+### FB41 — "Gespeichert"-Lüge
+
+**Problem:** Text "✓ Ihre Bewertung wurde bereits gespeichert" erscheint sofort bei 4+ Sternen, obwohl noch nichts gespeichert ist. Kunde könnte Seite verlassen.
+
+**Lösung:** Text ändern + Auto-Save einbauen:
+1. Text ersetzen: "Wählen Sie eine Option, um abzuschliessen"
+2. ODER: Bewertung (nur Sterne, ohne Text) sofort bei Phasenwechsel speichern, dann stimmt die Aussage
+3. Empfehlung: Option 2 — Sterne sofort speichern (fire-and-forget), Text erst bei Button. Dann stimmt "bereits gespeichert" und kein Rating geht verloren.
+
+### SEC-1 — Rate-Endpoint ohne Auth
+
+**Problem:** `/api/review/[caseId]/rate` hat keine Authentifizierung. Jeder mit einer UUID kann Bewertungen abgeben.
+
+**Lösung:**
+1. Token als `authorization` Header oder Query-Parameter mitsenden
+2. `validateVerifyToken(caseId, createdAt, token)` im Rate-Endpoint prüfen
+3. ReviewSurfaceClient: Token aus URL auslesen, bei jedem `saveReview()` mitsenden
+
+### SEC-2 — Review-Link läuft nie ab
+
+**Problem:** HMAC hat keinen Timestamp → Link ist ewig gültig.
+
+**Lösung:** 90-Tage-Ablauf:
+1. `generateVerifyToken()` bekommt optionalen `maxAgeDays` Parameter
+2. Server-Side: Prüfe `review_sent_at` + 90 Tage > jetzt
+3. Abgelaufener Link → freundliche Meldung "Dieser Link ist leider abgelaufen"
+
+### BUG-1 — deriveReviewStatus: "bewertet" fehlt
+
+**Problem:** Nach Rating zeigt UI "Geöffnet" statt "Bewertet". Es gibt keinen Status `bewertet`.
+
+**Lösung:**
+1. Neuen Status `bewertet` hinzufügen (höchste Priorität in der Logik)
+2. Check: `review_rating IS NOT NULL` → Status = `bewertet`
+3. Sub-Status: `bewertet_positiv` (≥4★) vs `bewertet_negativ` (≤3★)
+4. UI: Grüner Haken + Sterne-Anzeige im BewertungEndCap
+
+### FB40 — SMS zu lang / hässlich
+
+**Problem:** Volle Token-URL sprengt 160 Zeichen.
+
+**Lösung:** Short-Token wie bei postCallSms.ts:
+1. `generateShortVerifyToken()` statt `generateVerifyToken()` verwenden
+2. Kurze URL: `flowsight.ch/r/{caseRef}?t={shortToken}` (ca. 45 Zeichen statt ~100)
+3. Neuer Route-Handler: `/r/[caseRef]` → Redirect auf `/review/[caseId]?token=...`
+
+### FB34 — Erledigt-Button Rand-Logik
+
+**Problem:** Erledigt-Button zeigt keinen Bewertungsstatus.
+
+**Lösung (Founder-Design):**
+
+| Zustand | Füllung | Rand |
+|---------|---------|------|
+| Erledigt, keine Anfrage | Grün | Grün |
+| Erledigt, Bewertung angefragt | Grün | Gold |
+| Erledigt, Bewertung ≥4★ | Gold | Gold |
+| Erledigt, Bewertung ≤3★ | Grün | Rot |
+
+Implementierung: In SystemCard den "Erledigt"-Node um `review_status` erweitern. Rand = `border-2` mit dynamischer Farbe.
+
+### FB35 — Kategorien-Dropdown (Tenant-dynamisch)
+
+**Problem:** Wizard hat dynamische Kategorien pro Tenant, Leitstand hat Freitext-Input.
+
+**Lösung:**
+1. `getCustomer(tenantSlug)` im CaseDetailForm → `.categories` Array laden
+2. `<select>` Dropdown statt `<input type="text">`
+3. Fallback: Freitext-Option "Andere" am Ende der Liste
+4. Gleiche Lösung für CreateCaseModal
+5. **Voraussetzung:** Tenant-Slug muss im Case-Detail-Context verfügbar sein (über tenant_id → slug Lookup)
+
+### FB38 — Login-Redirect: Ziel-URL bewahren
+
+**Problem:** Auth-Guard leitet auf `/ops/login` ohne `?next=` Parameter.
+
+**Lösung:**
+1. `middleware.ts` erweitern: Wenn User nicht eingeloggt + Pfad beginnt mit `/ops` (nicht `/ops/login`) → Redirect auf `/ops/login?next={currentPath}`
+2. `LoginForm.tsx` liest `next` Parameter bereits (Zeile 39) → funktioniert sofort
+3. Kein Umbau nötig, nur Middleware-Erweiterung
+
+### FB44 — Fehlermeldungen deutsch
+
+**Lösung:** Fehlendes Mapping ergänzen:
+```typescript
+const MSG: Record<string, string> = {
+  case_not_done: "Der Fall muss zuerst als \"Erledigt\" gespeichert werden.",
+  no_contact_info: "Keine E-Mail oder Telefonnummer beim Kunden hinterlegt.",
+  max_reviews_reached: "Maximale Anzahl Bewertungsanfragen erreicht (2).",
+  cooldown_active: "Bitte 7 Tage warten bis zur nächsten Anfrage.",
+  review_skipped: "Für diesen Fall wurde keine Bewertung angefragt.",
+  review_send_failed: "Bewertungsanfrage konnte nicht gesendet werden.",
+};
+```
+
+### PUSH-1 — Negativ-Push: eigener Event-Type
+
+**Problem:** `notfall` Event-Type für negative Reviews → Staff mit deaktiviertem Notfall-Push bekommt kein Alert.
+
+**Lösung:** Eigenen Event-Type `negative_review` einführen:
+1. In `sendOpsPush.ts` Filter-Logik: `negative_review` → IMMER senden (kein Opt-out, bypass Preferences)
+2. In `rate/route.ts`: `eventType: rating <= 3 ? "negative_review" : "review"`
+3. Push-Kategorie "Negatives Kundenfeedback" = nicht abschaltbar (business-critical)
+
+### PUSH-2 — Push-Preferences UI
+
+**Problem:** PATCH-Endpoint existiert, aber keine UI. Betrieb kann Preferences nicht ändern.
+
+**Lösung:** Neuer Abschnitt auf Settings-Seite:
+```
+Benachrichtigungen
+─────────────────
+🔔 Push-Benachrichtigungen          [Aktiviert ✓]
+
+  Immer aktiv (nicht deaktivierbar):
+  • Notfälle
+  • Negatives Kundenfeedback
+  • Ihnen zugewiesene Fälle
+
+  Optional:
+  ○ Positives Kundenfeedback         [An / Aus]
+  ○ Alle neuen Fälle                 [An / Aus]
+```
+Liest/schreibt über PATCH `/api/ops/push/subscribe`.
+
+### PUSH-3 — Zuweisung-Push: nur zugewiesene Person
+
+**Problem:** `notify-assignees` sendet an ALLE Staff mit `notify_assignment=true`, nicht nur an die zugewiesene Person.
+
+**Lösung:** `targetUserId` Parameter in `sendOpsPush()` bereits vorgesehen. Nutzen: nur Subscriptions mit matchendem `user_id` filtern.
+
+### BUG-3 — Double-Submit
+
+**Lösung:** Conditional Update: `WHERE review_rating IS NULL` (nur erstes Rating zählt). Rate-Endpoint: Bei zweitem Submit → `{ ok: true, already_rated: true }` statt Überschreibung.
+
+### BUG-4 — review_surface_opened Deduplizierung
+
+**Lösung:** Vor Insert prüfen: Gibt es bereits ein `review_surface_opened` Event für diesen Case? Wenn ja → kein neues Event.
+
+### BUG-5 — review_sent_count nie inkrementiert
+
+**Lösung:** In `request-review/route.ts` nach erfolgreichem Send:
+```sql
+UPDATE cases SET review_sent_count = review_sent_count + 1 WHERE id = ?
+```
+
+### X2 — faelle Seite: is_deleted Filter
+
+**Lösung:** `.eq("is_deleted", false)` zur Query hinzufügen (wie in cases/page.tsx).
+
+### X3 — "Voice Agent" englisch in E-Mail
+
+**Lösung:** `SOURCE_LABELS` in `resend.ts`: `voice: "Sprachassistent"` statt `"Voice Agent"`.
+
+---
+
+## Implementierungsreihenfolge
+
+### Runde 1 — Blocker (1 PR)
+
+1. `normalizeSwissPhone()` Utility erstellen (`src/lib/phone/normalizeSwissPhone.ts`)
+2. FB27: Normalisierung einbauen (CaseDetailForm, sendSmsEcall, request-review)
+3. FB36: Neuer Endpunkt `POST /api/ops/cases` mit `resolveTenantScope()`
+4. FB41: Stars bei Phasenwechsel auto-speichern (fire-and-forget)
+5. SEC-1: Token-Validierung im Rate-Endpoint
+6. SEC-2: 90-Tage-Ablauf auf Review-Links
+7. BUG-1: `bewertet` / `bewertet_positiv` / `bewertet_negativ` in deriveReviewStatus
+8. FB44: Fehlermeldungen deutsch + X3 Voice Agent Label
+
+### Runde 2 — UX (1 PR)
+
+1. FB40: Short-Token SMS-URL + `/r/[caseRef]` Redirect-Route
+2. FB34: Erledigt-Button Rand-Logik (SystemCard + FlowBar)
+3. FB35: Kategorien-Dropdown (CaseDetailForm + CreateCaseModal)
+4. FB38: Middleware Login-Redirect mit `?next=`
+5. PUSH-1: Negativ-Push eigener Event-Type `negative_review` (immer aktiv)
+6. PUSH-2: Push-Preferences UI auf Settings-Seite
+7. PUSH-3: Zuweisung-Push nur an zugewiesene Person
+8. BUG-3: Double-Submit Guard (conditional update)
+9. BUG-4: review_surface_opened Deduplizierung
+10. BUG-5: review_sent_count Inkrement
+9. X2: is_deleted Filter auf faelle-Seite
+
+### Runde 3 — Nice to have (optional, separater PR)
+
+1. FB35b: Foto-Upload in CreateCaseModal
+2. FB34b: KPI Bewertungen Ø + n in SystemCard
+
+---
+
+## Verification Checklist
+
+### Runde 1 — nach Merge testen:
+
+- [ ] Fall manuell erstellen → erscheint sofort in Fallliste
+- [ ] Telefon `076 123 45 67` eingeben → wird zu `+41 76 123 45 67` normalisiert
+- [ ] SMS-Bewertungsanfrage mit `076`-Nummer → SMS kommt an
+- [ ] Stammkunden-Check: `076...` matcht mit `+41 76...`
+- [ ] Review Surface: 4★ klicken → Text sagt NICHT "bereits gespeichert" (oder Sterne sind tatsächlich gespeichert)
+- [ ] Rate-Endpoint: Request ohne Token → 401
+- [ ] Review-Link nach 90 Tagen → "Link abgelaufen" Meldung
+- [ ] Fall bewerten → Status in Leitstand zeigt "Bewertet" (nicht "Geöffnet")
+- [ ] Fehlermeldung bei "Nicht anfragen" → deutsch
+
+### Runde 2 — nach Merge testen:
+
+- [ ] SMS-Link kurz und tippbar (< 160 Zeichen gesamt)
+- [ ] Erledigt-Button: grün → gold-Rand (angefragt) → gold-voll (positiv) → rot-Rand (negativ)
+- [ ] Kategorie-Dropdown zeigt Tenant-spezifische Kategorien
+- [ ] E-Mail "Fall öffnen" → Login → landet auf richtigem Fall
+- [ ] Negatives Rating → Push kommt auch bei deaktiviertem Notfall-Push
+- [ ] Doppelklick auf "Feedback senden" → nur 1 Event im Verlauf
+- [ ] Gelöschte Fälle nicht mehr in faelle-Tabelle

--- a/src/web/app/api/cases/route.ts
+++ b/src/web/app/api/cases/route.ts
@@ -8,6 +8,7 @@ import { getTenantSmsConfig } from "@/src/lib/tenants/getTenantSmsConfig";
 import { sendPostCallSms } from "@/src/lib/sms/postCallSms";
 import { generateShortVerifyToken } from "@/src/lib/sms/verifySmsToken";
 import { APP_BASE_URL } from "@/src/lib/config/appUrl";
+import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 
 // ---------------------------------------------------------------------------
 // Validation helpers (aligned with case_contract.md)
@@ -178,12 +179,17 @@ export async function POST(request: NextRequest) {
 
   const data = validation.data;
 
-  // Resolve tenant_id: body.tenant_id > tenant_slug lookup > FALLBACK_TENANT_ID
+  // Resolve tenant_id: body.tenant_id > tenant_slug lookup > OPS session > FALLBACK_TENANT_ID
   let tenantId = data.tenant_id;
   if (!tenantId && data.tenant_slug) {
     const supabase = getServiceClient();
     const { data: t } = await supabase.from("tenants").select("id").eq("slug", data.tenant_slug).single();
     if (t) tenantId = t.id;
+  }
+  // For manual cases from Leitstand: derive tenant from logged-in user's session
+  if (!tenantId && data.source === "manual") {
+    const scope = await resolveTenantScope();
+    if (scope?.tenantId) tenantId = scope.tenantId;
   }
   tenantId = tenantId ?? process.env.FALLBACK_TENANT_ID;
   if (!tenantId) {

--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -7,6 +7,7 @@ import { sendSms } from "@/src/lib/sms/sendSms";
 import { getTenantSmsConfig } from "@/src/lib/tenants/getTenantSmsConfig";
 import { generateVerifyToken } from "@/src/lib/sms/verifySmsToken";
 import { APP_BASE_URL } from "@/src/lib/config/appUrl";
+import { normalizeSwissPhone } from "@/src/lib/phone/normalizeSwissPhone";
 
 // ---------------------------------------------------------------------------
 // POST /api/ops/cases/[id]/request-review
@@ -89,15 +90,17 @@ export async function POST(
 
   // ── B6: Stammkunden-Schutz — max 1 review request per contact per 6 months
   // Prevents nagging repeat customers who visit multiple times per year.
+  // Normalize phone for consistent matching (076... == +4176...)
+  const normalizedPhone = row.contact_phone ? normalizeSwissPhone(row.contact_phone) ?? row.contact_phone : null;
+
   const contactIdentifiers: string[] = [];
   if (row.contact_email) contactIdentifiers.push(row.contact_email);
-  if (row.contact_phone) contactIdentifiers.push(row.contact_phone);
+  if (normalizedPhone) contactIdentifiers.push(normalizedPhone);
 
   // Founder test contacts — exempt from repeat-customer check
   const WHITELISTED_CONTACTS = [
     "gunnar.wende@flowsight.ch",
     "+41764458942",
-    "0764458942",
     "+41445520919",
   ];
   const isWhitelisted = contactIdentifiers.some(c => WHITELISTED_CONTACTS.includes(c));
@@ -114,13 +117,13 @@ export async function POST(
       .not("review_sent_at", "is", null)
       .gte("review_sent_at", sixMonthsAgo);
 
-    // Check by email OR phone
-    if (row.contact_email && row.contact_phone) {
-      recentRequestQuery = recentRequestQuery.or(`contact_email.eq.${row.contact_email},contact_phone.eq.${row.contact_phone}`);
+    // Check by email OR phone (use normalized phone for matching)
+    if (row.contact_email && normalizedPhone) {
+      recentRequestQuery = recentRequestQuery.or(`contact_email.eq.${row.contact_email},contact_phone.eq.${normalizedPhone}`);
     } else if (row.contact_email) {
       recentRequestQuery = recentRequestQuery.eq("contact_email", row.contact_email);
     } else {
-      recentRequestQuery = recentRequestQuery.eq("contact_phone", row.contact_phone!);
+      recentRequestQuery = recentRequestQuery.eq("contact_phone", normalizedPhone!);
     }
 
     const { data: recentRequests } = await recentRequestQuery;

--- a/src/web/app/api/review/[caseId]/rate/route.ts
+++ b/src/web/app/api/review/[caseId]/rate/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getServiceClient } from "@/src/lib/supabase/server";
+import { validateVerifyToken } from "@/src/lib/sms/verifySmsToken";
 
 // POST /api/review/[caseId]/rate — Save customer rating + optional text from review surface
 export async function POST(
@@ -10,6 +11,7 @@ export async function POST(
 
   let rating: number;
   let text: string | null = null;
+  let token: string | null = null;
   try {
     const body = await req.json();
     rating = Number(body.rating);
@@ -19,18 +21,30 @@ export async function POST(
     if (typeof body.text === "string" && body.text.trim().length > 0) {
       text = body.text.trim().slice(0, 2000);
     }
+    if (typeof body.token === "string") {
+      token = body.token;
+    }
   } catch {
     return NextResponse.json({ error: "Invalid body" }, { status: 400 });
   }
 
   const supabase = getServiceClient();
 
-  // Get tenant_id + reporter_name for push notification
+  // Get case data for token validation + push notification
   const { data: caseRow } = await supabase
     .from("cases")
-    .select("tenant_id, reporter_name")
+    .select("tenant_id, reporter_name, created_at")
     .eq("id", caseId)
     .single();
+
+  if (!caseRow) {
+    return NextResponse.json({ error: "Case not found" }, { status: 404 });
+  }
+
+  // Token validation — prevents unauthenticated rating spam
+  if (!token || !validateVerifyToken(caseId, caseRow.created_at, token)) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
 
   const updatePayload: Record<string, unknown> = {
     review_rating: rating,

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -7,6 +7,7 @@ import type { CaseEvent } from "@/src/components/ops/CaseTimeline";
 import { AttachmentsSection } from "./AttachmentsSection";
 import { AppointmentPicker } from "@/src/components/ops/AppointmentPicker";
 import { getStatusColorClass } from "@/src/lib/cases/statusColors";
+import { normalizeSwissPhone } from "@/src/lib/phone/normalizeSwissPhone";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -460,7 +461,7 @@ export function CaseDetailForm({
       house_number: houseNumber.trim() || null,
       plz: plz.trim(), city: city.trim(),
       reporter_name: reporterName.trim() || null,
-      contact_phone: contactPhone.trim() || null,
+      contact_phone: (normalizeSwissPhone(contactPhone.trim()) ?? contactPhone.trim()) || null,
       contact_email: contactEmail.trim() || null,
     });
   }
@@ -509,6 +510,7 @@ export function CaseDetailForm({
     caseStatus: status,
     hasContactInfo,
     reviewSentAt: initialData.review_sent_at,
+    reviewRating: initialData.review_rating,
     events: localEvents.map(e => ({ event_type: e.event_type, created_at: e.created_at })),
   });
   const canRequestReview = reviewInfo.canRequest || reviewInfo.canResend;
@@ -539,6 +541,8 @@ export function CaseDetailForm({
           no_contact_info: "Keine E-Mail oder Telefonnummer beim Kunden hinterlegt.",
           max_reviews_reached: "Maximale Anzahl Bewertungsanfragen erreicht (2).",
           cooldown_active: "Bitte 7 Tage warten bis zur nächsten Anfrage.",
+          review_skipped: "F\u00fcr diesen Fall wurde keine Bewertung angefragt.",
+          review_send_failed: "Bewertungsanfrage konnte nicht gesendet werden.",
         };
         throw new Error(MSG[code ?? ""] ?? `Senden fehlgeschlagen (${code ?? res.status}).`);
       }
@@ -924,7 +928,7 @@ export function CaseDetailForm({
                 <SectionHead title="Kontakt" editing onClose={cancelEdit} />
                 <div className="space-y-3">
                   <div><label className={lbl}>Kunde</label><input type="text" value={reporterName} onChange={e => setReporterName(e.target.value)} placeholder="Hans Müller" className={inp} /></div>
-                  <div><label className={lbl}>Telefon</label><input type="tel" value={contactPhone} onChange={e => setContactPhone(e.target.value)} placeholder="+41 79..." className={inp} /></div>
+                  <div><label className={lbl}>Telefon</label><input type="tel" value={contactPhone} onChange={e => setContactPhone(e.target.value)} placeholder="076 123 45 67" className={inp} /></div>
                   <div><label className={lbl}>E-Mail</label><input type="email" value={contactEmail} onChange={e => setContactEmail(e.target.value)} placeholder="name@beispiel.ch" className={inp} /></div>
                   <div className="grid grid-cols-3 gap-2">
                     <div className="col-span-2"><label className={lbl}>Strasse</label><input type="text" value={street} onChange={e => setStreet(e.target.value)} className={inp} /></div>
@@ -1328,24 +1332,40 @@ function BewertungEndCap({
   hasEvents: boolean;
 }) {
   const isActive = status === "done";
+  const isBewertet = reviewInfo.status === "bewertet_positiv" || reviewInfo.status === "bewertet_negativ";
   const reviewSent = reviewInfo.status === "angefragt" || reviewInfo.status === "geoeffnet" || reviewInfo.status === "geklickt";
-  const starsMuted = !isActive; // muted when case not yet done
+  const starsMuted = !isActive && !isBewertet;
 
   // Determine copy
   let label: string;
-  if (reviewSent) {
+  let labelColor: string;
+  if (isBewertet) {
+    label = reviewInfo.label; // "Bewertet: ★★★☆☆"
+    labelColor = reviewInfo.status === "bewertet_positiv" ? "text-amber-700" : "text-red-600";
+  } else if (reviewSent) {
     label = "Bewertung angefragt";
+    labelColor = "text-amber-700";
   } else if (status === "done" && canRequestReview) {
     label = "Bewertung anfragen";
+    labelColor = "text-gray-700";
   } else if (reviewInfo.status === "kein_kontakt") {
     label = "Kein Kontakt hinterlegt";
+    labelColor = "text-gray-400";
   } else if (reviewInfo.status === "uebersprungen") {
     label = "Keine Bewertung angefragt";
+    labelColor = "text-gray-400";
   } else if (isActive) {
     label = "Bewertung möglich";
+    labelColor = "text-gray-700";
   } else {
     label = "Nach Erledigung möglich";
+    labelColor = "text-gray-400";
   }
+
+  // Dot color: gold=rated positive, red=rated negative, amber=sent, brand=default
+  const dotColor = isBewertet
+    ? (reviewInfo.status === "bewertet_positiv" ? "#f59e0b" : "#ef4444")
+    : reviewSent ? "#f59e0b" : brandColor;
 
   return (
     <div className={`relative mt-3 pt-3 ${hasEvents ? "border-t-0" : ""}`}>
@@ -1355,20 +1375,25 @@ function BewertungEndCap({
       <div className="relative flex items-center gap-3">
         {/* Star circle — end-cap of timeline */}
         <div className="relative z-10 flex-shrink-0">
-          <div className="w-[10px] h-[10px] rounded-full" style={{ backgroundColor: reviewSent ? "#f59e0b" : brandColor, opacity: starsMuted ? 0.35 : 1 }} />
+          <div className="w-[10px] h-[10px] rounded-full" style={{ backgroundColor: dotColor, opacity: starsMuted ? 0.35 : 1 }} />
         </div>
 
         <div className="flex-1 flex flex-col sm:flex-row sm:items-center gap-2">
-          {/* Stars */}
+          {/* Stars — show actual rating when bewertet */}
           <div className="flex items-center gap-0.5">
             {[0, 1, 2, 3, 4].map(i => (
-              <StarIcon key={i} filled={reviewSent} brandColor={brandColor} muted={starsMuted} />
+              <StarIcon
+                key={i}
+                filled={isBewertet ? i < (reviewInfo.reviewRating ?? 0) : (reviewSent || isBewertet)}
+                brandColor={isBewertet && reviewInfo.status === "bewertet_negativ" ? "#ef4444" : brandColor}
+                muted={starsMuted}
+              />
             ))}
           </div>
 
           {/* Label + actions */}
           <div className="flex items-center gap-2 flex-wrap">
-            <span className={`text-sm font-medium ${reviewSent ? "text-amber-700" : isActive ? "text-gray-700" : "text-gray-400"}`}>
+            <span className={`text-sm font-medium ${labelColor}`}>
               {label}
             </span>
 

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -40,6 +40,7 @@ export interface CaseDetail {
   scheduled_end_at: string | null;
   internal_notes: string | null;
   review_sent_at: string | null;
+  review_rating: number | null;
   is_deleted: boolean | null;
   deleted_at: string | null;
 }

--- a/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
+++ b/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
@@ -11,6 +11,7 @@ interface Props {
   googleReviewUrl: string | null;
   trackUrl: string | null;
   caseId?: string;
+  token?: string;
 }
 
 const STAR_PATH =
@@ -32,6 +33,7 @@ export function ReviewSurfaceClient({
   googleReviewUrl,
   trackUrl,
   caseId,
+  token,
 }: Props) {
   const [rating, setRating] = useState<number>(0);
   const [hoverRating, setHoverRating] = useState<number>(0);
@@ -66,15 +68,15 @@ export function ReviewSurfaceClient({
       await fetch(`/api/review/${caseId}/rate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ rating: stars, ...(text ? { text } : {}) }),
+        body: JSON.stringify({ rating: stars, ...(text ? { text } : {}), ...(token ? { token } : {}) }),
       });
     } catch { /* fire-and-forget */ }
     setSaving(false);
   }
 
   // B9: Stars are ALWAYS clickable. Rating changes dynamically.
-  // Rating is NOT saved on star click — only when customer explicitly submits.
-  // This prevents premature push notifications (e.g., 2★ push before customer changes to 5★).
+  // Auto-save rating (stars only, no text) on phase transition so
+  // "bereits gespeichert" is accurate. Text is added on explicit submit.
   function handleStarClick(n: number) {
     setRating(n);
     // Reset chips/text when switching between positive/negative
@@ -86,6 +88,9 @@ export function ReviewSurfaceClient({
       setSelectedChips(new Set());
       setFreeText("");
     }
+    // Auto-save stars (fire-and-forget, no text) so rating isn't lost
+    // if customer leaves before clicking a button
+    saveReview(n);
   }
 
   function toggleChip(chip: string) {
@@ -261,16 +266,16 @@ export function ReviewSurfaceClient({
                     </svg>
                     {copied ? "Text kopiert — Google öffnet sich..." : "Auf Google teilen (optional)"}
                   </button>
-                  {/* B5: Clarify that internal review is already saved */}
+                  {/* B5: Confirm star rating was saved */}
                   <p className="mt-2 text-center text-xs text-emerald-600 font-medium">
-                    ✓ Ihre Bewertung wurde bereits gespeichert.
+                    ✓ Ihre Sterne-Bewertung wurde gespeichert.
                   </p>
                   <button
                     type="button"
                     onClick={handlePositiveFeedback}
                     className="mt-2 w-full text-center text-xs text-gray-400 hover:text-gray-600 transition-colors py-1"
                   >
-                    Kein Google-Konto? Kein Problem — einfach hier fertig.
+                    Kein Google-Konto? Einfach hier abschliessen.
                   </button>
                 </>
               ) : (

--- a/src/web/app/review/[caseId]/page.tsx
+++ b/src/web/app/review/[caseId]/page.tsx
@@ -36,7 +36,7 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
   const supabase = getServiceClient();
   const { data: caseRow, error } = await supabase
     .from("cases")
-    .select("id, created_at, tenant_id, category, plz, city")
+    .select("id, created_at, tenant_id, category, plz, city, review_sent_at")
     .eq("id", caseId)
     .single();
 
@@ -45,6 +45,23 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
   // ── HMAC validation ─────────────────────────────────────────────────
   if (!validateVerifyToken(caseId, caseRow.created_at, token)) {
     return invalidShell;
+  }
+
+  // ── 90-day expiry ──────────────────────────────────────────────────
+  const REVIEW_LINK_MAX_AGE_DAYS = 90;
+  const sentAt = caseRow.review_sent_at ? new Date(caseRow.review_sent_at) : new Date(caseRow.created_at);
+  const daysSinceSent = (Date.now() - sentAt.getTime()) / (1000 * 60 * 60 * 24);
+  if (daysSinceSent > REVIEW_LINK_MAX_AGE_DAYS) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-gray-100 p-4">
+        <div className="w-full max-w-[420px] rounded-2xl bg-white p-8 text-center shadow-lg">
+          <p className="text-lg font-semibold text-gray-900">Link abgelaufen</p>
+          <p className="mt-2 text-sm text-gray-500">
+            Dieser Bewertungslink ist leider abgelaufen. Bitte kontaktieren Sie den Betrieb direkt.
+          </p>
+        </div>
+      </div>
+    );
   }
 
   // ── Resolve tenant ─────────────────────────────────────────────────
@@ -97,6 +114,7 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
       googleReviewUrl={googleReviewUrl}
       trackUrl={`/api/review/${caseId}/track`}
       caseId={caseId}
+      token={token}
     />
   );
 }

--- a/src/web/src/components/ops/CreateCaseModal.tsx
+++ b/src/web/src/components/ops/CreateCaseModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { PLZ_CITY_MAP } from "@/src/lib/plz/plzCityMap";
+import { normalizeSwissPhone } from "@/src/lib/phone/normalizeSwissPhone";
 
 const CATEGORIES = [
   "Sanitär",
@@ -79,7 +80,7 @@ export function CreateCaseModal({
         body: JSON.stringify({
           source: "manual",
           reporter_name: reporterName.trim() || undefined,
-          contact_phone: phone.trim() || undefined,
+          contact_phone: (normalizeSwissPhone(phone.trim()) ?? phone.trim()) || undefined,
           contact_email: email.trim() || undefined,
           plz: plz.trim(),
           city: city.trim(),
@@ -194,7 +195,7 @@ export function CreateCaseModal({
               required
               value={phone}
               onChange={(e) => setPhone(e.target.value)}
-              placeholder="+41 79 123 45 67"
+              placeholder="076 123 45 67"
               className={reqClass(phone)}
             />
           </div>

--- a/src/web/src/lib/email/resend.ts
+++ b/src/web/src/lib/email/resend.ts
@@ -49,7 +49,7 @@ function formatCaseLabel(caseId: string, seqNumber?: number | null, prefix: stri
 // ---------------------------------------------------------------------------
 
 const SOURCE_LABELS: Record<string, string> = {
-  voice: "Voice Agent",
+  voice: "Sprachassistent",
   wizard: "Website-Formular",
   manual: "Manuell erfasst",
 };

--- a/src/web/src/lib/phone/normalizeSwissPhone.ts
+++ b/src/web/src/lib/phone/normalizeSwissPhone.ts
@@ -1,0 +1,31 @@
+/**
+ * Normalize a Swiss phone number to E.164 format (+41...).
+ *
+ * Accepts:
+ *   076 123 45 67  →  +41761234567
+ *   0761234567     →  +41761234567
+ *   +41 76 123 45 67 → +41761234567
+ *   0041761234567  →  +41761234567
+ *
+ * Returns null if the input doesn't look like a valid Swiss number.
+ */
+export function normalizeSwissPhone(raw: string): string | null {
+  // Strip whitespace, dashes, dots, parentheses
+  const cleaned = raw.replace(/[\s\-.()/]/g, "");
+
+  if (cleaned.length === 0) return null;
+
+  // Already E.164: +41...
+  if (/^\+41\d{9}$/.test(cleaned)) return cleaned;
+
+  // International with 00 prefix: 0041...
+  if (/^0041\d{9}$/.test(cleaned)) return "+" + cleaned.slice(2);
+
+  // Local format: 07x... (10 digits)
+  if (/^0[1-9]\d{8}$/.test(cleaned)) return "+41" + cleaned.slice(1);
+
+  // Partial E.164 without +: 41... (11 digits starting with 41)
+  if (/^41\d{9}$/.test(cleaned)) return "+" + cleaned;
+
+  return null;
+}

--- a/src/web/src/lib/reviews/deriveReviewStatus.ts
+++ b/src/web/src/lib/reviews/deriveReviewStatus.ts
@@ -3,13 +3,15 @@
 // ---------------------------------------------------------------------------
 
 export type ReviewStatus =
-  | "moeglich"        // done + contact data + no review sent → green
-  | "angefragt"       // review_sent_at set, no surface opened → yellow
-  | "geoeffnet"       // surface_opened event → blue
-  | "geklickt"        // cta_clicked event → strong green
-  | "kein_kontakt"    // done + no contact data → gray
-  | "uebersprungen"   // explicit skip → gray
-  | "nicht_bereit"    // not done yet → hidden
+  | "bewertet_positiv" // customer rated ≥4★ → gold
+  | "bewertet_negativ" // customer rated ≤3★ → red accent
+  | "moeglich"         // done + contact data + no review sent → green
+  | "angefragt"        // review_sent_at set, no surface opened → yellow
+  | "geoeffnet"        // surface_opened event → blue
+  | "geklickt"         // cta_clicked event → strong green
+  | "kein_kontakt"     // done + no contact data → gray
+  | "uebersprungen"    // explicit skip → gray
+  | "nicht_bereit"     // not done yet → hidden
   ;
 
 export interface ReviewStatusInfo {
@@ -20,6 +22,7 @@ export interface ReviewStatusInfo {
   canResend: boolean;
   canSkip: boolean;
   reviewCount: number;
+  reviewRating?: number; // 1-5, present when bewertet
 }
 
 const MAX_REVIEW_REQUESTS = 2;
@@ -34,9 +37,10 @@ export function deriveReviewStatus(opts: {
   caseStatus: string;
   hasContactInfo: boolean;
   reviewSentAt: string | null;
+  reviewRating: number | null;
   events: CaseEvent[];
 }): ReviewStatusInfo {
-  const { caseStatus, hasContactInfo, events } = opts;
+  const { caseStatus, hasContactInfo, events, reviewRating } = opts;
 
   // Not done → not ready for review
   if (caseStatus !== "done") {
@@ -56,6 +60,24 @@ export function deriveReviewStatus(opts: {
   const hasSkipped = events.some(e => e.event_type === "review_skipped");
   const hasSurfaceOpened = events.some(e => e.event_type === "review_surface_opened");
   const hasCtaClicked = events.some(e => e.event_type === "review_cta_clicked");
+
+  // ── Customer has rated → highest priority ──────────────────────────
+  if (reviewRating != null && reviewRating >= 1 && reviewRating <= 5) {
+    const isPositive = reviewRating >= 4;
+    const stars = "\u2605".repeat(reviewRating) + "\u2606".repeat(5 - reviewRating);
+    return {
+      status: isPositive ? "bewertet_positiv" : "bewertet_negativ",
+      label: `Bewertet: ${stars}`,
+      color: isPositive
+        ? "bg-amber-50 text-amber-800 border-amber-300"
+        : "bg-red-50 text-red-700 border-red-300",
+      canRequest: false,
+      canResend: false,
+      canSkip: false,
+      reviewCount,
+      reviewRating,
+    };
+  }
 
   // Explicit skip
   if (hasSkipped) {

--- a/src/web/src/lib/sms/sendSmsEcall.ts
+++ b/src/web/src/lib/sms/sendSmsEcall.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { SendSmsResult } from "./sendSms";
+import { normalizeSwissPhone } from "../phone/normalizeSwissPhone";
 
 /**
  * Send an SMS via eCall.ch REST API (Swiss SMS gateway).
@@ -18,17 +19,23 @@ import type { SendSmsResult } from "./sendSms";
  * 2. Numeric fallback (ECALL_SENDER_NUMBER) — if alphanumeric is empty or too long.
  *
  * Phone format: eCall expects international format with 00 prefix (e.g. 0041791234567).
- * We accept E.164 (+41...) and convert automatically.
+ * We accept E.164 (+41...), local (076...), and 0041... and convert automatically.
  *
  * Never throws — returns result with sent:false on any error.
  */
 
-/** Convert E.164 (+41791234567) to eCall format (0041791234567). */
-function toEcallNumber(e164: string): string {
-  if (e164.startsWith("+")) {
-    return "00" + e164.slice(1);
+/** Convert any Swiss phone number to eCall format (0041791234567). */
+function toEcallNumber(input: string): string {
+  // Normalize to E.164 first (handles 076... → +41...), then convert +→00
+  const normalized = normalizeSwissPhone(input);
+  if (normalized) {
+    return "00" + normalized.slice(1); // +41... → 0041...
   }
-  return e164;
+  // Fallback: original conversion for already-formatted numbers
+  if (input.startsWith("+")) {
+    return "00" + input.slice(1);
+  }
+  return input;
 }
 
 export async function sendSmsEcall(


### PR DESCRIPTION
## Summary
Bewertungen-System produktionsreif machen — alle harten Bugs aus Founder-Testing (FB27-FB44) + Security-Audit.

**Phone normalization (FB27/39/X1):**
- `normalizeSwissPhone()` utility: `076...` → `+4176...` automatisch
- Eingebaut in CaseDetailForm, CreateCaseModal, sendSmsEcall, Stammkunden-Check
- Placeholder: `076 123 45 67` (Betrieb tippt lokales Format)

**Case creation tenant fix (FB36):**
- Manuell erstellte Fälle lösen tenant_id aus OPS-Session (resolveTenantScope)
- Verhindert unsichtbare Fälle durch falschen Tenant + RLS

**Review surface (FB41):**
- Sterne auto-save bei Klick (fire-and-forget) — "gespeichert" stimmt jetzt
- Token wird bei jedem Rate-Request mitgesendet (SEC-1)

**Security:**
- `/api/review/[caseId]/rate` validiert jetzt HMAC-Token (war 0 Auth)
- Review-Links laufen nach 90 Tagen ab (SEC-2)

**Review status (BUG-1):**
- `deriveReviewStatus` kennt jetzt `bewertet_positiv` / `bewertet_negativ`
- BewertungEndCap zeigt tatsächliche Sterne + Farbcodierung

**Error messages (FB44/X3):**
- `review_skipped`, `review_send_failed` auf Deutsch
- "Voice Agent" → "Sprachassistent" in E-Mail-Labels

## Test plan
- [ ] Telefon `076 123 45 67` eingeben → wird normalisiert gespeichert
- [ ] SMS-Bewertungsanfrage mit `076`-Nummer → SMS kommt an
- [ ] Fall manuell erstellen → erscheint sofort in Fallliste
- [ ] Review Surface: Sterne klicken → "gespeichert" Text erscheint (stimmt jetzt)
- [ ] Rate-Endpoint ohne Token → 401
- [ ] Fall bewerten → BewertungEndCap zeigt "Bewertet: ★★★★☆"
- [ ] Negative Bewertung → rote Farbcodierung im EndCap
- [ ] Fehlermeldung "Nicht anfragen" → deutsch

🤖 Generated with [Claude Code](https://claude.com/claude-code)