### PR TITLE
fix: Bewertungen Runde 2 — UX, Push, Kategorien, 6 Bugfixes

### DIFF
--- a/src/web/app/api/ops/cases/[id]/notify-assignees/route.ts
+++ b/src/web/app/api/ops/cases/[id]/notify-assignees/route.ts
@@ -63,7 +63,7 @@ export async function POST(
       resolveTenantIdentityById(row.tenant_id),
       supabase
         .from("staff")
-        .select("display_name, email")
+        .select("display_name, email, user_id")
         .eq("tenant_id", row.tenant_id)
         .in("display_name", names)
         .eq("is_active", true),
@@ -105,9 +105,9 @@ export async function POST(
 
     const sentCount = results.filter(Boolean).length;
 
-    // Push notification to assigned staff (best-effort)
+    // Push notification to assigned staff only (best-effort, targeted per person)
     import("@/src/lib/push/sendOpsPush").then(({ sendOpsPush }) => {
-      for (const s of staffWithEmail) {
+      for (const s of staffWithEmail as { display_name: string; email: string; user_id: string | null }[]) {
         sendOpsPush({
           tenantId: scope.tenantId!,
           eventType: "assignment",
@@ -115,6 +115,7 @@ export async function POST(
           body: `${row.category}: ${row.city} — ${row.urgency === "notfall" ? "NOTFALL" : row.urgency}`,
           url: `/ops/cases/${id}`,
           tag: `assign-${id}`,
+          ...(s.user_id ? { targetUserId: s.user_id } : {}),
         });
       }
     }).catch(() => {});

--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -5,7 +5,7 @@ import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 import { sendReviewRequest } from "@/src/lib/email/resend";
 import { sendSms } from "@/src/lib/sms/sendSms";
 import { getTenantSmsConfig } from "@/src/lib/tenants/getTenantSmsConfig";
-import { generateVerifyToken } from "@/src/lib/sms/verifySmsToken";
+import { generateVerifyToken, generateShortVerifyToken } from "@/src/lib/sms/verifySmsToken";
 import { APP_BASE_URL } from "@/src/lib/config/appUrl";
 import { normalizeSwissPhone } from "@/src/lib/phone/normalizeSwissPhone";
 
@@ -35,7 +35,7 @@ export async function POST(
   const supabase = getServiceClient();
   const { data: row, error: dbError } = await supabase
     .from("cases")
-    .select("id, created_at, tenant_id, status, contact_email, contact_phone, review_sent_at, category, plz, city")
+    .select("id, created_at, tenant_id, status, contact_email, contact_phone, review_sent_at, review_sent_count, category, plz, city, seq_number")
     .eq("id", id)
     .single();
 
@@ -171,14 +171,16 @@ export async function POST(
   let googleReviewUrl: string | undefined;
   let tenantDisplayName: string | undefined;
   let primaryColor: string | undefined;
+  let caseIdPrefix: string | undefined;
   {
     const { data: tenant } = await supabase
       .from("tenants")
-      .select("name, modules")
+      .select("name, modules, case_id_prefix")
       .eq("id", row.tenant_id)
       .single();
 
     tenantDisplayName = tenant?.name ?? undefined;
+    caseIdPrefix = (tenant as Record<string, unknown> | null)?.case_id_prefix as string | undefined;
     const modules = tenant?.modules as Record<string, unknown> | null;
     if (typeof modules?.google_review_url === "string" && modules.google_review_url.length > 0) {
       googleReviewUrl = modules.google_review_url;
@@ -226,8 +228,11 @@ export async function POST(
     channel = "sms";
     const smsConfig = await getTenantSmsConfig(row.tenant_id);
     const senderName = smsConfig?.senderName ?? "FlowSight";
-    // ≤ 160 chars: personal thanks + clear CTA
-    const smsBody = `${senderName}: Vielen Dank für Ihr Vertrauen. Über eine kurze Bewertung freuen wir uns:\n${reviewSurfaceUrl}`;
+    // Build short URL for SMS (< 160 chars total)
+    const shortToken = generateShortVerifyToken(id, row.created_at);
+    const caseRef = caseIdPrefix && row.seq_number ? `${caseIdPrefix}-${row.seq_number}` : id;
+    const smsReviewUrl = `${APP_BASE_URL}/r/${caseRef}?t=${shortToken}`;
+    const smsBody = `${senderName}: Vielen Dank für Ihr Vertrauen. Über eine kurze Bewertung freuen wir uns:\n${smsReviewUrl}`;
     const smsResult = await sendSms(row.contact_phone, smsBody, senderName);
     sent = smsResult.sent;
   }
@@ -247,7 +252,7 @@ export async function POST(
   // ── Set review_sent_at ────────────────────────────────────────────────
   const { error: updateError } = await supabase
     .from("cases")
-    .update({ review_sent_at: new Date().toISOString() })
+    .update({ review_sent_at: new Date().toISOString(), review_sent_count: (row.review_sent_count ?? 0) + 1 })
     .eq("id", id);
 
   if (updateError) {

--- a/src/web/app/api/review/[caseId]/rate/route.ts
+++ b/src/web/app/api/review/[caseId]/rate/route.ts
@@ -46,9 +46,17 @@ export async function POST(
     return NextResponse.json({ error: "Invalid token" }, { status: 401 });
   }
 
+  // Check if already rated — allow update but skip event+push on subsequent submits
+  const { data: existingCase } = await supabase
+    .from("cases")
+    .select("review_rating")
+    .eq("id", caseId)
+    .single();
+  const isFirstRating = existingCase?.review_rating == null;
+
   const updatePayload: Record<string, unknown> = {
     review_rating: rating,
-    review_received_at: new Date().toISOString(),
+    ...(isFirstRating ? { review_received_at: new Date().toISOString() } : {}),
   };
   if (text !== null) {
     updatePayload.review_text = text;
@@ -61,6 +69,11 @@ export async function POST(
 
   if (error) {
     return NextResponse.json({ error: "Failed to save rating" }, { status: 500 });
+  }
+
+  // Only create event + push on first rating (prevents duplicate timeline entries)
+  if (!isFirstRating) {
+    return NextResponse.json({ ok: true, updated: true });
   }
 
   // Track event (B7: negative reviews flagged)
@@ -92,7 +105,7 @@ export async function POST(
     import("@/src/lib/push/sendOpsPush").then(({ sendOpsPush }) =>
       sendOpsPush({
         tenantId: caseRow.tenant_id,
-        eventType: isNegative ? "notfall" : "review", // Negative = urgent event type for louder push
+        eventType: isNegative ? "negative_review" : "review", // negative_review = always push (no opt-out)
         title,
         body: bodyText,
         url: `/ops/cases/${caseId}`,

--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -156,6 +156,7 @@ export function CaseDetailForm({
   currentStaffName,
   staffRole,
   notifySettings,
+  tenantCategories = [],
 }: {
   initialData: CaseDetail;
   isProspect?: boolean;
@@ -171,6 +172,8 @@ export function CaseDetailForm({
     terminSms: boolean;
     staffAssignment: boolean;
   };
+  /** Tenant-specific categories from customer registry (for dropdown) */
+  tenantCategories?: { value: string; label: string }[];
 }) {
   const ns = notifySettings ?? { terminEmail: true, terminSms: true, staffAssignment: true };
   // ── Field state ──────────────────────────────────────────────────────
@@ -896,7 +899,17 @@ export function CaseDetailForm({
               <div className="bg-gray-50 -m-4 p-4 rounded-xl flex-1">
                 <SectionHead title="Beschreibung" editing onClose={cancelEdit} />
                 <div className="space-y-3">
-                  <div><label className={lbl}>Kategorie</label><input type="text" value={category} onChange={e => setCategory(e.target.value)} className={inp} /></div>
+                  <div><label className={lbl}>Kategorie</label>{tenantCategories.length > 0 ? (
+                    <select value={category} onChange={e => setCategory(e.target.value)} className={inp}>
+                      {tenantCategories.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
+                      {!tenantCategories.some(c => c.value === category) && category && (
+                        <option value={category}>{category}</option>
+                      )}
+                      <option value="">Andere</option>
+                    </select>
+                  ) : (
+                    <input type="text" value={category} onChange={e => setCategory(e.target.value)} className={inp} />
+                  )}</div>
                   <div><label className={lbl}>Beschreibung</label><textarea rows={5} value={description} onChange={e => setDescription(e.target.value)} className={`${inp} max-h-60 overflow-y-auto`} /></div>
                 </div>
                 <EditActions onSave={saveBeschreibung} onCancel={cancelEdit} saving={saveState === "saving"} dirty={beschreibungDirty} error={saveState === "error" ? errorMsg : ""} />

--- a/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/page.tsx
@@ -10,6 +10,7 @@ import { CaseDetailForm } from "./CaseDetailForm";
 import { PrintButton } from "./PrintButton";
 import { DeleteButton } from "./DeleteButton";
 import { ScrollToTop } from "./ScrollToTop";
+import { getCustomer } from "@/src/lib/customers/registry";
 import type { CaseEvent } from "@/src/components/ops/CaseTimeline";
 
 // ---------------------------------------------------------------------------
@@ -117,10 +118,13 @@ export default async function CaseDetailPage({
   // Load tenant modules for notification settings (channel hints)
   const { data: tenantRow } = await supabase
     .from("tenants")
-    .select("modules")
+    .select("modules, slug")
     .eq("id", caseData.tenant_id)
     .single();
   const tenantModules = (tenantRow?.modules ?? {}) as Record<string, unknown>;
+  const tenantSlug = (tenantRow as Record<string, unknown> | null)?.slug as string | undefined;
+  const tenantCustomer = tenantSlug ? getCustomer(tenantSlug) : undefined;
+  const tenantCategories = tenantCustomer?.categories?.map(c => ({ value: c.value, label: c.label })) ?? [];
 
   // Resolve logged-in user for self-send guard + RBAC
   const authClient = await getAuthClient();
@@ -188,6 +192,7 @@ export default async function CaseDetailPage({
           terminSms: tenantModules.notify_termin_sms !== false,
           staffAssignment: tenantModules.notify_staff_assignment !== false,
         }}
+        tenantCategories={tenantCategories}
       />
 
     </>

--- a/src/web/app/ops/(dashboard)/faelle/page.tsx
+++ b/src/web/app/ops/(dashboard)/faelle/page.tsx
@@ -72,6 +72,7 @@ export default async function FaellePage({
       { count: "exact" }
     )
     .eq("is_demo", false)
+    .eq("is_deleted", false)
     .order("created_at", { ascending: false });
   if (filterTenantId) listQuery = listQuery.eq("tenant_id", filterTenantId);
 

--- a/src/web/app/r/[caseRef]/page.tsx
+++ b/src/web/app/r/[caseRef]/page.tsx
@@ -1,0 +1,83 @@
+import { redirect } from "next/navigation";
+import { getServiceClient } from "@/src/lib/supabase/server";
+import { validateShortVerifyToken, generateVerifyToken } from "@/src/lib/sms/verifySmsToken";
+
+interface PageProps {
+  params: Promise<{ caseRef: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export const dynamic = "force-dynamic";
+
+function isUuid(s: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
+}
+
+function parseCaseRef(s: string): { prefix: string; seq: number } | null {
+  const match = s.match(/^([A-Za-z]{1,5})-(\d+)$/);
+  if (!match) return null;
+  return { prefix: match[1].toUpperCase(), seq: parseInt(match[2], 10) };
+}
+
+/**
+ * Short review redirect: /r/[caseRef]?t=<16 hex chars>
+ * Validates short token, then redirects to /review/[caseId]?token=<full token>
+ */
+export default async function ReviewShortRedirect({ params, searchParams }: PageProps) {
+  const { caseRef } = await params;
+  const sp = await searchParams;
+  const shortToken = typeof sp.t === "string" ? sp.t : "";
+
+  const invalid = (
+    <div className="flex min-h-dvh items-center justify-center bg-gray-100 p-4">
+      <div className="w-full max-w-[420px] rounded-2xl bg-white p-8 text-center shadow-lg">
+        <p className="text-lg font-semibold text-gray-900">Link ung&uuml;ltig</p>
+        <p className="mt-2 text-sm text-gray-500">
+          Dieser Bewertungslink ist nicht mehr g&uuml;ltig.
+        </p>
+      </div>
+    </div>
+  );
+
+  if (!shortToken) return invalid;
+
+  const supabase = getServiceClient();
+  let caseRow: { id: string; created_at: string } | null = null;
+
+  if (isUuid(caseRef)) {
+    const { data } = await supabase
+      .from("cases")
+      .select("id, created_at")
+      .eq("id", caseRef)
+      .single();
+    caseRow = data;
+  } else {
+    const ref = parseCaseRef(caseRef);
+    if (ref) {
+      const { data: tenants } = await supabase
+        .from("tenants")
+        .select("id")
+        .eq("case_id_prefix", ref.prefix);
+      if (tenants && tenants.length > 0) {
+        const tenantIds = tenants.map((t: { id: string }) => t.id);
+        const { data } = await supabase
+          .from("cases")
+          .select("id, created_at")
+          .in("tenant_id", tenantIds)
+          .eq("seq_number", ref.seq)
+          .single();
+        caseRow = data;
+      }
+    }
+  }
+
+  if (!caseRow) return invalid;
+
+  if (!validateShortVerifyToken(caseRow.id, caseRow.created_at, shortToken)) {
+    return invalid;
+  }
+
+  // Generate full token for the review surface (it needs the long token for rate API)
+  const fullToken = generateVerifyToken(caseRow.id, caseRow.created_at);
+  redirect(`/review/${caseRow.id}?token=${fullToken}`);
+}

--- a/src/web/app/review/[caseId]/page.tsx
+++ b/src/web/app/review/[caseId]/page.tsx
@@ -88,12 +88,20 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
   const customer = tenantSlug ? getCustomer(tenantSlug) : undefined;
   const brandColor = customer?.brandColor ?? "#d4a853"; // FlowSight gold as fallback
 
-  // ── Track surface opened (fire-and-forget) ─────────────────────────
-  await supabase.from("case_events").insert({
-    case_id: caseId,
-    event_type: "review_surface_opened",
-    title: "Bewertungsseite ge\u00f6ffnet",
-  }).then(() => {});
+  // ── Track surface opened (deduplicated — only first open) ──────────
+  const { data: existingOpen } = await supabase
+    .from("case_events")
+    .select("id")
+    .eq("case_id", caseId)
+    .eq("event_type", "review_surface_opened")
+    .limit(1);
+  if (!existingOpen || existingOpen.length === 0) {
+    await supabase.from("case_events").insert({
+      case_id: caseId,
+      event_type: "review_surface_opened",
+      title: "Bewertungsseite ge\u00f6ffnet",
+    }).then(() => {});
+  }
 
   // ── Display values ─────────────────────────────────────────────────
   const location = [caseRow.plz, caseRow.city].filter(Boolean).join(" ") || "\u2014";

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -93,6 +93,20 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  // ── Redirect unauthenticated OPS users to login with ?next= ─────────
+  const pathname = request.nextUrl.pathname;
+  const isOpsProtected = pathname.startsWith("/ops") &&
+    !pathname.startsWith("/ops/login") &&
+    !pathname.startsWith("/ops/expired") &&
+    !pathname.startsWith("/ops/open") &&
+    !pathname.startsWith("/ops/app");
+
+  if (!user && isOpsProtected) {
+    const loginUrl = new URL("/ops/login", request.url);
+    loginUrl.searchParams.set("next", pathname + request.nextUrl.search);
+    return NextResponse.redirect(loginUrl);
+  }
+
   return supabaseResponse;
 }
 

--- a/src/web/src/components/ops/SystemCard.tsx
+++ b/src/web/src/components/ops/SystemCard.tsx
@@ -47,6 +47,7 @@ export function SystemCard({
       manual = 0;
     let reviewSent = 0,
       reviewReceived = 0,
+      reviewNegative = 0,
       doneTotal = 0;
 
     for (const c of cases) {
@@ -71,7 +72,10 @@ export function SystemCard({
       if (c.status === "done") {
         doneTotal++;
         if (c.review_sent_at) reviewSent++;
-        if (c.review_rating != null) reviewReceived++;
+        if (c.review_rating != null) {
+          reviewReceived++;
+          if (c.review_rating <= 3) reviewNegative++;
+        }
       }
     }
 
@@ -85,6 +89,7 @@ export function SystemCard({
       manual,
       reviewSent,
       reviewReceived,
+      reviewNegative,
       doneTotal,
     };
   }, [cases, cutoff]);
@@ -240,14 +245,24 @@ export function SystemCard({
             </button>
           </div>
 
-          {/* Erledigt — bottom center */}
+          {/* Erledigt — bottom center (border reflects review health) */}
           <div
             className="absolute left-1/2 -translate-x-1/2"
             style={{ bottom: "2%" }}
           >
             <button
               onClick={() => toggle("erledigt")}
-              className={`${nc("erledigt")} w-[100px] h-[72px] sm:w-[125px] sm:h-[85px]`}
+              className={`${nb} ${
+                activeNode === "erledigt"
+                  ? "border-blue-400 bg-blue-50 shadow-md ring-2 ring-blue-100"
+                  : stats.reviewNegative > 0
+                    ? "border-red-400 bg-white hover:shadow-sm ring-1 ring-red-100"
+                    : stats.reviewReceived > 0
+                      ? "border-amber-400 bg-amber-50/30 hover:shadow-sm"
+                      : stats.reviewSent > 0
+                        ? "border-amber-300 bg-white hover:shadow-sm"
+                        : "border-gray-200 bg-white hover:border-gray-300 hover:shadow-sm"
+              } w-[100px] h-[72px] sm:w-[125px] sm:h-[85px]`}
             >
               <div className="flex items-baseline gap-1">
                 <span className="text-xs sm:text-sm">✅</span>

--- a/src/web/src/lib/push/sendOpsPush.ts
+++ b/src/web/src/lib/push/sendOpsPush.ts
@@ -10,7 +10,7 @@ import { getServiceClient } from "@/src/lib/supabase/server";
  */
 export async function sendOpsPush(opts: {
   tenantId: string;
-  eventType: "notfall" | "assignment" | "review" | "case";
+  eventType: "notfall" | "assignment" | "review" | "negative_review" | "case";
   title: string;
   body: string;
   url?: string;
@@ -39,10 +39,11 @@ export async function sendOpsPush(opts: {
     const { data: subs } = await query;
     if (!subs || subs.length === 0) return { sent: 0, failed: 0 };
 
-    // Filter by preferences
+    // Filter by preferences (negative_review always pushes — business-critical, no opt-out)
     const filtered = subs.filter((s) => {
       switch (opts.eventType) {
         case "notfall": return s.notify_notfall;
+        case "negative_review": return true; // always push — cannot be disabled
         case "assignment": return s.notify_assignment;
         case "review": return s.notify_review;
         case "case": return s.notify_all_cases;


### PR DESCRIPTION
## Summary
Zweite Runde der Bewertungen-Fixes: UX-Verbesserungen, Push-System, und 6 Bugfixes.

**SMS Short-URL (FB40):**
- Neuer `/r/[caseRef]` Redirect-Route mit Short-Token (~45 statt ~100 Zeichen)
- SMS bleibt unter 160 Zeichen, URL auf Mobile tippbar

**Erledigt-Button Rand-Logik (FB34):**
- SystemCard: Negative Bewertungen → roter Rand, Positive → gold, Angefragt → amber

**Kategorien-Dropdown (FB35):**
- CaseDetailForm nutzt Tenant-spezifische Kategorien aus Registry
- Select-Dropdown wenn Kategorien vorhanden, Freitext als Fallback

**Login-Redirect (FB38):**
- Middleware bewahrt `?next=` bei Auth-Redirect → E-Mail Deep-Links überleben Login

**Push-System (PUSH-1/3):**
- `negative_review` Event-Type: pusht IMMER (kein Opt-out, business-critical)
- Zuweisung-Push jetzt gezielt an zugewiesene Person via `targetUserId`

**Bugfixes:**
- BUG-3: Double-Submit Guard (erstes Rating → Event+Push, danach silent update)
- BUG-4: review_surface_opened Deduplizierung
- BUG-5: review_sent_count Inkrement
- X2: Gelöschte Fälle nicht mehr in faelle-Tabelle

## Test plan
- [ ] SMS-Bewertungsanfrage → kurze URL in SMS (< 160 Zeichen)
- [ ] `/r/DA-73?t=abc123` → Redirect auf Review Surface
- [ ] SystemCard: Erledigt-Node hat roten Rand bei negativer Bewertung
- [ ] Kategorie-Dropdown im Fall-Detail zeigt Tenant-Kategorien
- [ ] E-Mail "Fall öffnen" → Login → landet auf richtigem Fall
- [ ] Negative Bewertung → Push kommt (auch wenn Notfall-Push deaktiviert)
- [ ] Doppelklick auf "Feedback senden" → nur 1 Event im Verlauf
- [ ] Gelöschte Fälle nicht in faelle-Tabelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)