### PR TITLE
feat: Bewertungen Runde 3 — KPI, Push-Preferences, Test-Setup

### DIFF
--- a/docs/redesign/leitstand/test_bewertungen_abschluss.md
+++ b/docs/redesign/leitstand/test_bewertungen_abschluss.md
@@ -1,0 +1,131 @@
+# Test-Checkliste: Bewertungen Abschluss
+
+> Founder-Test in ~15 Minuten. 3 PRs (#470, #471, #472 + Runde 3).
+> Vorbereitung: Login als Admin auf flowsight.ch/ops
+
+---
+
+## Setup: 1 Test-Fall vorbereiten (2 Min)
+
+1. Leitstand offnen: https://flowsight.ch/ops/cases
+2. "Neuer Fall" klicken
+3. Ausfullen:
+   - Name: `Test Bewertung`
+   - Telefon: `076 123 45 67` (lokales Format!)
+   - E-Mail: `gunnar.wende@flowsight.ch`
+   - PLZ/Ort: `8800 Thalwil`
+   - Kategorie: **Dropdown sollte Tenant-Kategorien zeigen** (FB35)
+4. Speichern
+
+**Pruf-Punkt:** Fall muss sofort in der Liste erscheinen (FB36).
+
+---
+
+## Test 1: Telefon-Normalisierung (1 Min)
+
+1. Fall offnen
+2. Kontakt-Bereich: Telefon sollte `+41761234567` zeigen (normalisiert)
+3. **Pass?** Nummer wurde beim Speichern automatisch umgewandelt
+
+---
+
+## Test 2: Review-Anfrage per E-Mail (3 Min)
+
+1. Status auf "Erledigt" setzen + speichern
+2. "Bewertung anfragen" klicken
+3. **Pruf:** Erfolgsmeldung "Gesendet"
+4. E-Mail-Postfach prufen: Review-Anfrage muss ankommen
+5. Link in E-Mail klicken
+6. **Pruf:** Review Surface offnet sich mit Firmen-Branding
+
+---
+
+## Test 3: Review Surface — Positiv-Pfad (3 Min)
+
+1. 5 Sterne klicken
+2. **Pruf:** Text "Sterne-Bewertung wurde gespeichert" (FB41 — stimmt jetzt)
+3. Chips auswahlen + Freitext eingeben
+4. "Auf Google teilen" klicken
+5. **Pruf:** Text wird in Zwischenablage kopiert, Google Maps offnet sich
+6. Zuruck zur Review-Surface: "Vielen Dank"-Screen
+
+---
+
+## Test 4: Review Surface — Negativ-Pfad (2 Min)
+
+1. Neuen Fall erstellen + auf "Erledigt" + Bewertung anfragen
+2. Review-Link offnen
+3. 2 Sterne klicken → Negativ-Phase
+4. Feedback-Text eingeben → "Feedback senden"
+5. **Pruf:** Danke-Meldung erscheint
+
+---
+
+## Test 5: Leitstand nach Bewertung (2 Min)
+
+1. Zuruck zum Fall im Leitstand (oder Seite neu laden)
+2. **Pruf:** BewertungEndCap zeigt "Bewertet: XX" mit echten Sternen (BUG-1)
+3. **Pruf:** Positiv = Gold-Sterne, Negativ = Rot-Sterne
+4. **Pruf:** Verlauf zeigt Review-Text + "Negatives Feedback"-Badge (wenn <=3)
+5. SystemCard prufen: Erledigt-Node hat farbigen Rand (FB34)
+6. Bewertungs-Node: zeigt Anzahl + Durchschnitt (FB34b)
+
+---
+
+## Test 6: Push-Benachrichtigung (1 Min)
+
+1. Bei Negativ-Bewertung: Push muss ankommen (trotz deaktiviertem Notfall-Push)
+2. Einstellungen > Push-Benachrichtigungen prufen:
+   - "Immer aktiv" (3 Punkte, nicht deaktivierbar)
+   - "Optional" (2 Toggles funktionieren)
+
+---
+
+## Test 7: Fehlermeldungen (1 Min)
+
+1. Fall OHNE Kontaktdaten auf "Erledigt" setzen
+2. "Bewertung anfragen" klicken
+3. **Pruf:** Deutsche Fehlermeldung "Keine E-Mail oder Telefonnummer..." (FB44)
+
+---
+
+## Test 8: Sicherheit (kurz prufen)
+
+1. Review-Link aus E-Mail: Token in URL vorhanden?
+2. Browser-Konsole: POST an /api/review/.../rate enthalt Token?
+3. Review-Link nach 90 Tagen theoretisch abgelaufen (nicht testbar, aber Code ist da)
+
+---
+
+## Test 9: Login-Redirect (1 Min)
+
+1. Abmelden
+2. Direkt-Link zu einem Fall offnen: https://flowsight.ch/ops/cases/[CASE_ID]
+3. **Pruf:** Login-Seite offnet sich
+4. Einloggen
+5. **Pruf:** Landet auf dem Fall (nicht auf der Fallliste) (FB38)
+
+---
+
+## Schnell-Ergebnis
+
+| # | Test | Pass? |
+|---|------|-------|
+| 1 | Telefon `076` → `+41` normalisiert | |
+| 2 | Review-Anfrage per E-Mail | |
+| 3 | Positiv-Pfad (5★ + Google) | |
+| 4 | Negativ-Pfad (2★ + Feedback) | |
+| 5 | Leitstand zeigt Bewertung + Sterne | |
+| 6 | Push bei negativer Bewertung | |
+| 7 | Deutsche Fehlermeldung | |
+| 8 | Token in API-Calls | |
+| 9 | Login-Redirect bewahrt URL | |
+
+---
+
+## Bekannte Limitierungen (kein Bug)
+
+- **Foto-Upload bei Fall-Erstellung:** Geht nur nach Erstellung (Edit-Modus). Feature fur spater.
+- **SMS-Test mit `076`:** Funktioniert nur wenn eCall-Allowlist die Nummer enthalt.
+- **Push-Preferences:** Nur sichtbar wenn Push auf dem Gerat aktiviert ist.
+- **Kategorien-Dropdown:** Nur Betriebe mit Registry-Eintrag haben dynamische Kategorien.

--- a/src/web/app/api/ops/push/subscribe/route.ts
+++ b/src/web/app/api/ops/push/subscribe/route.ts
@@ -4,6 +4,35 @@ import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
 
 /**
+ * GET /api/ops/push/subscribe?endpoint=... — Read push preferences for a subscription.
+ */
+export async function GET(request: NextRequest) {
+  const scope = await resolveTenantScope();
+  if (!scope?.userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const endpoint = request.nextUrl.searchParams.get("endpoint");
+  if (!endpoint) {
+    return NextResponse.json({ error: "missing_endpoint" }, { status: 400 });
+  }
+
+  const supabase = getServiceClient();
+  const { data } = await supabase
+    .from("ops_push_subscriptions")
+    .select("notify_notfall, notify_assignment, notify_review, notify_all_cases")
+    .eq("endpoint", endpoint)
+    .eq("user_id", scope.userId)
+    .single();
+
+  if (!data) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  return NextResponse.json(data);
+}
+
+/**
  * POST /api/ops/push/subscribe — Save Web Push subscription for a tenant staff member.
  * Body: { endpoint, keys: { p256dh, auth } }
  */

--- a/src/web/app/ops/(dashboard)/settings/page.tsx
+++ b/src/web/app/ops/(dashboard)/settings/page.tsx
@@ -42,6 +42,16 @@ export default function SettingsPage() {
   const [notifySaved, setNotifySaved] = useState(false);
   const [notifyError, setNotifyError] = useState<string | null>(null);
 
+  // Form state — Push-Benachrichtigungen
+  const [pushSupported, setPushSupported] = useState(false);
+  const [pushActive, setPushActive] = useState(false);
+  const [pushEndpoint, setPushEndpoint] = useState<string | null>(null);
+  const [pushReview, setPushReview] = useState(true);
+  const [pushAllCases, setPushAllCases] = useState(false);
+  const [pushBaseline, setPushBaseline] = useState({ review: true, allCases: false });
+  const [pushSaving, setPushSaving] = useState(false);
+  const [pushSaved, setPushSaved] = useState(false);
+
   // Form state — Termin-Einstellungen
   const [calendarEmail, setCalendarEmail] = useState("");
   const [calendarEmailBaseline, setCalendarEmailBaseline] = useState("");
@@ -92,6 +102,47 @@ export default function SettingsPage() {
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [router]);
+
+  // Load push subscription status
+  useEffect(() => {
+    if (!("serviceWorker" in navigator) || !("PushManager" in window)) return;
+    setPushSupported(true);
+    navigator.serviceWorker.ready.then(async (reg) => {
+      const sub = await reg.pushManager.getSubscription();
+      if (!sub) return;
+      setPushActive(true);
+      setPushEndpoint(sub.endpoint);
+      // Load preferences from API
+      try {
+        const res = await fetch(`/api/ops/push/subscribe?endpoint=${encodeURIComponent(sub.endpoint)}`);
+        if (res.ok) {
+          const prefs = await res.json();
+          setPushReview(prefs.notify_review ?? true);
+          setPushAllCases(prefs.notify_all_cases ?? false);
+          setPushBaseline({ review: prefs.notify_review ?? true, allCases: prefs.notify_all_cases ?? false });
+        }
+      } catch { /* ignore */ }
+    });
+  }, []);
+
+  const pushDirty = pushReview !== pushBaseline.review || pushAllCases !== pushBaseline.allCases;
+
+  async function savePush() {
+    if (!pushEndpoint) return;
+    setPushSaving(true);
+    setPushSaved(false);
+    try {
+      await fetch("/api/ops/push/subscribe", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: pushEndpoint, notify_review: pushReview, notify_all_cases: pushAllCases }),
+      });
+      setPushBaseline({ review: pushReview, allCases: pushAllCases });
+      setPushSaved(true);
+      setTimeout(() => setPushSaved(false), 2000);
+    } catch { /* ignore */ }
+    setPushSaving(false);
+  }
 
   const notifyDirty =
     notifyEmail !== notifyBaseline.email || notifySms !== notifyBaseline.sms ||
@@ -313,6 +364,56 @@ export default function SettingsPage() {
             />
           )}
         </Section>
+
+        {/* Push-Benachrichtigungen — per-card save */}
+        {pushSupported && (
+          <Section
+            title="Push-Benachrichtigungen"
+            description={pushActive ? "Einstellungen für Push-Benachrichtigungen auf diesem Gerät." : "Push-Benachrichtigungen sind auf diesem Gerät nicht aktiviert."}
+          >
+            {pushActive ? (
+              <div className="space-y-4">
+                <div>
+                  <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Immer aktiv</p>
+                  <div className="space-y-2">
+                    <div className="flex items-start gap-3 opacity-60">
+                      <div className="pt-0.5 flex-shrink-0">
+                        <div className="w-9 h-5 bg-emerald-500 rounded-full relative"><div className="absolute right-0.5 top-0.5 w-4 h-4 bg-white rounded-full" /></div>
+                      </div>
+                      <div className="min-w-0"><p className="text-sm font-medium text-gray-700">Notf&auml;lle</p><p className="text-xs text-gray-400">Kann nicht deaktiviert werden</p></div>
+                    </div>
+                    <div className="flex items-start gap-3 opacity-60">
+                      <div className="pt-0.5 flex-shrink-0">
+                        <div className="w-9 h-5 bg-emerald-500 rounded-full relative"><div className="absolute right-0.5 top-0.5 w-4 h-4 bg-white rounded-full" /></div>
+                      </div>
+                      <div className="min-w-0"><p className="text-sm font-medium text-gray-700">Negatives Kundenfeedback</p><p className="text-xs text-gray-400">Kann nicht deaktiviert werden</p></div>
+                    </div>
+                    <div className="flex items-start gap-3 opacity-60">
+                      <div className="pt-0.5 flex-shrink-0">
+                        <div className="w-9 h-5 bg-emerald-500 rounded-full relative"><div className="absolute right-0.5 top-0.5 w-4 h-4 bg-white rounded-full" /></div>
+                      </div>
+                      <div className="min-w-0"><p className="text-sm font-medium text-gray-700">Ihnen zugewiesene F&auml;lle</p><p className="text-xs text-gray-400">Kann nicht deaktiviert werden</p></div>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Optional</p>
+                  <div className="space-y-3">
+                    <Toggle checked={pushReview} onChange={setPushReview} label="Positives Kundenfeedback" description="Push bei positiver Bewertung (4-5 Sterne)" />
+                    <Toggle checked={pushAllCases} onChange={setPushAllCases} label="Alle neuen F&auml;lle" description="Push bei jedem neuen Fall (kann viel sein)" />
+                  </div>
+                </div>
+                {pushDirty && (
+                  <CardSaveBar saving={pushSaving} saved={pushSaved} error={null} onSave={savePush} onCancel={() => { setPushReview(pushBaseline.review); setPushAllCases(pushBaseline.allCases); }} />
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500">
+                Push-Benachrichtigungen sind nicht aktiviert. Beim n&auml;chsten Login erscheint ein Banner zur Aktivierung.
+              </p>
+            )}
+          </Section>
+        )}
       </div>
     </div>
   );

--- a/src/web/src/components/ops/SystemCard.tsx
+++ b/src/web/src/components/ops/SystemCard.tsx
@@ -48,6 +48,7 @@ export function SystemCard({
     let reviewSent = 0,
       reviewReceived = 0,
       reviewNegative = 0,
+      ratingSum = 0,
       doneTotal = 0;
 
     for (const c of cases) {
@@ -74,6 +75,7 @@ export function SystemCard({
         if (c.review_sent_at) reviewSent++;
         if (c.review_rating != null) {
           reviewReceived++;
+          ratingSum += c.review_rating;
           if (c.review_rating <= 3) reviewNegative++;
         }
       }
@@ -90,12 +92,16 @@ export function SystemCard({
       reviewSent,
       reviewReceived,
       reviewNegative,
+      ratingSum,
       doneTotal,
     };
   }, [cases, cutoff]);
 
-  const starsFilled = avgRating != null ? Math.round(avgRating) : 0;
-  const starDisplay = avgRating != null ? avgRating.toFixed(1) : "—";
+  // Prefer external avgRating (Google), fall back to internal case average
+  const internalAvg = stats.reviewReceived > 0 ? stats.ratingSum / stats.reviewReceived : null;
+  const effectiveAvg = avgRating ?? internalAvg;
+  const starsFilled = effectiveAvg != null ? Math.round(effectiveAvg) : 0;
+  const starDisplay = effectiveAvg != null ? effectiveAvg.toFixed(1) : "—";
 
   function toggle(node: string) {
     onNodeClick(activeNode === node ? null : node);
@@ -307,7 +313,11 @@ export function SystemCard({
                 Bewertung
               </span>
               <span className="text-[8px] sm:text-[9px] text-gray-400">
-                {stats.reviewReceived}/{stats.reviewSent} erhalten
+                {stats.reviewReceived > 0
+                  ? `${stats.reviewReceived} Bewertung${stats.reviewReceived !== 1 ? "en" : ""}`
+                  : stats.reviewSent > 0
+                    ? `${stats.reviewSent} angefragt`
+                    : "Noch keine"}
               </span>
             </button>
           </div>


### PR DESCRIPTION
## Summary
Letzte Runde der Bewertungen-Überarbeitung.

**SystemCard KPI (FB34b):**
- Bewertungs-Node zeigt internen Ø aus Fallbewertungen (statt nur Google-Ø)
- Subtitle: "X Bewertungen" / "X angefragt" / "Noch keine"

**Push-Preferences UI (PUSH-2):**
- Neuer Abschnitt auf Settings-Seite: "Push-Benachrichtigungen"
- Immer aktiv (nicht deaktivierbar): Notfälle, Negatives Feedback, Zuweisungen
- Optional (Toggles): Positives Feedback, Alle neuen Fälle
- GET-Endpoint zum Lesen der aktuellen Preferences

**Founder Test-Setup:**
- 9-Punkte-Checkliste in ~15 Minuten testbar
- `docs/redesign/leitstand/test_bewertungen_abschluss.md`

## Test plan
- [ ] SystemCard: Bewertungs-Node zeigt Ø + Anzahl
- [ ] Einstellungen: Push-Abschnitt sichtbar (wenn Push aktiviert)
- [ ] Push-Toggles: Positives Feedback + Alle Fälle schaltbar
- [ ] Immer-aktiv-Items: visuell als nicht-deaktivierbar erkennbar
- [ ] Founder-Checkliste: alle 9 Tests durchlaufen

🤖 Generated with [Claude Code](https://claude.com/claude-code)