### PR TITLE
fix: Bewertungen Founder-Feedback — 5 Fixes (FB50-FB57)

### DIFF
--- a/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
+++ b/src/web/app/ops/(dashboard)/cases/[id]/CaseDetailForm.tsx
@@ -1314,10 +1314,10 @@ function TimelineItem({ event }: { event: CaseEvent }) {
 function StarIcon({ filled, muted }: { filled: boolean; brandColor?: string; muted?: boolean }) {
   return (
     <svg className="w-4 h-4" viewBox="0 0 24 24"
-      fill={filled ? "#f59e0b" : "rgba(245,158,11,0.35)"}
+      fill={filled ? "#f59e0b" : "#d1d5db"}
       strokeWidth={1.5}
-      stroke={filled ? "#b45309" : "#d97706"}
-      style={muted ? { opacity: 0.5 } : undefined}
+      stroke={filled ? "#b45309" : "#9ca3af"}
+      style={muted ? { opacity: 0.35 } : undefined}
     >
       <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
     </svg>

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -4,6 +4,7 @@ import { getAuthClient } from "@/src/lib/supabase/server-auth";
 import { resolveTenantIdentity, resolveTenantIdentityById } from "@/src/lib/tenants/resolveTenantIdentity";
 import { resolveStaffRole } from "@/src/lib/staff/resolveStaffRole";
 import { LeitzentraleView } from "@/src/components/ops/LeitzentraleView";
+import { getCustomer } from "@/src/lib/customers/registry";
 import type { LeitzentraleCase } from "@/src/components/ops/LeitzentraleView";
 
 // ---------------------------------------------------------------------------
@@ -167,6 +168,7 @@ export default async function OpsCasesPage({
   let featuredReview: string | null = null;
   let avgRatingFromTenant: number | null = null;
   let googleReviewCount: number | null = null;
+  let tenantCategories: { value: string; label: string }[] = [];
   try {
     const authClient = await getAuthClient();
     const {
@@ -217,7 +219,7 @@ export default async function OpsCasesPage({
       if (scope?.tenantId) {
         const { data: tenant } = await supabase
           .from("tenants")
-          .select("modules")
+          .select("modules, slug")
           .eq("id", scope.tenantId)
           .single();
         const modules = (tenant?.modules ?? {}) as Record<string, unknown>;
@@ -230,6 +232,14 @@ export default async function OpsCasesPage({
         }
         if (typeof modules.google_review_count === "number") {
           googleReviewCount = modules.google_review_count as number;
+        }
+        // Resolve tenant-specific categories from customer registry
+        const tenantSlug = (tenant as Record<string, unknown> | null)?.slug as string | undefined;
+        if (tenantSlug) {
+          const customer = getCustomer(tenantSlug);
+          if (customer?.categories) {
+            tenantCategories = customer.categories.map(c => ({ value: c.value, label: c.label }));
+          }
         }
       }
     }
@@ -258,6 +268,7 @@ export default async function OpsCasesPage({
       staffRole={currentStaffRole}
       googleReviewCount={googleReviewCount}
       showDeleted={showDeleted}
+      tenantCategories={tenantCategories}
     />
   );
 }

--- a/src/web/app/ops/(dashboard)/faelle/page.tsx
+++ b/src/web/app/ops/(dashboard)/faelle/page.tsx
@@ -68,7 +68,7 @@ export default async function FaellePage({
   let listQuery = supabase
     .from("cases")
     .select(
-      "id, seq_number, created_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, review_sent_at",
+      "id, seq_number, created_at, status, urgency, category, description, city, plz, street, house_number, source, assignee_text, reporter_name, review_sent_at, review_rating",
       { count: "exact" }
     )
     .eq("is_demo", false)

--- a/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
+++ b/src/web/app/review/[caseId]/ReviewSurfaceClient.tsx
@@ -75,8 +75,8 @@ export function ReviewSurfaceClient({
   }
 
   // B9: Stars are ALWAYS clickable. Rating changes dynamically.
-  // Auto-save rating (stars only, no text) on phase transition so
-  // "bereits gespeichert" is accurate. Text is added on explicit submit.
+  // Rating is NOT saved on star click — only on explicit button click.
+  // Prevents accidental 1-star saves + premature push notifications.
   function handleStarClick(n: number) {
     setRating(n);
     // Reset chips/text when switching between positive/negative
@@ -88,9 +88,6 @@ export function ReviewSurfaceClient({
       setSelectedChips(new Set());
       setFreeText("");
     }
-    // Auto-save stars (fire-and-forget, no text) so rating isn't lost
-    // if customer leaves before clicking a button
-    saveReview(n);
   }
 
   function toggleChip(chip: string) {
@@ -266,16 +263,12 @@ export function ReviewSurfaceClient({
                     </svg>
                     {copied ? "Text kopiert — Google öffnet sich..." : "Auf Google teilen (optional)"}
                   </button>
-                  {/* B5: Confirm star rating was saved */}
-                  <p className="mt-2 text-center text-xs text-emerald-600 font-medium">
-                    ✓ Ihre Sterne-Bewertung wurde gespeichert.
-                  </p>
                   <button
                     type="button"
                     onClick={handlePositiveFeedback}
-                    className="mt-2 w-full text-center text-xs text-gray-400 hover:text-gray-600 transition-colors py-1"
+                    className="mt-3 w-full text-center text-sm text-gray-500 hover:text-gray-700 transition-colors py-2"
                   >
-                    Kein Google-Konto? Einfach hier abschliessen.
+                    Ohne Google abschliessen
                   </button>
                 </>
               ) : (

--- a/src/web/src/components/ops/CaseListClient.tsx
+++ b/src/web/src/components/ops/CaseListClient.tsx
@@ -26,6 +26,7 @@ export interface CaseRow {
   assignee_text: string | null;
   reporter_name: string | null;
   review_sent_at: string | null;
+  review_rating: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -295,20 +296,18 @@ export function CaseListClient({
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-1.5">
                         <span
-                          className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-500"}`}
+                          className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ring-1 ${
+                            c.status === "done" && c.review_rating != null && c.review_rating <= 3
+                              ? "bg-emerald-100 text-emerald-700 ring-rose-300"
+                              : c.status === "done" && c.review_rating != null && c.review_rating >= 4
+                                ? "bg-amber-100 text-amber-800 ring-amber-300"
+                                : c.status === "done" && c.review_sent_at
+                                  ? "bg-emerald-100 text-emerald-700 ring-amber-300"
+                                  : `${STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-500"} ring-transparent`
+                          }`}
                         >
                           {STATUS_LABELS[c.status] ?? c.status}
                         </span>
-                        {c.status === "done" && !c.review_sent_at && (
-                          <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-50 text-emerald-600 border border-emerald-200" title="Review m\u00f6glich">
-                            R
-                          </span>
-                        )}
-                        {c.status === "done" && c.review_sent_at && (
-                          <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-100 text-emerald-700 border border-emerald-300" title="Review gesendet">
-                            R&#10003;
-                          </span>
-                        )}
                       </div>
                     </td>
                     <td className="px-4 py-3 text-gray-500 text-xs">
@@ -338,7 +337,15 @@ export function CaseListClient({
                     )}
                   </div>
                   <span
-                    className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-500"}`}
+                    className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ring-1 ${
+                      c.status === "done" && c.review_rating != null && c.review_rating <= 3
+                        ? "bg-emerald-100 text-emerald-700 ring-rose-300"
+                        : c.status === "done" && c.review_rating != null && c.review_rating >= 4
+                          ? "bg-amber-100 text-amber-800 ring-amber-300"
+                          : c.status === "done" && c.review_sent_at
+                            ? "bg-emerald-100 text-emerald-700 ring-amber-300"
+                            : `${STATUS_COLORS[c.status] ?? "bg-gray-100 text-gray-500"} ring-transparent`
+                    }`}
                   >
                     {STATUS_LABELS[c.status] ?? c.status}
                   </span>

--- a/src/web/src/components/ops/CreateCaseModal.tsx
+++ b/src/web/src/components/ops/CreateCaseModal.tsx
@@ -5,13 +5,11 @@ import { useRouter } from "next/navigation";
 import { PLZ_CITY_MAP } from "@/src/lib/plz/plzCityMap";
 import { normalizeSwissPhone } from "@/src/lib/phone/normalizeSwissPhone";
 
-const CATEGORIES = [
-  "Sanitär",
-  "Heizung",
-  "Lüftung",
-  "Klima",
-  "Allgemein",
-] as const;
+const FALLBACK_CATEGORIES = [
+  { value: "Sanitär", label: "Sanitär" },
+  { value: "Heizung", label: "Heizung" },
+  { value: "Allgemein", label: "Allgemein" },
+];
 
 const URGENCIES = [
   { value: "normal", label: "Normal" },
@@ -22,17 +20,20 @@ const URGENCIES = [
 export function CreateCaseModal({
   open,
   onClose,
+  categories,
 }: {
   open: boolean;
   onClose: () => void;
+  categories?: { value: string; label: string }[];
 }) {
+  const effectiveCategories = categories && categories.length > 0 ? categories : FALLBACK_CATEGORIES;
   const router = useRouter();
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [submitAttempted, setSubmitAttempted] = useState(false);
 
   const [reporterName, setReporterName] = useState("");
-  const [category, setCategory] = useState("Sanitär");
+  const [category, setCategory] = useState("");
   const [urgency, setUrgency] = useState("normal");
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
@@ -46,7 +47,7 @@ export function CreateCaseModal({
 
   function resetForm() {
     setReporterName("");
-    setCategory("Sanitär");
+    setCategory("");
     setUrgency("normal");
     setPhone("");
     setEmail("");
@@ -164,8 +165,9 @@ export function CreateCaseModal({
                 onChange={(e) => setCategory(e.target.value)}
                 className={inputClasses}
               >
-                {CATEGORIES.map((c) => (
-                  <option key={c} value={c}>{c}</option>
+                <option value="">Kategorie wählen</option>
+                {effectiveCategories.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
                 ))}
               </select>
             </div>

--- a/src/web/src/components/ops/LeitzentraleView.tsx
+++ b/src/web/src/components/ops/LeitzentraleView.tsx
@@ -56,6 +56,7 @@ export interface LeitzentraleProps {
   staffRole?: "admin" | "techniker";
   googleReviewCount?: number | null;
   showDeleted?: boolean;
+  tenantCategories?: { value: string; label: string }[];
 }
 
 // ---------------------------------------------------------------------------
@@ -239,6 +240,7 @@ export function LeitzentraleView({
   staffRole,
   googleReviewCount,
   showDeleted,
+  tenantCategories,
 }: LeitzentraleProps) {
   const router = useRouter();
   const [activeNode, setActiveNode] = useState<string | null>(null);
@@ -806,7 +808,7 @@ export function LeitzentraleView({
         )}
       </div>
 
-      <CreateCaseModal open={modalOpen} onClose={() => setModalOpen(false)} />
+      <CreateCaseModal open={modalOpen} onClose={() => setModalOpen(false)} categories={tenantCategories} />
     </div>
   );
 }

--- a/src/web/src/lib/reviews/deriveReviewStatus.ts
+++ b/src/web/src/lib/reviews/deriveReviewStatus.ts
@@ -64,10 +64,9 @@ export function deriveReviewStatus(opts: {
   // ── Customer has rated → highest priority ──────────────────────────
   if (reviewRating != null && reviewRating >= 1 && reviewRating <= 5) {
     const isPositive = reviewRating >= 4;
-    const stars = "\u2605".repeat(reviewRating) + "\u2606".repeat(5 - reviewRating);
     return {
       status: isPositive ? "bewertet_positiv" : "bewertet_negativ",
-      label: `Bewertet: ${stars}`,
+      label: "Bewertet",
       color: isPositive
         ? "bg-amber-50 text-amber-800 border-amber-300"
         : "bg-red-50 text-red-700 border-red-300",
@@ -144,7 +143,7 @@ export function deriveReviewStatus(opts: {
       color: "bg-blue-50 text-blue-700 border-blue-200",
       canRequest: false,
       canResend,
-      canSkip: true,
+      canSkip: false, // already sent — skip makes no sense
       reviewCount,
     };
   }
@@ -156,7 +155,7 @@ export function deriveReviewStatus(opts: {
     color: "bg-amber-50 text-amber-700 border-amber-200",
     canRequest: false,
     canResend,
-    canSkip: true,
+    canSkip: false, // already sent — skip makes no sense
     reviewCount,
   };
 }


### PR DESCRIPTION
## Summary
Fixes aus Founder-Testing der Bewertungen Runde 1-3.

- **FB54/55:** Star auto-save reverted — Rating nur bei explizitem Button-Klick gespeichert
- **FB50:** CreateCaseModal nutzt jetzt Tenant-Kategorien aus Registry (wie Wizard)
- **FB52:** "Nicht anfragen" Button verschwindet nach Versand
- **FB56:** BewertungEndCap: eine Sternreihe (Gold/Grau), kein Doppelpunkt
- **FB57:** Fallliste: Status-Badge mit review-aware Ring (Rose bei negativ, Gold bei positiv)

## Test plan
- [ ] Review Surface: Sterne klicken → NICHTS wird gespeichert (kein Push)
- [ ] Review Surface: "Auf Google teilen" oder "Ohne Google abschliessen" → erst dann gespeichert
- [ ] Neuer Fall: Kategorien-Dropdown zeigt Dörfler-Kategorien (Verstopfung, Leck, Heizung...)
- [ ] Fall nach Bewertungsversand: "Nicht anfragen" Button weg
- [ ] BewertungEndCap: Eine Sternreihe, Gold+Grau, Text "Bewertet"
- [ ] Fallliste: Erledigt-Badge bei negativer Bewertung hat Rose-Ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)