### PR TITLE
feat: Kommunikations-Decisions D1/D2/D4r/D5 + Stresstest-Asset

### DIFF
--- a/docs/gtm/stresstest_icp_profile.md
+++ b/docs/gtm/stresstest_icp_profile.md
@@ -1,0 +1,122 @@
+# ICP Stresstest-Profile — Wiederverwendbares Asset
+
+> **Zweck:** Fixe Referenz für Stresstests quer durch das gesamte System.
+> Dieses Dokument wird NICHT regelmässig upgedated — es beschreibt stabile ICP-Realitäten.
+> Bei jedem Stresstest (Kommunikation, Voice Agent, Leitsystem, Maschine) wird dieses Dokument als Input verwendet.
+
+---
+
+## Die 3 ICP-Profile
+
+### Profil A: "Meier Sanitär" — 2-Mann-Betrieb
+
+**Realität:**
+- **Team:** Beat Meier (Chef, 58) + Lehrling Florian (19)
+- **Büro:** Beat's Frau Vreni hilft morgens 2h mit Telefon + Buchhaltung
+- **Tagesablauf:** Beat fährt um 07:00 los, 4-5 Einsätze/Tag, abends Offerten schreiben
+- **Technik:** Beat hat ein Samsung Galaxy (3 Jahre alt), Florian ein iPhone. Kein Laptop auf der Baustelle.
+- **Kommunikation:** Beat schaut Handy zwischen Einsätzen (~3x/Tag). Vreni checkt E-Mail morgens.
+- **Schwachstelle:** Beat vergisst Rückrufe. Vreni hat keinen Zugang zum Leitsystem.
+- **Notfälle:** Beat fährt selber hin, Florian bleibt auf der aktuellen Baustelle.
+
+**Typischer Stress-Montag:**
+- 07:00 — 2 Anrufe auf Anrufbeantworter vom Wochenende (1x Leck, 1x Heizung)
+- 08:30 — Notfall: Rohrbruch in Thalwil, Wasser läuft
+- 09:00-12:00 — Beat beim Notfall, Florian auf geplantem Einsatz
+- 12:00 — 3 neue Meldungen im System (1 Voice, 2 Wizard)
+- 14:00 — Bewertung vom Freitag: 2 Sterne ("Zu spät gekommen")
+- 15:00 — Vreni meldet: "Da hat jemand 3x angerufen wegen Offerte"
+- **Total:** 5-6 Fälle, 1 Notfall, 1 negative Bewertung
+
+**Was Beat braucht:** Wenig Benachrichtigungen, nur das Wichtigste. Push nur bei Notfall + negativem Feedback. E-Mail-Flut = Tod (checkt Mail 1x abends).
+
+---
+
+### Profil B: "Brunner Haustechnik" — 15-Mann-Betrieb
+
+**Realität:**
+- **Team:** Thomas Brunner (GF, 45) + Sandra (Büro, 38) + 2 Teamleiter + 8 Techniker + 2 Lehrlinge + Lager
+- **Büro:** Sandra nimmt Anrufe an, plant Einsätze, schreibt Offerten. Arbeitet 08:00-17:00.
+- **Tagesablauf:** Sandra plant morgens die Einsätze, Thomas macht Kundenbesuche + Offerten
+- **Technik:** Sandra hat Desktop + Firmen-Handy. Techniker haben Firmen-iPhones. Thomas hat MacBook + iPhone.
+- **Kommunikation:** Sandra checkt Leitsystem alle 30min. Techniker checken Handy zwischen Einsätzen. Thomas checkt Mails 3x/Tag.
+- **Schwachstelle:** Sandra ist Bottleneck — wenn sie krank ist, steht alles. Teamleiter haben keine Planungstools.
+- **Notfälle:** Teamleiter entscheidet wer fährt. Nächsten Techniker umrouten.
+
+**Typischer Stress-Montag:**
+- 07:30 — Sandra öffnet Leitsystem: 8 neue Fälle vom Wochenende (3 Voice, 5 Wizard)
+- 08:00-09:00 — 4 Anrufe kommen rein (1 Notfall Heizung ausgefallen)
+- 09:00 — Sandra weist Fälle zu: 6 Techniker bekommen je 2-3 Einsätze
+- 10:00 — 3 weitere Wizard-Meldungen
+- 11:00 — Techniker meldet: "Kunde nicht da, vergebliche Anfahrt"
+- 13:00 — 2 Bewertungen (1x 5★, 1x 3★)
+- 14:00 — Notfall #2: Überschwemmung in Praxis
+- 15:00 — Thomas fragt: "Wie sieht's aus mit den Bewertungen diese Woche?"
+- 16:00 — 2 weitere Meldungen, 1 Terminverschiebung
+- **Total:** 18 Fälle, 2-3 Notfälle, 5 Bewertungsanfragen, 2 Reviews rein
+
+**Was Sandra braucht:** Klare Übersicht morgens, Push nur bei Notfall. Techniker brauchen nur IHRE Fälle als Push.
+**Was Thomas braucht:** Wöchentliches Summary, Negativ-Alert sofort, sonst Ruhe.
+
+---
+
+### Profil C: "Leuthold AG" — 25-Mann-Betrieb
+
+**Realität:**
+- **Team:** Walter Leuthold (GF, 52) + 2 Büro-MA + 1 Teamleiter Sanitär + 1 Teamleiter Heizung + 15 Techniker + 3 Lehrlinge + 2 Lager/Logistik
+- **Büro:** 2 MA teilen sich Telefon + Planung. Eine macht Sanitär, andere Heizung.
+- **Tagesablauf:** Strukturiert — Morgen-Meeting 07:15, Einsatzplanung digital, Teamleiter koordinieren.
+- **Technik:** Firmenlaptop für Büro, iPads für Teamleiter, iPhones für Techniker. WLAN auf dem Firmengelände.
+- **Kommunikation:** Büro im Leitsystem den ganzen Tag. Teamleiter schauen alle 1-2h. Techniker 2-3x/Tag.
+- **Schwachstelle:** Kommunikation zwischen Sanitär-Team und Heizung-Team. Doppelbuchungen.
+- **Notfälle:** Dienstplan: je 1 Techniker pro Team ist "Notfall-Bereitschaft". Wechselt wöchentlich.
+
+**Typischer Stress-Montag:**
+- 07:15 — Morgen-Meeting: 12 geplante Einsätze, 5 offene Fälle vom Wochenende
+- 07:30-09:00 — 8 Anrufe (2 Notfälle)
+- 09:00 — Büro plant: 15 Techniker auf 20 Einsätze verteilen
+- 10:00-12:00 — 10 weitere Meldungen (Mix Voice/Wizard/Manuell)
+- 12:00 — 3 Bewertungsanfragen raus, 2 Terminverschiebungen
+- 13:00 — Notfall #3: Gasgeruch → sofort raus
+- 14:00 — 5 neue Bewertungen eingegangen (4x positiv, 1x negativ)
+- 15:00 — Teamleiter Heizung: "Morgen sind 3 Techniker krank"
+- 16:00 — 5 weitere Meldungen, Büro plant morgen
+- **Total:** 35 Fälle, 3-5 Notfälle, 10 Bewertungsanfragen, 5 Reviews rein
+
+**Was Büro braucht:** Digest statt Einzelmails. Push nur Notfall.
+**Was Teamleiter braucht:** Sein Team sehen, Notfall in seinem Bereich.
+**Was Walter braucht:** Dashboard 1x/Tag, Negativ-Alert sofort, Weekly Summary.
+
+---
+
+## Stresstest-Methodik
+
+### Wie den Stresstest anwenden:
+
+1. **Objekt wählen:** Was wird getestet? (Kommunikation, Voice Agent, Leitsystem-UI, Maschine Manifest, etc.)
+2. **Profil wählen:** A (2-MA), B (15-MA), C (25-MA) — oder alle drei
+3. **Stress-Montag durchspielen:** Für jede Person im Betrieb: Was passiert wann? Was sieht sie? Was verpasst sie? Was nervt sie?
+4. **Reibungspunkte dokumentieren:** Jeder "Moment wo es hakt" wird als Problem notiert
+5. **Fixes priorisieren:** Kritisch (Funktionsstörung) → Hoch (Noise) → Mittel (Ergonomie) → Niedrig (Nice-to-have)
+
+### Stresstest-Checkliste (für jedes System/Feature):
+
+- [ ] Profil A durchgespielt — Probleme notiert
+- [ ] Profil B durchgespielt — Probleme notiert
+- [ ] Profil C durchgespielt — Probleme notiert
+- [ ] Probleme konsolidiert und priorisiert
+- [ ] Top-3-Fixes identifiziert
+- [ ] Fixes implementiert oder als Ticket erfasst
+
+---
+
+## Referenz: Schweizer Sanitär/Heizung Markt-Daten
+
+- **Ø Betriebsgrösse CH:** 4.2 Mitarbeiter (suissetec Branchenstatistik)
+- **Verteilung:** ~60% haben 1-5 MA, ~25% haben 6-20 MA, ~15% haben 20+ MA
+- **Digitalisierungsgrad:** Tief. ~70% nutzen noch Papier-Rapporte.
+- **Smartphone-Penetration Techniker:** ~95% haben Smartphone, aber nur ~30% nutzen eine Business-App
+- **E-Mail-Nutzung:** Chef/Büro = täglich. Techniker = selten bis nie auf dem Handy.
+- **Hauptkanal Techniker:** Telefon + WhatsApp-Gruppenchat (informell)
+- **Hauptkanal Büro → Kunde:** Telefon + E-Mail
+- **Notfall-Erwartung Endkunde:** Rückruf innerhalb 30 Minuten

--- a/src/web/app/api/cases/route.ts
+++ b/src/web/app/api/cases/route.ts
@@ -316,10 +316,13 @@ export async function POST(request: NextRequest) {
       } catch { /* SMS best-effort */ }
     }
 
+    // D2: Self-notification suppression — skip Ops email if manual case by logged-in staff
+    const isSelfCreated = data.source === "manual";
+
     // MUST await — fire-and-forget causes Vercel to kill the invocation
     // before the Resend API call + console.log complete (msgLen=0 bug).
     // resend.ts owns the single console.log: _tag:"resend", decision, case_id, etc.
-    const emailSent = await sendCaseNotification({
+    const emailSent = isSelfCreated ? false : await sendCaseNotification({
       caseId: row.id,
       seqNumber: row.seq_number,
       caseIdPrefix: caseIdPrefix,
@@ -393,7 +396,8 @@ export async function POST(request: NextRequest) {
     }
 
     // Notify: system failures only (email dispatch fail → RED alert)
-    if (!emailSent) {
+    // D2: Skip alert if email was intentionally suppressed (self-created manual case)
+    if (!emailSent && !isSelfCreated) {
       await notify({ severity: "RED", code: "EMAIL_DISPATCH_FAILED", refs: { case_id: row.id }, opsLink: `${APP_BASE_URL}/ops/cases/${row.id}` });
     }
 

--- a/src/web/app/api/lifecycle/tick/route.ts
+++ b/src/web/app/api/lifecycle/tick/route.ts
@@ -287,13 +287,13 @@ async function processTerminReminders(
   const windowStart = new Date(now.getTime() - 3 * 60 * 60 * 1000);
   const windowEnd = new Date(now.getTime() + 36 * 60 * 60 * 1000);
 
+  // D5: Include email-only cases (not just phone) for email reminder fallback
   const { data: cases } = await supabase
     .from("cases")
-    .select("id, tenant_id, seq_number, scheduled_at, scheduled_end_at, category, contact_phone, reporter_name")
+    .select("id, tenant_id, seq_number, scheduled_at, scheduled_end_at, category, contact_phone, contact_email, reporter_name")
     .gte("scheduled_at", windowStart.toISOString())
     .lte("scheduled_at", windowEnd.toISOString())
-    .in("status", ["scheduled", "in_arbeit"])
-    .not("contact_phone", "is", null);
+    .in("status", ["scheduled", "in_arbeit"]);
 
   if (!cases || cases.length === 0) return results;
 
@@ -320,49 +320,73 @@ async function processTerminReminders(
 
   for (const c of cases) {
     if (alreadySent.has(c.id)) continue;
-    if (!c.contact_phone) continue;
+    if (!c.contact_phone && !c.contact_email) continue;
 
     const tenant = tenantMap.get(c.tenant_id);
     if (!tenant) continue;
 
     const modules = (tenant.modules ?? {}) as Record<string, unknown>;
-    if (modules.notify_termin_reminder_sms === false) {
-      results.push({ case_id: c.id, sent: false, reason: "toggle_off" });
-      continue;
-    }
-    if (modules.sms !== true) {
-      results.push({ case_id: c.id, sent: false, reason: "sms_disabled" });
-      continue;
-    }
 
+    // Format termin details (shared between SMS + Email)
     const senderName = typeof modules.sms_sender_name === "string" ? modules.sms_sender_name : tenant.name;
     const tenantPhone = typeof tenant.phone === "string" ? tenant.phone : "";
-
     const start = new Date(c.scheduled_at);
     const day = start.toLocaleDateString("de-CH", { weekday: "short", timeZone: "Europe/Zurich" }).replace(/\.$/, "");
     const date = start.toLocaleDateString("de-CH", { day: "2-digit", month: "2-digit", timeZone: "Europe/Zurich" });
     const time = start.toLocaleTimeString("de-CH", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" });
-
     let endTime = "";
     if (c.scheduled_end_at) {
       const end = new Date(c.scheduled_end_at);
-      endTime = `–${end.toLocaleTimeString("de-CH", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" })}`;
+      endTime = `\u2013${end.toLocaleTimeString("de-CH", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" })}`;
     }
 
-    const phoneStr = tenantPhone ? ` Bei Fragen: ${tenantPhone}.` : "";
-    const smsBody = `${senderName}: Erinnerung — Ihr Termin morgen ${day} ${date}, ${time}${endTime}.${phoneStr}`;
+    let sent = false;
+    let channel: "sms" | "email" | "none" = "none";
+    let reason: string | undefined;
 
-    const smsResult = await sendSms(c.contact_phone, smsBody, senderName);
+    // D5: SMS primary for phone contacts (time-critical, 98% open rate)
+    if (c.contact_phone && modules.notify_termin_reminder_sms !== false && modules.sms === true) {
+      const phoneStr = tenantPhone ? ` Bei Fragen: ${tenantPhone}.` : "";
+      const smsBody = `${senderName}: Erinnerung \u2014 Ihr Termin morgen ${day} ${date}, ${time}${endTime}.${phoneStr}`;
+      const smsResult = await sendSms(c.contact_phone, smsBody, senderName);
+      sent = smsResult.sent;
+      channel = "sms";
+      reason = smsResult.reason;
+    }
+
+    // D5: Email fallback when no phone or SMS failed/disabled
+    if (!sent && c.contact_email) {
+      try {
+        const { sendTerminReminderEmail } = await import("@/src/lib/email/resend");
+        const emailSent = await sendTerminReminderEmail({
+          tenantName: tenant.name,
+          contactEmail: c.contact_email,
+          terminDay: day,
+          terminDate: date,
+          terminTime: `${time}${endTime}`,
+          category: c.category ?? undefined,
+          tenantPhone: tenantPhone || undefined,
+        });
+        if (emailSent) {
+          sent = true;
+          channel = "email";
+        }
+      } catch { /* email best-effort */ }
+    }
+
+    if (!sent) {
+      reason = reason ?? (c.contact_phone ? "sms_disabled_no_email" : "no_phone_email_failed");
+    }
 
     // Insert idempotency guard event
     await supabase.from("case_events").insert({
       case_id: c.id,
       event_type: "termin_reminder_sent",
-      title: "24h-Erinnerung an Kunden gesendet",
-      metadata: { sms_sent: smsResult.sent, reason: smsResult.reason ?? null },
+      title: `24h-Erinnerung an Kunden gesendet (${channel === "sms" ? "SMS" : channel === "email" ? "E-Mail" : "fehlgeschlagen"})`,
+      metadata: { channel, sent, reason: reason ?? null },
     });
 
-    results.push({ case_id: c.id, sent: smsResult.sent, reason: smsResult.reason });
+    results.push({ case_id: c.id, sent, reason });
   }
 
   return results;

--- a/src/web/app/api/ops/cases/[id]/notify-assignees/route.ts
+++ b/src/web/app/api/ops/cases/[id]/notify-assignees/route.ts
@@ -75,9 +75,21 @@ export async function POST(
 
     const caseLabel = formatCaseId(row.seq_number, identity.caseIdPrefix);
 
-    const staffWithEmail = (staffMatches ?? []).filter(
+    const allStaffWithEmail = (staffMatches ?? []).filter(
       (s: { email: string | null }) => s.email,
     );
+
+    // D2: Self-assignment suppression — skip if assigner = assignee at small businesses (≤3 staff)
+    const { count: staffCount } = await supabase
+      .from("staff")
+      .select("id", { count: "exact", head: true })
+      .eq("tenant_id", row.tenant_id)
+      .eq("is_active", true);
+    const isSmallBusiness = (staffCount ?? 0) <= 3;
+
+    const staffWithEmail = isSmallBusiness
+      ? allStaffWithEmail.filter((s: { user_id: string | null }) => s.user_id !== scope.userId)
+      : allStaffWithEmail;
 
     if (staffWithEmail.length === 0) {
       return NextResponse.json(

--- a/src/web/app/api/ops/cases/[id]/request-review/route.ts
+++ b/src/web/app/api/ops/cases/[id]/request-review/route.ts
@@ -204,10 +204,26 @@ export async function POST(
   Sentry.setTag("tenant_id", row.tenant_id);
 
   let sent = false;
-  let channel: "email" | "sms" = "email";
+  let channel: "email" | "sms" = "sms";
 
-  if (row.contact_email) {
+  // D4r: SMS primary for review requests (higher conversion: 98% open rate vs 25% email)
+  // Email as fallback when no phone number available
+  if (row.contact_phone) {
+    Sentry.setTag("area", "sms");
+    channel = "sms";
+    const smsConfig = await getTenantSmsConfig(row.tenant_id);
+    const senderName = smsConfig?.senderName ?? "FlowSight";
+    const shortToken = generateShortVerifyToken(id, row.created_at);
+    const caseRef = caseIdPrefix && row.seq_number ? `${caseIdPrefix}-${row.seq_number}` : id;
+    const smsReviewUrl = `${APP_BASE_URL}/r/${caseRef}?t=${shortToken}`;
+    const smsBody = `${senderName}: Vielen Dank für Ihr Vertrauen. Über eine kurze Bewertung freuen wir uns:\n${smsReviewUrl}`;
+    const smsResult = await sendSms(row.contact_phone, smsBody, senderName);
+    sent = smsResult.sent;
+  }
+
+  if (!sent && row.contact_email) {
     Sentry.setTag("area", "email");
+    channel = "email";
     const location = [row.plz, row.city].filter(Boolean).join(" ") || undefined;
     sent = await sendReviewRequest({
       caseId: id,
@@ -220,21 +236,6 @@ export async function POST(
       category: row.category || undefined,
       location,
     });
-    channel = "email";
-  }
-
-  if (!sent && row.contact_phone) {
-    Sentry.setTag("area", "sms");
-    channel = "sms";
-    const smsConfig = await getTenantSmsConfig(row.tenant_id);
-    const senderName = smsConfig?.senderName ?? "FlowSight";
-    // Build short URL for SMS (< 160 chars total)
-    const shortToken = generateShortVerifyToken(id, row.created_at);
-    const caseRef = caseIdPrefix && row.seq_number ? `${caseIdPrefix}-${row.seq_number}` : id;
-    const smsReviewUrl = `${APP_BASE_URL}/r/${caseRef}?t=${shortToken}`;
-    const smsBody = `${senderName}: Vielen Dank für Ihr Vertrauen. Über eine kurze Bewertung freuen wir uns:\n${smsReviewUrl}`;
-    const smsResult = await sendSms(row.contact_phone, smsBody, senderName);
-    sent = smsResult.sent;
   }
 
   if (!sent) {

--- a/src/web/app/api/review/[caseId]/rate/route.ts
+++ b/src/web/app/api/review/[caseId]/rate/route.ts
@@ -30,10 +30,10 @@ export async function POST(
 
   const supabase = getServiceClient();
 
-  // Get case data for token validation + push notification
+  // Get case data for token validation + push notification + email alert
   const { data: caseRow } = await supabase
     .from("cases")
-    .select("tenant_id, reporter_name, created_at")
+    .select("tenant_id, reporter_name, created_at, category, city, seq_number")
     .eq("id", caseId)
     .single();
 
@@ -112,6 +112,21 @@ export async function POST(
         tag: `review-${caseId}`,
       })
     ).catch(() => {});
+
+    // D1: Negative review email alert — must not be missed even if push is disabled
+    if (isNegative) {
+      import("@/src/lib/email/resend").then(({ sendNegativeReviewAlert }) =>
+        sendNegativeReviewAlert({
+          tenantId: caseRow.tenant_id,
+          caseId,
+          rating,
+          reviewText: text ?? undefined,
+          reporterName: name,
+          category: caseRow.category ?? undefined,
+          city: caseRow.city ?? undefined,
+        })
+      ).catch(() => {});
+    }
   }
 
   return NextResponse.json({ ok: true });

--- a/src/web/src/components/ops/CreateCaseModal.tsx
+++ b/src/web/src/components/ops/CreateCaseModal.tsx
@@ -245,7 +245,7 @@ export function CreateCaseModal({
   }
 
   const inputClasses =
-    "w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500";
+    "w-full rounded-lg border border-gray-300 bg-white px-3 py-1.5 md:py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500";
   const labelClasses = "block text-xs font-medium text-gray-600 mb-1";
   const requiredMark = <span className="text-red-500 ml-0.5">*</span>;
 
@@ -264,7 +264,7 @@ export function CreateCaseModal({
       {/* Modal */}
       <div className="relative w-full h-full md:h-auto md:max-w-lg md:rounded-xl bg-white shadow-xl flex flex-col md:max-h-[90vh]">
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200">
+        <div className="flex items-center justify-between px-4 py-3 md:px-5 md:py-4 border-b border-gray-200">
           <h2 className="text-lg font-semibold text-gray-900">Neuer Fall</h2>
           <button
             onClick={onClose}
@@ -277,7 +277,7 @@ export function CreateCaseModal({
         </div>
 
         {/* Form */}
-        <form id="create-case-form" onSubmit={handleSubmit} className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+        <form id="create-case-form" onSubmit={handleSubmit} className="flex-1 overflow-y-auto px-4 py-3 space-y-3 md:px-5 md:py-4 md:space-y-4">
           {/* Reporter name */}
           <div>
             <label htmlFor="mc-name" className={labelClasses}>Name des Kunden</label>
@@ -506,7 +506,7 @@ export function CreateCaseModal({
         </form>
 
         {/* Footer */}
-        <div className="px-5 py-4 border-t border-gray-200 flex items-center justify-end gap-3">
+        <div className="px-4 py-3 md:px-5 md:py-4 border-t border-gray-200 flex items-center justify-end gap-3">
           <button
             type="button"
             onClick={onClose}

--- a/src/web/src/lib/email/resend.ts
+++ b/src/web/src/lib/email/resend.ts
@@ -995,3 +995,133 @@ export async function sendAppointmentIcsEmail(payload: AppointmentEmailPayload):
     return false;
   }
 }
+
+// ---------------------------------------------------------------------------
+// D5: 24h Termin-Erinnerung per E-Mail (Fallback wenn kein SMS)
+// ---------------------------------------------------------------------------
+
+interface TerminReminderEmailPayload {
+  tenantName: string;
+  contactEmail: string;
+  terminDay: string;
+  terminDate: string;
+  terminTime: string;
+  category?: string;
+  tenantPhone?: string;
+}
+
+export async function sendTerminReminderEmail(payload: TerminReminderEmailPayload): Promise<boolean> {
+  if (!process.env.RESEND_API_KEY) return false;
+
+  try {
+    const from = buildFromAddress(payload.tenantName);
+    const phoneHint = payload.tenantPhone ? `<p style="margin:12px 0 0;font-size:14px;color:#6b7280">Bei Fragen erreichen Sie uns unter <strong>${escapeHtml(payload.tenantPhone)}</strong>.</p>` : "";
+
+    const html = `
+<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:520px;margin:0 auto;padding:24px">
+  <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:12px;padding:20px">
+    <p style="margin:0 0 12px;font-size:16px;font-weight:600;color:#166534">Erinnerung an Ihren Termin</p>
+    <p style="margin:0;font-size:20px;font-weight:700;color:#111827">${escapeHtml(payload.terminDay)} ${escapeHtml(payload.terminDate)}, ${escapeHtml(payload.terminTime)}</p>
+    ${payload.category ? `<p style="margin:8px 0 0;font-size:14px;color:#6b7280">${escapeHtml(payload.category)}</p>` : ""}
+    ${phoneHint}
+  </div>
+  <p style="margin:16px 0 0;font-size:12px;color:#9ca3af">Diese Erinnerung wurde automatisch von ${escapeHtml(payload.tenantName)} gesendet.</p>
+</div>`;
+
+    const { error } = await getResend().emails.send({
+      from,
+      to: payload.contactEmail,
+      subject: `Erinnerung: Ihr Termin am ${payload.terminDay} ${payload.terminDate}`,
+      html,
+    });
+
+    if (error) {
+      Sentry.captureException(error, {
+        tags: { _tag: "resend", area: "customer", email_type: "termin_reminder" },
+      });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { _tag: "resend", area: "customer", email_type: "termin_reminder" },
+    });
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// D1: Negative Review Alert — Email to business when customer rates ≤3★
+// ---------------------------------------------------------------------------
+
+interface NegativeReviewAlertPayload {
+  tenantId: string;
+  caseId: string;
+  rating: number;
+  reviewText?: string;
+  reporterName: string;
+  category?: string;
+  city?: string;
+}
+
+export async function sendNegativeReviewAlert(payload: NegativeReviewAlertPayload): Promise<boolean> {
+  if (!process.env.RESEND_API_KEY) return false;
+
+  try {
+    const { getServiceClient: getSvc } = await import("@/src/lib/supabase/server");
+    const supabase = getSvc();
+    const { data: tenant } = await supabase
+      .from("tenants")
+      .select("name, modules")
+      .eq("id", payload.tenantId)
+      .single();
+
+    const modules = (tenant?.modules ?? {}) as Record<string, unknown>;
+    const notificationEmail = (typeof modules.notification_email === "string" && modules.notification_email)
+      ? modules.notification_email
+      : process.env.MAIL_REPLY_TO;
+
+    if (!notificationEmail) return false;
+
+    const tenantName = tenant?.name ?? "Betrieb";
+    const from = buildFromAddress(tenantName);
+    const stars = "\u2605".repeat(payload.rating) + "\u2606".repeat(5 - payload.rating);
+    const location = [payload.category, payload.city].filter(Boolean).join(" \u2014 ") || "";
+    const deepLink = `${(await import("@/src/lib/config/appUrl")).APP_BASE_URL}/ops/open/${payload.caseId}`;
+
+    const html = `
+<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:520px;margin:0 auto;padding:24px">
+  <div style="background:#fef2f2;border:1px solid #fecaca;border-radius:12px;padding:20px">
+    <p style="margin:0 0 4px;font-size:16px;font-weight:600;color:#991b1b">\u26a0\ufe0f Negatives Kundenfeedback</p>
+    <p style="margin:0 0 16px;font-size:28px;color:#b91c1c">${stars}</p>
+    <table style="width:100%;font-size:14px;color:#374151;border-collapse:collapse">
+      <tr><td style="padding:4px 0;color:#6b7280">Kunde</td><td style="padding:4px 0;font-weight:500">${escapeHtml(payload.reporterName)}</td></tr>
+      ${location ? `<tr><td style="padding:4px 0;color:#6b7280">Auftrag</td><td style="padding:4px 0">${escapeHtml(location)}</td></tr>` : ""}
+      ${payload.reviewText ? `<tr><td style="padding:4px 0;color:#6b7280;vertical-align:top">Feedback</td><td style="padding:4px 0;font-style:italic">\u201e${escapeHtml(payload.reviewText.slice(0, 300))}\u201c</td></tr>` : ""}
+    </table>
+    <a href="${escapeHtml(deepLink)}" style="display:inline-block;margin-top:16px;padding:10px 20px;background:#991b1b;color:white;text-decoration:none;border-radius:8px;font-size:14px;font-weight:500">Fall ansehen</a>
+  </div>
+  <p style="margin:16px 0 0;font-size:12px;color:#9ca3af">Tipp: Reagieren Sie zeitnah auf negatives Feedback \u2014 ein pers\u00f6nlicher Anruf kann die Situation oft drehen.</p>
+</div>`;
+
+    const { error } = await getResend().emails.send({
+      from,
+      to: notificationEmail,
+      subject: `\u26a0\ufe0f Negatives Feedback (${payload.rating}\u2605) \u2014 ${payload.reporterName}`,
+      html,
+    });
+
+    if (error) {
+      Sentry.captureException(error, {
+        tags: { _tag: "resend", area: "ops", email_type: "negative_review_alert", case_id: payload.caseId },
+      });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { _tag: "resend", area: "ops", email_type: "negative_review_alert" },
+    });
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
4 Founder-Decisions aus der Kommunikationsmatrix-Analyse implementiert.

**D1 — Negativ-Review E-Mail-Alert:**
- ≤3★ → E-Mail an Betrieb (notification_email) mit Feedback-Text, Deep Link, Handlungs-Tipp
- Push kann verpasst werden → E-Mail als Backup für business-critical Feedback

**D2 — Self-Notification unterdrücken:**
- Manuell erstellte Fälle: keine Ops-E-Mail an den Ersteller (er weiss es schon)
- Self-Assignment bei ≤3-MA-Betrieben: keine E-Mail/Push an sich selbst

**D4r — Review-Anfrage SMS primär:**
- SMS zuerst wenn Handy vorhanden (98% Open Rate → höhere Bewertungs-Conversion)
- E-Mail nur als Fallback wenn kein Handy

**D5 — 24h-Erinnerung per E-Mail:**
- Neues Template für E-Mail-Erinnerung (Fallback wenn kein SMS möglich)
- Cases ohne Handy-Nr. werden jetzt auch erinnert

**Stresstest-Asset:** `docs/gtm/stresstest_icp_profile.md` — 3 fixe ICP-Profile (2/15/25 MA) für wiederverwendbare Stresstests.

## Test plan
- [ ] Negativ-Bewertung abgeben → Betrieb bekommt E-Mail-Alert
- [ ] Manuellen Fall erstellen → KEINE Ops-E-Mail an sich selbst
- [ ] Bewertung anfragen (Kunde hat Handy+Email) → SMS geht raus (nicht Email)
- [ ] Termin-Erinnerung: Kunde ohne Handy → E-Mail-Erinnerung statt keine
- [ ] Einstellungen-Toggles respektiert (SMS-Toggle aus → kein SMS, nur Email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)