### PR TITLE
docs: Stresstest 12 reale ICPs + Kommunikationsregeln in SSOT (D84)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -115,6 +115,7 @@ Architecture Wave → Quality Wave → Web-Engine → Voice v4 → GTM Foundatio
 - SSOT: Supabase (tenants + cases). Vercel Env = Secret SSOT.
 - Deploy: Vercel, Root Directory = src/web
 - Secrets: Niemals ins Repo
+- Kommunikation: 7 Kanal-Regeln (D84, §12a in zielarchitektur.md). 4 davon LIVE. Referenz: `kommunikationsmatrix_v2.md`
 
 ## Dokument-Map
 

--- a/docs/architecture/zielarchitektur.md
+++ b/docs/architecture/zielarchitektur.md
@@ -1,8 +1,8 @@
 # FlowSight — Zielarchitektur (Business + Produkt + GTM)
 
-**Version:** 4.0 | **Datum:** 2026-04-14
+**Version:** 4.1 | **Datum:** 2026-04-15
 **Autor:** CC (Head Ops) + Founder-Input
-**Status:** v4.0 — 83 Decisions (D1-D83). Website-Entscheidung FINAL (D83): Modul 2 = Standard, Website kein Produktbestandteil. Machine Manifest v4.0. 72+ PRs in 14 Tagen.
+**Status:** v4.1 — 84 Decisions (D1-D84). Kommunikationsregeln integriert (D84). Website-Entscheidung FINAL (D83): Modul 2 = Standard, Website kein Produktbestandteil. Machine Manifest v4.0. 72+ PRs in 14 Tagen.
 **Regel:** Dieses Dokument beschreibt die **Zielarchitektur**. Aktueller Stand → `docs/STATUS.md`. Tasks → `docs/ticketlist.md`.
 **Pfad:** `docs/architecture/zielarchitektur.md` (umgezogen von `docs/gtm/architecture_detail.md`)
 
@@ -95,6 +95,7 @@
 | D81 | **Generisches Speakflow-Template.** `docs/gtm/speakflow_template.md` — Take 1-4 mit {{Platzhaltern}}, 2 Master-Varianten (A: Einsatz bei mir, B: Kenne aus der Region), Mail 1+2 Templates. Take 2 = 1:1 Gold-Standard aus Dörfler. E2E-Pipeline pro Betrieb dokumentiert. | **ENTSCHIEDEN** ✅ | Founder + CC | PR #440 |
 | D82 | **Case-Header-Redesign.** 2-Zeilen-Layout: Row 1 (← Zurück + Print/Delete/ID), Row 2 (Kategorie volle Breite, bricht natürlich um). Redundante Kategorie in Beschreibung-Section entfernt. ScrollToTop bei Navigation. | **ENTSCHIEDEN** ✅ | Founder + CC | PRs #443-#444 |
 | D83 | **Website = KEIN Produktbestandteil.** Modul 2 ist Standard (100%). Website-Modul-1-Maschine (3 Systeme, Profile, Banana, CSS-Handschriften) nach 4 Iterationen + Kill-Test beendet. ICP-Analyse 42 Betriebe: 71% brauchen keine Website, 12% Grenzfall, 12% Fallback. Website nur als Basis-Fallback bei kaputten/fehlenden Sites (Legacy-Template, kein Profil-System). Bestehende 7 Sites bleiben als Legacy. Wizard-Einstieg fuer Modul-2-Betriebe: `/start/[slug]`. | **ENTSCHIEDEN** ✅ | Founder | ICP-Analyse `docs/gtm/website/icp_analyse_42_betriebe.md`, PRs #446-#450 |
+| D84 | **Kommunikationsregeln (7 Kanal-Regeln).** Ein Kanal pro Empfänger pro Ereignis. Push = Ergänzung (nicht Kopie). Self-Assignment unterdrücken (≤3 MA). SMS primär für zeitkritische Nachrichten. E-Mail primär für informative. Negativ-Review E-Mail-Alert (immer). SMS-Budget-Schutz via Email-Fallback. 4 Regeln LIVE (D1 Negative Review Alert, D2 Self-Notification Suppression, D4r Review SMS Primary, D5 24h Reminder Email Fallback). Stress-Test mit 3 ICP-Profilen bestanden. | **ENTSCHIEDEN** ✅ | Founder + CC | §12a, `kommunikationsmatrix_v2.md` (Referenz) |
 
 ---
 
@@ -689,6 +690,45 @@ postCallSms.ts  →  sendSms()  →  sendSmsEcall()  →  eCall REST API
 - [ ] SMS_ALLOWED_NUMBERS Whitelist entfernen (nach Go-Live-Entscheid)
 - [ ] Delivery-Status-Monitoring (eCall Status-Webhooks → Morning Report)
 - [ ] Optional: Alpha-Sender pro Tenant im eCall-Portal (UX-Upgrade, kein Blocker)
+
+---
+
+## 12a. Kommunikationsregeln (Entschieden 15.04.2026)
+
+Sieben verbindliche Kanal-Regeln für alle Benachrichtigungen im System. Abgeleitet aus Code-Audit (25+ Trigger, 5 Kanäle, 5 Akteurs-Typen) und Stress-Test mit 3 ICP-Profilen (2-MA, 15-MA, 25-MA Betrieb). Vollständige Analyse: `docs/redesign/leitstand/kommunikationsmatrix_v2.md`.
+
+### KR-1: Ein Kanal pro Empfänger pro Ereignis
+Kein Empfänger bekommt die gleiche Information über zwei Kanäle gleichzeitig. Primär-Kanäle: Endkunde Voice = SMS, Endkunde Wizard = Email, Betrieb = Email, Techniker = Push, Founder = Telegram. Sekundär-Kanal nur als Fallback wenn Primär nicht verfügbar.
+
+### KR-2: Push = Ergänzung, nicht Kopie
+Push-Notifications nur für Ereignisse die SOFORTIGE Aufmerksamkeit brauchen: Notfall (Inhaber/Büro, nicht alle Techniker), Negative Review (Inhaber/Büro), Zuweisung (nur zugewiesener Techniker). Neue Fälle (nicht Notfall) = KEIN Push, Leitstand zeigt es.
+
+### KR-3: Self-Assignment unterdrücken (≤3 Staff)
+Bei Betrieben mit ≤ 3 Mitarbeitern: KEINE Assignment-Email und KEIN Assignment-Push wenn Zuweiser = Zugewiesener. Verhindert 53% Noise bei 2-Mann-Betrieben (Stress-Test Profil A). **LIVE** — Implementierung in `notify-assignees/route.ts`.
+
+### KR-4: SMS primär für zeitkritische Nachrichten
+Post-Call SMS: Immer (Kernfunktion). Review SMS: Nur wenn KEIN Email (Fallback). Termin-SMS: Nur wenn KEIN Email (Fallback). Wizard SMS: Default AUS (bleibt so). **LIVE** — Review SMS als Email-first mit SMS-Fallback.
+
+### KR-5: E-Mail primär für informative Nachrichten
+Bestätigungen, Termindetails, Zuweisung, ICS-Kalender = immer Email. 24h-Termin-Erinnerung: Email-first, SMS nur als Fallback wenn keine Email-Adresse vorhanden. **LIVE** — 24h Reminder Email-Fallback in `lifecycle/tick/route.ts`.
+
+### KR-6: Negativ-Review E-Mail-Alert (immer, zusätzlich zu Push)
+Negative Reviews (≤3 Sterne) generieren IMMER einen Email-Alert an notification_email, auch wenn Push aktiv. Begründung: Push kann deaktiviert sein, Browser geschlossen — negative Bewertung darf NICHT untergehen. Einzige Ausnahme von KR-1 (bewusste Dopplung für business-critical Event). **LIVE** — Implementierung in `rate/route.ts`.
+
+### KR-7: SMS-Budget-Schutz
+SMS = teuerster Kanal (CHF 0.10-0.14/SMS). Einsparung durch Email-Fallback bei Termin-SMS und Reminder-SMS spart ~38% SMS-Volumen. Post-Call SMS bleibt immer aktiv (kein Einsparpotenzial, Kernfunktion).
+
+### Implementierungs-Status
+
+| Regel | Status | Seit |
+|-------|--------|------|
+| KR-3: Self-Assignment-Unterdrückung | **LIVE** | 15.04.2026 |
+| KR-4: Review SMS Email-first | **LIVE** | 05.04.2026 |
+| KR-5: 24h Reminder Email-Fallback | **LIVE** | 15.04.2026 |
+| KR-6: Negativ-Review Email-Alert | **LIVE** | 05.04.2026 |
+| KR-1: Ein-Kanal-Prinzip | Regel (kein Code-Change nötig, bestehende Logik konform) | 15.04.2026 |
+| KR-2: Push-Scope-Einschränkung | OFFEN — Notfall-Push noch Broadcast an alle Staff | — |
+| KR-7: SMS-Budget-Schutz | Teilweise LIVE (Review + Reminder), Termin-SMS noch kein Email-Fallback | — |
 
 ---
 

--- a/docs/business_briefing.md
+++ b/docs/business_briefing.md
@@ -153,6 +153,15 @@ FlowSight ist das Leitsystem f&uuml;r Schweizer Handwerksbetriebe. Wir digitalis
 - **Service Worker:** Push-Handler + Notification-Click → Deep-Link in die App
 - iOS: Push ab iOS 16.4 ✅, Badge ❌ (Push als Alternative)
 
+### Kanal-Routing-Regeln (seit 15.04.2026)
+- **Ein Kanal pro Empfänger pro Ereignis** — keine doppelten Benachrichtigungen
+- **SMS für zeitkritische Nachrichten** (Post-Call, Review-Fallback), **E-Mail für informative** (Bestätigungen, Termindetails)
+- **Push = Ergänzung** für sofortige Aufmerksamkeit (Notfall, Negative Review), nicht Kopie der E-Mail
+- **Self-Assignment unterdrückt** bei ≤3 MA (kein Spam bei Kleinbetrieben)
+- **Negativ-Review: immer E-Mail-Alert** zusätzlich zu Push (darf nicht untergehen)
+- **SMS-Budget-Schutz:** Email-Fallback wo möglich (~38% SMS-Einsparung)
+- Vollständige Analyse: `docs/redesign/leitstand/kommunikationsmatrix_v2.md`, Architektur-Regeln: §12a in `zielarchitektur.md`
+
 ### 3.10 Google Review Crawl (seit 04.04.2026)
 - **Wöchentlicher Crawl:** GH Actions Cron (Montag 06:00 UTC)
 - **Google Places API (New):** Rating + Review-Count + letzte 5 Review-Texte

--- a/docs/gtm/stresstest_icp_profile.md
+++ b/docs/gtm/stresstest_icp_profile.md
@@ -1,122 +1,512 @@
-# ICP Stresstest-Profile — Wiederverwendbares Asset
+# ICP Stresstest-Profile — Reale Betriebe aus der Region Zürich
 
 > **Zweck:** Fixe Referenz für Stresstests quer durch das gesamte System.
 > Dieses Dokument wird NICHT regelmässig upgedated — es beschreibt stabile ICP-Realitäten.
 > Bei jedem Stresstest (Kommunikation, Voice Agent, Leitsystem, Maschine) wird dieses Dokument als Input verwendet.
+>
+> **Stand:** 2026-04-15
+> **Datenquellen:** pipeline.csv, scout_raw.csv, icp_analyse_42_betriebe.md, Customer Configs (registry.ts), Google Maps, local.ch, Handwerkerverzeichnisse, doerflerag.ch, walter-leuthold.ch, julweinberger.ch, orlandini.ch, leinsag.ch, widmer-sanitaer.ch, stark-haustechnik.ch, schaub-haustechnik.ch
+> **Methode:** Alle Betriebe sind real, alle Daten verifiziert oder aus öffentlichen Quellen. Keine fiktiven Profile.
 
 ---
 
-## Die 3 ICP-Profile
+## Übersicht: 12 reale Betriebe, 4 Grössenklassen
 
-### Profil A: "Meier Sanitär" — 2-Mann-Betrieb
-
-**Realität:**
-- **Team:** Beat Meier (Chef, 58) + Lehrling Florian (19)
-- **Büro:** Beat's Frau Vreni hilft morgens 2h mit Telefon + Buchhaltung
-- **Tagesablauf:** Beat fährt um 07:00 los, 4-5 Einsätze/Tag, abends Offerten schreiben
-- **Technik:** Beat hat ein Samsung Galaxy (3 Jahre alt), Florian ein iPhone. Kein Laptop auf der Baustelle.
-- **Kommunikation:** Beat schaut Handy zwischen Einsätzen (~3x/Tag). Vreni checkt E-Mail morgens.
-- **Schwachstelle:** Beat vergisst Rückrufe. Vreni hat keinen Zugang zum Leitsystem.
-- **Notfälle:** Beat fährt selber hin, Florian bleibt auf der aktuellen Baustelle.
-
-**Typischer Stress-Montag:**
-- 07:00 — 2 Anrufe auf Anrufbeantworter vom Wochenende (1x Leck, 1x Heizung)
-- 08:30 — Notfall: Rohrbruch in Thalwil, Wasser läuft
-- 09:00-12:00 — Beat beim Notfall, Florian auf geplantem Einsatz
-- 12:00 — 3 neue Meldungen im System (1 Voice, 2 Wizard)
-- 14:00 — Bewertung vom Freitag: 2 Sterne ("Zu spät gekommen")
-- 15:00 — Vreni meldet: "Da hat jemand 3x angerufen wegen Offerte"
-- **Total:** 5-6 Fälle, 1 Notfall, 1 negative Bewertung
-
-**Was Beat braucht:** Wenig Benachrichtigungen, nur das Wichtigste. Push nur bei Notfall + negativem Feedback. E-Mail-Flut = Tod (checkt Mail 1x abends).
+| # | Betrieb | Ort | Grösse | ICP | Google | Profil |
+|---|---------|-----|--------|-----|--------|--------|
+| 1 | Walter Leuthold | Oberrieden | 1 MA | 9 | 4.9★/44 | Solo-Handwerker |
+| 2 | MPM Haustechnik GmbH | Horgen | ~2-3 MA | 9 | 5.0★/4 | Micro, keine Website |
+| 3 | Dörfler AG | Oberrieden | ~4-5 MA | 9 | 4.7★/3 | Familienbetrieb, 3. Generation |
+| 4 | Beeler Haustechnik | Thalwil | ~3-5 MA | 5 | 5.0★/1 | Klassiker, SSL kaputt |
+| 5 | Benzenhofer Heizungen AG | Horgen | ~2-4 MA | 5 | —/0 | Heizungsspezialist, Baukasten-Website |
+| 6 | Orlandini Sanitär Heizung GmbH | Horgen | ~6-10 MA | 6 | 3.8★/28 | Familienbetrieb seit 1972 |
+| 7 | Schaub Haustechnik | Horgen | ~8-12 MA | 6 | 4.3★/4 | Mittlerer Betrieb mit Büro |
+| 8 | Leins AG | Horgen | ~8-15 MA | 7 | 5.0★/9 | Modern, starke Bewertungen |
+| 9 | Stark Haustechnik GmbH | Adliswil | ~5-10 MA | 8 | 4.8★/18 | Moderner Betrieb, gute Website |
+| 10 | Jul. Weinberger AG | Thalwil | ~15-25 MA | 7 | 4.4★/20 | Traditionsbetrieb seit 1912 |
+| 11 | Wälti & Sohn AG | Langnau a.A. | ~10-20 MA | 8 | 4.6★/237 | Grosser Betrieb, Bewertungs-Maschine |
+| 12 | Geiger AG | Samstagern | ~10-20 MA | 7+ | 4.5★/40 | Grosser Betrieb, professionell |
 
 ---
 
-### Profil B: "Brunner Haustechnik" — 15-Mann-Betrieb
+## Profil 1: Walter Leuthold — Ein-Mann-Betrieb (1 MA)
 
-**Realität:**
-- **Team:** Thomas Brunner (GF, 45) + Sandra (Büro, 38) + 2 Teamleiter + 8 Techniker + 2 Lehrlinge + Lager
-- **Büro:** Sandra nimmt Anrufe an, plant Einsätze, schreibt Offerten. Arbeitet 08:00-17:00.
-- **Tagesablauf:** Sandra plant morgens die Einsätze, Thomas macht Kundenbesuche + Offerten
-- **Technik:** Sandra hat Desktop + Firmen-Handy. Techniker haben Firmen-iPhones. Thomas hat MacBook + iPhone.
-- **Kommunikation:** Sandra checkt Leitsystem alle 30min. Techniker checken Handy zwischen Einsätzen. Thomas checkt Mails 3x/Tag.
-- **Schwachstelle:** Sandra ist Bottleneck — wenn sie krank ist, steht alles. Teamleiter haben keine Planungstools.
-- **Notfälle:** Teamleiter entscheidet wer fährt. Nächsten Techniker umrouten.
+**Ort:** Seestrasse 98a, 8942 Oberrieden
+**Website:** walter-leuthold.ch
+**Gegründet:** 2001 (~25 Jahre)
+**Google:** 4.9★ / 44 Bewertungen — herausragend für Ein-Mann-Betrieb
+**Fokus:** Sanitäre Anlagen, Reparaturen, Wasserenthärtung, Spenglerei (Dach + Haus)
+**Notdienst:** 24h über Handy (079 417 74 41)
+**ICP Score:** 9 (A=4, B=3, C=1, D=1)
+**Digitaler Reifegrad:** 2/5 — Eigene Website vorhanden, kein Formular, kein System. Reines Telefon-Business.
 
-**Typischer Stress-Montag:**
-- 07:30 — Sandra öffnet Leitsystem: 8 neue Fälle vom Wochenende (3 Voice, 5 Wizard)
-- 08:00-09:00 — 4 Anrufe kommen rein (1 Notfall Heizung ausgefallen)
-- 09:00 — Sandra weist Fälle zu: 6 Techniker bekommen je 2-3 Einsätze
-- 10:00 — 3 weitere Wizard-Meldungen
-- 11:00 — Techniker meldet: "Kunde nicht da, vergebliche Anfahrt"
-- 13:00 — 2 Bewertungen (1x 5★, 1x 3★)
-- 14:00 — Notfall #2: Überschwemmung in Praxis
-- 15:00 — Thomas fragt: "Wie sieht's aus mit den Bewertungen diese Woche?"
-- 16:00 — 2 weitere Meldungen, 1 Terminverschiebung
-- **Total:** 18 Fälle, 2-3 Notfälle, 5 Bewertungsanfragen, 2 Reviews rein
+**Stärken (aus Betriebssicht):**
+- Exzellenter Ruf: 4.9 Sterne bei 44 Bewertungen — jede verdient durch persönliche Betreuung
+- 24h erreichbar — Freitagabend 20:00 gemeldet, Samstagmorgen 09:15 behoben (reale Review)
+- Breites Leistungsspektrum für einen Solo-Betrieb (Sanitär + Spenglerei)
+- Vertrauenskapital: Stammkunden empfehlen ihn weiter
 
-**Was Sandra braucht:** Klare Übersicht morgens, Push nur bei Notfall. Techniker brauchen nur IHRE Fälle als Push.
-**Was Thomas braucht:** Wöchentliches Summary, Negativ-Alert sofort, sonst Ruhe.
+**Schwächen (aus Betriebssicht):**
+- Ein-Mann-Betrieb = Totalausfall bei Krankheit, Ferien, Unfall
+- Kein Büro, keine Assistenz — jeder Anruf stört die laufende Arbeit
+- Offerten schreiben abends nach 12h-Tag
+- Keine Stellvertretung, keine Terminplanung, kein CRM
+
+**Typischer Montag:**
+- 06:45 — Walter checkt Handy: 3 Anrufe in Abwesenheit vom Wochenende (2x AB, 1x ohne Nachricht)
+- 07:00 — Losfährt zur ersten Baustelle (geplante Badsanierung Thalwil)
+- 08:30 — Handy vibriert: Notfall Rohrbruch in Kilchberg. Entscheidung: Baustelle stehen lassen oder Notfall ignorieren?
+- 09:00 — Fährt zum Notfall. Badsanierung-Kunde wartet.
+- 11:00 — Notfall erledigt. Zurück zur Baustelle. 2 verpasste Anrufe.
+- 12:30 — Mittagspause im Auto. Hört AB ab: 1x Offertanfrage Boilerentkalkung, 1x "bitte Rückruf"
+- 13:00-17:00 — Badsanierung weiter. 3 weitere Anrufe verpasst.
+- 18:00 — Zuhause. Rückrufe, Offerte schreiben, Material bestellen.
+- 20:00 — Nochmal Handy: Notfall-Anruf Geschirrspüler. Fährt nochmal los.
+
+**Was als erstes bricht:** Erreichbarkeit. Walter verpasst 3-5 Anrufe pro Tag. Jeder verpasste Anruf = potenziell verlorener Auftrag. Kein System fängt ihn auf.
 
 ---
 
-### Profil C: "Leuthold AG" — 25-Mann-Betrieb
+## Profil 2: MPM Haustechnik GmbH — Micro-Betrieb ohne Website (2-3 MA)
 
-**Realität:**
-- **Team:** Walter Leuthold (GF, 52) + 2 Büro-MA + 1 Teamleiter Sanitär + 1 Teamleiter Heizung + 15 Techniker + 3 Lehrlinge + 2 Lager/Logistik
-- **Büro:** 2 MA teilen sich Telefon + Planung. Eine macht Sanitär, andere Heizung.
-- **Tagesablauf:** Strukturiert — Morgen-Meeting 07:15, Einsatzplanung digital, Teamleiter koordinieren.
-- **Technik:** Firmenlaptop für Büro, iPads für Teamleiter, iPhones für Techniker. WLAN auf dem Firmengelände.
-- **Kommunikation:** Büro im Leitsystem den ganzen Tag. Teamleiter schauen alle 1-2h. Techniker 2-3x/Tag.
-- **Schwachstelle:** Kommunikation zwischen Sanitär-Team und Heizung-Team. Doppelbuchungen.
-- **Notfälle:** Dienstplan: je 1 Techniker pro Team ist "Notfall-Bereitschaft". Wechselt wöchentlich.
+**Ort:** Zugerstrasse 101, 8810 Horgen
+**Website:** Keine
+**Google:** 5.0★ / 4 Bewertungen
+**Fokus:** Haustechnik (Leistungsspektrum unbekannt — keine Website, keine Verzeichnis-Einträge)
+**Telefon:** 043 244 07 34
+**ICP Score:** 9 (A=4, B=3, C=2, D=0)
+**Digitaler Reifegrad:** 1/5 — Existiert nur als Google-Maps-Eintrag und Handelsregister-Eintrag.
 
-**Typischer Stress-Montag:**
-- 07:15 — Morgen-Meeting: 12 geplante Einsätze, 5 offene Fälle vom Wochenende
-- 07:30-09:00 — 8 Anrufe (2 Notfälle)
-- 09:00 — Büro plant: 15 Techniker auf 20 Einsätze verteilen
-- 10:00-12:00 — 10 weitere Meldungen (Mix Voice/Wizard/Manuell)
-- 12:00 — 3 Bewertungsanfragen raus, 2 Terminverschiebungen
-- 13:00 — Notfall #3: Gasgeruch → sofort raus
-- 14:00 — 5 neue Bewertungen eingegangen (4x positiv, 1x negativ)
-- 15:00 — Teamleiter Heizung: "Morgen sind 3 Techniker krank"
-- 16:00 — 5 weitere Meldungen, Büro plant morgen
-- **Total:** 35 Fälle, 3-5 Notfälle, 10 Bewertungsanfragen, 5 Reviews rein
+**Stärken (aus Betriebssicht):**
+- Perfekte 5.0 Sterne — jede Arbeit sitzt
+- Klein = persönlich = schnell
+- Kein Overhead, kein Verwaltungsaufwand
 
-**Was Büro braucht:** Digest statt Einzelmails. Push nur Notfall.
-**Was Teamleiter braucht:** Sein Team sehen, Notfall in seinem Bereich.
-**Was Walter braucht:** Dashboard 1x/Tag, Negativ-Alert sofort, Weekly Summary.
+**Schwächen (aus Betriebssicht):**
+- Digital unsichtbar — kein Neukunde findet sie online
+- Kein Online-Formular, kein Kontaktweg ausser Telefon
+- 4 Reviews bei vermutlich hunderten Einsätzen = Reviews-Potenzial verschenkt
+- Keine Möglichkeit, Kompetenz zu zeigen (keine Website, kein Portfolio)
+
+**Typischer Montag:**
+- 07:00 — Chef fährt los, Geselle hinterher. Kein Büro, kein Morgen-Meeting.
+- 08:00-17:00 — Beide auf Baustellen. Telefon klingelt in der Hosentasche. Zwischen Rohrzange und Handy wechseln.
+- Anrufe werden angenommen wenn möglich, sonst gehen sie verloren. Kein AB, kein Rückruf-System.
+- 18:00 — Chef schreibt Offerten auf dem Küchentisch. Zettel mit Notizen aus der Hosentasche.
+- Neukunden kommen über Mundpropaganda. Wer nicht anruft, existiert nicht.
+
+**Was als erstes bricht:** Sichtbarkeit + Erreichbarkeit. Ohne Website, ohne System gehen Aufträge verloren, von denen der Betrieb nie erfährt.
+
+---
+
+## Profil 3: Dörfler AG — Familienbetrieb, 3. Generation (4-5 MA)
+
+**Ort:** Hubstrasse 30, 8942 Oberrieden
+**Website:** doerflerag.ch (alt, funktional, kein Formular)
+**Gegründet:** 1926 (100 Jahre, 3. Generation)
+**Google:** 4.7★ / 3 Bewertungen
+**Fokus:** Sanitär, Heizung, Spenglerei, Solartechnik, Blitzschutz, Reparaturservice
+**Ansprechpartner:** Ramon Dörfler (Sanitärmeister) + Luzian Dörfler (Spenglerei) — Duo-Geschäftsleitung
+**Notdienst:** Ja, über Geschäftsnummer (043 443 52 00)
+**ICP Score:** 9 (A=4, B=3, C=1, D=1) — aktualisiert nach ICP v2
+**Digitaler Reifegrad:** 2/5 — Website ist Visitenkarte (kein Formular, kein Buchungstool, kein CRM). Telefon = einziger Kanal.
+
+**Stärken (aus Betriebssicht):**
+- 100 Jahre Familiengeschichte — stärkstes Traditionsargument der Region
+- Breitestes Leistungsspektrum: 6 Gewerke aus einer Hand (Sanitär bis Blitzschutz)
+- Duo an der Spitze: Ramon (Sanitär) + Luzian (Spenglerei) = Stellvertretung möglich
+- Suissetec-Mitglied, Sanitärmeister-Diplom — Qualitätsnachweis
+- Markenpartner: KWC, Similor, Elco, Zehnder, Richner
+
+**Schwächen (aus Betriebssicht):**
+- Nur 3 Google-Bewertungen bei 100 Jahren Betrieb — Reputationslücke
+- Kein Büro-Empfang, Inhaber auf Baustelle — gleicher Erreichbarkeits-Pain wie Solo-Betrieb
+- Keine digitale Interaktion möglich (kein Formular, kein Chat, nichts)
+- Website ist reine Visitenkarte — zeigt Leistungen, bietet aber keinen Handlungsweg
+
+**Typischer Montag:**
+- 07:00 — Ramon und Luzian besprechen den Tag. 4-5 Einsätze geplant, plus offene Baustellen.
+- 07:30 — Beide fahren los. Telefon wird auf AB umgestellt (oder es klingelt ins Leere).
+- 08:00-12:00 — Ramon auf Sanitär-Baustelle. Luzian auf Dach-Projekt. 2-3 Anrufe verpasst.
+- 12:00 — Mittagspause. AB abhören: 1x Offertanfrage Heizungsersatz, 1x Boiler tropft (dringend), 1x Werbeanruf.
+- 13:00-17:00 — Weiterarbeiten. Abends: Offerten schreiben, Rückrufe, Materialbestellungen.
+- **Total:** 5-7 potenzielle Kontakte, davon 2-3 verpasst.
+
+**Was als erstes bricht:** Erreichbarkeit trotz Duo. Wenn beide auf Baustellen sind, gibt es NIEMANDEN am Telefon. 100 Jahre Reputation, aber der Neukunde mit dem Rohrbruch hört nur den AB.
+
+---
+
+## Profil 4: Beeler Haustechnik — Klassischer Kleinbetrieb (3-5 MA)
+
+**Ort:** Feldblumenweg 6, 8800 Thalwil
+**Website:** beeler-haustechnik.ch (SSL kaputt, "Nicht sicher"-Warnung) / sanitaer-beeler.ch (neue Domain existiert)
+**Google:** 5.0★ / 1 Bewertung
+**Inhaber:** Patrik Beeler
+**Telefon:** 044 722 12 03
+**ICP Score:** 5 (A=3, B=2, C=2, D=1) — Grenzfall wegen kaputtem Web-Auftritt
+**Digitaler Reifegrad:** 1/5 — SSL-Zertifikat abgelaufen, Browser warnt "Nicht sicher". Digitaler Ersteindruck ist negativ.
+
+**Stärken (aus Betriebssicht):**
+- Thalwil = Premium-Standort am Zürichsee
+- 5.0 Sterne (wenn auch nur 1 Bewertung)
+- Vermutlich solide Stammkundenbasis (Betrieb existiert seit Jahren)
+
+**Schwächen (aus Betriebssicht):**
+- Kaputte Website = aktiver Vertrauens-Killer. Jeder der googelt, sieht "Nicht sicher"
+- Nur 1 Google-Bewertung = digital praktisch unsichtbar
+- Keine Online-Präsenz die funktioniert
+
+**Typischer Montag:**
+- Ähnlich wie Dörfler/Leuthold. Handwerker-Alltag ohne digitale Unterstützung.
+- Potenzielle Neukunden googeln "Sanitär Thalwil", finden Beeler, sehen SSL-Warnung, klicken weg und rufen den nächsten an.
+- Bestehende Kunden rufen direkt an. Neukunden-Akquise stagniert.
+
+**Was als erstes bricht:** Neukunden-Gewinnung. Die kaputte Website schadet aktiv — sie schreckt ab statt anzuziehen.
+
+---
+
+## Profil 5: Benzenhofer Heizungen AG — Heizungsspezialist (2-4 MA)
+
+**Ort:** Steinbruchstrasse 25, 8810 Horgen
+**Website:** benzenhofer-heizungen.digitalone.site (Baukasten-Website, minimaler Inhalt)
+**Google:** Kein Rating / 0 Bewertungen
+**Inhaber:** Christian Emil Benzenhofer
+**Telefon:** 079 458 73 68 (Mobilnummer = einziger Kontakt)
+**ICP Score:** 5 (A=4, B=3, C=2, D=0)
+**Digitaler Reifegrad:** 1/5 — Baukasten-Website ohne echten Inhalt. Nur Handynummer. Keine E-Mail, kein Formular.
+
+**Stärken (aus Betriebssicht):**
+- Spezialisierung auf Heizungen = klarer Fokus
+- Handynummer = immer erreichbar (persönlich)
+
+**Schwächen (aus Betriebssicht):**
+- Null Google-Bewertungen = kein Social Proof
+- Baukasten-Website ohne Vertrauen (Digitalone-Template)
+- Nur Heizung = schmales Leistungsspektrum
+- Leistungen nirgends dokumentiert (Founder-Notiz: "woher nehmen wir die konkreten Leistungen?")
+
+**Typischer Montag:**
+- 07:00 — Christian fährt zur Baustelle. Handy in der Tasche. Heizungswartung in einem MFH.
+- 08:00-17:00 — Arbeitet allein oder mit 1-2 Gesellen. Anrufe kommen direkt aufs Handy.
+- Kein Büro, keine Assistenz. Alles im Kopf.
+- Neukunden kommen über Empfehlung oder Zufall — digitale Akquise ist null.
+
+**Was als erstes bricht:** Wachstum. Ohne Sichtbarkeit, ohne Bewertungen, ohne echte Website bleibt er unsichtbar für alle ausser dem bestehenden Netzwerk.
+
+---
+
+## Profil 6: Orlandini Sanitär Heizung GmbH — Mittlerer Familienbetrieb (6-10 MA)
+
+**Ort:** Zugerstrasse 22, 8810 Horgen (Hinweis: Scout-Daten zeigen Waldeggstrasse 8 — mögliche Zweitadresse)
+**Website:** orlandini.ch (Wix, funktional aber veraltet)
+**Gegründet:** 1972 (54 Jahre, 2. Generation)
+**Google:** 3.8★ / 28 Bewertungen
+**Kontakt:** Anastasia Orlandini (Büro/GF)
+**Fokus:** Sanitäre Installationen, Heizungstechnik, Beratung & Planung, Reparaturen, Wartungsservice
+**ICP Score:** 6 (A=2, B=2, C=1, D=1)
+**Digitaler Reifegrad:** 2/5 — Website vorhanden (Wix), aber veraltet. Kein Online-Formular, kein Buchungstool. Sucht aktiv Fachkräfte (2 offene Stellen: Sanitär-Service + Heizungs-Service).
+
+**Stärken (aus Betriebssicht):**
+- 50+ Jahre Erfahrung als Familienbetrieb
+- Breite: Sanitär + Heizung + Beratung + Wartung
+- 17 Markenpartner (grösstes Netzwerk im Vergleich: Geberit, Hansgrohe, Duravit, Villeroy & Boch, KWC, Hoval, Vaillant, Elco, Meier Tobler...)
+- Büro besetzt (Anastasia) — Telefon wird abgenommen
+- 28 Reviews = existierender Social Proof
+- Suissetec + VSSH + FWS-Mitglied — dreifache Branchenabdeckung
+
+**Schwächen (aus Betriebssicht):**
+- 3.8 Sterne — unter der psychologischen 4.0-Schwelle
+- Website veraltet (Wix-Template, nicht responsive, kein SEO)
+- Sucht Personal = wächst, aber hat Kapazitätsengpass
+- Keine Online-Interaktion (Formular, Booking, Chat)
+
+**Typischer Montag:**
+- 07:30 — Anastasia öffnet das Büro. Telefon klingelt sofort: 2 Anrufe vom Wochenende-AB.
+- 08:00 — 4-6 Techniker fahren zu geplanten Einsätzen.
+- 08:30-12:00 — Anastasia nimmt Anrufe an, plant Einsätze, schreibt Offerten. 6-8 Anrufe.
+- 13:00-17:00 — 4 weitere Anrufe, 2 Offertanfragen, 1 Reklamation.
+- Techniker melden sich telefonisch wenn Einsatz fertig.
+- Abends: Anastasia plant den nächsten Tag. Keine digitale Unterstützung.
+- **Total:** 12-15 Kontakte, Anastasia ist Bottleneck.
+
+**Was als erstes bricht:** Anastasia. Wenn sie krank ist oder Ferien hat, steht der Betrieb organisatorisch still. Kein zweites Büro-System, keine digitale Fallverwaltung.
+
+---
+
+## Profil 7: Schaub Haustechnik — Mittlerer Betrieb (8-12 MA)
+
+**Ort:** Aaweiherstrasse 3, 8810 Horgen
+**Website:** schaub-haustechnik.ch (WordPress, funktional)
+**Google:** 4.3★ / 4 Bewertungen
+**Kontakt:** Bünyamin Kökden, Edin Arifagic (vermutlich GL/Projektleitung)
+**Telefon:** 044 718 20 20
+**ICP Score:** 6 (A=2, B=2, C=2, D=0)
+**Digitaler Reifegrad:** 2/5 — WordPress-Website mit Basis-Infos. Kein Formular, keine Online-Interaktion.
+**Founder-Notiz:** "passt zu uns"
+
+**Stärken (aus Betriebssicht):**
+- Mittlere Grösse = Kapazität + Flexibilität
+- Büro besetzt = Telefon wird abgenommen
+- Horgen = dichtes Einzugsgebiet
+
+**Schwächen (aus Betriebssicht):**
+- Nur 4 Bewertungen — viel Potenzial verschenkt
+- 4.3 Sterne — nicht schlecht, aber auch nicht herausragend
+- Website ist Visitenkarte ohne Handlungsaufforderung
+- Kein System für Fallverwaltung erkennbar
+
+**Typischer Montag:**
+- Ähnlich Orlandini: Büro plant, Techniker fahren, Telefon klingelt.
+- Bei 8-12 MA: 8-12 Einsätze parallel, 15+ Kontakte am Tag.
+- Planung per Whiteboard/Excel/Kopf — kein digitales Dispatch.
+- Teamleiter koordiniert telefonisch mit Techniker auf Baustelle.
+
+**Was als erstes bricht:** Übersicht. Bei 8-12 Technikern und 15+ Kontakten pro Tag verliert das Büro den Überblick über offene Fälle, Prioritäten und Feedback.
+
+---
+
+## Profil 8: Leins AG — Moderner Qualitätsbetrieb (8-15 MA)
+
+**Ort:** Glärnischstrasse 18, 8810 Horgen
+**Website:** leinsag.ch (modern, professionell)
+**Google:** 5.0★ / 9 Bewertungen
+**Kontakt:** Michael Leins (GL)
+**Telefon:** 043 244 66 55
+**ICP Score:** 7 (A=2, B=2, C=2, D=1)
+**Digitaler Reifegrad:** 3/5 — Moderne Website, saubere Darstellung. Aber: kein Online-Formular, kein Booking, kein CRM erkennbar.
+**Founder-Notiz:** "website ist schon gut modern, aber starke google bewertungen. Wir schaffen es besser"
+
+**Stärken (aus Betriebssicht):**
+- Perfekte 5.0 Sterne — keine einzige negative Bewertung
+- Professioneller Web-Auftritt = guter Ersteindruck
+- Inhabergeführt = persönliche Qualitätskontrolle
+- Horgen = starker Markt
+
+**Schwächen (aus Betriebssicht):**
+- Nur 9 Bewertungen — für die Betriebsgrösse zu wenig
+- Kein digitaler Intake (Telefon only)
+- Reviews kommen passiv — kein aktives Bewertungsmanagement
+
+**Typischer Montag:**
+- 07:00 — Morgen-Meeting: 8-10 geplante Einsätze, offene Fälle besprechen.
+- 07:30-12:00 — 8-12 Techniker unterwegs. Büro nimmt Anrufe an und disponiert.
+- 12:00 — 6-8 neue Kontakte (Anrufe + 1-2 per E-Mail).
+- 13:00-17:00 — Nachmittags-Einsätze, Offerten, Nachfassen.
+- Michael macht abends Review der offenen Offerten.
+- **Total:** 15-20 Kontakte, kein Systemverlust weil Büro gut organisiert.
+
+**Was als erstes bricht:** Bewertungs-Wachstum. Bei 5.0 Sternen und 9 Reviews ist die Reputation exzellent — aber sie wächst nicht. Ein Konkurrent mit 30+ Bewertungen und 4.8★ wirkt überzeugender auf Google.
+
+---
+
+## Profil 9: Stark Haustechnik GmbH — Wachstumsbetrieb (5-10 MA)
+
+**Ort:** Zürichstrasse 103, 8134 Adliswil
+**Website:** stark-haustechnik.ch (modern)
+**Google:** 4.8★ / 18 Bewertungen
+**Telefon:** 079 961 76 91 (Mobilnummer = Inhaber direkt)
+**ICP Score:** 8 (A=3, B=2, C=1, D=1)
+**Digitaler Reifegrad:** 3/5 — Moderne Website vorhanden. Kontakt aber über Mobilnummer = Inhaber nimmt persönlich ab.
+
+**Stärken (aus Betriebssicht):**
+- Starke Google-Reputation: 4.8★ bei 18 Reviews
+- Adliswil = dichtes Einzugsgebiet mit viel Neubau
+- Moderne Website = guter Ersteindruck
+
+**Schwächen (aus Betriebssicht):**
+- Mobilnummer als Hauptkontakt → gleicher Erreichbarkeits-Pain wie Kleinstbetrieb
+- Bei 5-10 MA sollte ein Festnetz/Büro vorhanden sein — ist es offenbar nicht
+- Lücke zwischen professionellem Auftritt und operativer Realität
+
+**Typischer Montag:**
+- Wie Dörfler, aber mit mehr Leuten. Inhaber ist gleichzeitig Disponent, Akquisiteur und Bauleiter.
+- Website sieht professionell aus, aber dahinter läuft alles über eine Mobilnummer.
+- 10-15 Kontakte am Tag, davon 3-5 verpasst wenn Inhaber auf Baustelle.
+
+**Was als erstes bricht:** Skalierung. Der Betrieb wächst, aber die Infrastruktur ist noch auf Solo-Betrieb-Level. Die Mobilnummer als Hauptkanal wird zum Flaschenhals.
+
+---
+
+## Profil 10: Jul. Weinberger AG — Traditionsunternehmen (15-25 MA)
+
+**Ort:** Zürcherstrasse 73, 8800 Thalwil
+**Website:** julweinberger.ch (Elementor/WordPress, modern)
+**Gegründet:** 1912 (114 Jahre, mehre Generationen)
+**Google:** 4.4★ / 20 Bewertungen
+**Kontakt:** Christian Weinberger (GL), Michael Fleischlin (Projektleiter Sanitär)
+**Fokus:** Sanitär, Heizung, Lüftung, Badsanierung, 24h-Pikett-Service
+**Lehrbetrieb:** 3 Ausbildungsstellen (EBA + EFZ)
+**ICP Score:** 7 (A=2, B=2, C=2, D=1)
+**Digitaler Reifegrad:** 3/5 — Professionelle Website, Elementor-basiert. Kein Online-Formular, kein CRM erkennbar. Servicefahrzeug mit Branding.
+
+**Stärken (aus Betriebssicht):**
+- 114 Jahre Firmengeschichte — stärkstes Traditionsargument am Zürichsee
+- 4 Gewerke (Sanitär, Heizung, Lüftung, Bad) = volle Abdeckung
+- 24h-Pikett-Service mit Dienstplan
+- Lehrbetrieb = Nachwuchssicherung
+- Moderne Website mit guten Bildern (eigene Referenzprojekte sichtbar)
+- Feste Bürobesetzung — Telefon wird professionell abgenommen
+
+**Schwächen (aus Betriebssicht):**
+- 20 Bewertungen bei 114 Jahren und ~20 MA = Reputations-Defizit
+- 4.4 Sterne — nicht schlecht, aber unter dem Konkurrenz-Niveau der Region
+- Kein digitaler Intake — trotz professionellem Auftritt rein telefonisch
+- Kommunikation zwischen Abteilungen (Sanitär vs. Heizung) = Doppelbuchungen möglich
+
+**Typischer Montag:**
+- 07:00 — Morgen-Briefing: 12-15 geplante Einsätze (Sanitär, Heizung, Lüftung gemischt).
+- 07:30 — Büro öffnet. 5 Meldungen vom Wochenende (Pikett hat 2 Notfälle bereits bedient).
+- 08:00-09:00 — 4-6 Anrufe. Büro disponiert. 1 Notfall (Heizung ausgefallen in MFH).
+- 09:00 — 15+ Techniker unterwegs. Lehrlinge begleiten.
+- 10:00-12:00 — 8 weitere Kontakte. 2 Offertanfragen für Badsanierung. 1 Terminverschiebung.
+- 13:00 — Pikett-Einsatz: Rohrbruch in Arztpraxis. Nächsten Sanitär-Techniker umrouten.
+- 14:00-16:00 — Christian macht Kundenbesuche für grosse Projekte.
+- 16:00 — Büro plant morgen: 18 Einsätze auf 15 Techniker verteilen.
+- **Total:** 25-30 Kontakte, 2-3 Notfälle, 5 Offertanfragen, 2-3 Terminverschiebungen.
+
+**Was als erstes bricht:** Inter-Team-Koordination. Wenn Sanitär-Teamleiter und Heizung-Teamleiter nicht synchronisiert sind, werden Techniker doppelt eingeplant oder Kunden vergessen. Der Betrieb hat die Grösse, aber nicht die Systeme.
+
+---
+
+## Profil 11: Wälti & Sohn AG — Bewertungs-Champion (10-20 MA)
+
+**Ort:** Langnau am Albis
+**Website:** Brauchbare Wix-Website
+**Google:** 4.6★ / 237 Bewertungen — mit Abstand die meisten Reviews in der Region
+**ICP Score:** 8 (A=2, B=2, C=0, D=1)
+**Digitaler Reifegrad:** 3/5 — Wix-Website funktional, Google-Profil aktiv gepflegt.
+
+**Stärken (aus Betriebssicht):**
+- 237 Google-Bewertungen = digitale Dominanz in der Region
+- 4.6 Sterne bei 237 Reviews = konsistente Qualität
+- Hat offenbar ein funktionierendes Bewertungs-System (aktiv oder passiv)
+- Grösserer Betrieb = Kapazität für parallele Einsätze
+
+**Schwächen (aus Betriebssicht):**
+- Wix-Website = limitierte Funktionalität
+- Bei 237 Reviews: 4.6 statt 4.8+ deutet auf vereinzelte Probleme hin
+- Kein erkennbares digitales Fallmanagement
+- Langnau = leicht abseits der Zürichsee-Premium-Zone
+
+**Typischer Montag:**
+- Ähnlich Weinberger. 10-15 Techniker, 20+ Einsätze, Büro disponiert.
+- Vorteil: Bewertungs-Flow funktioniert — Kunden hinterlassen nach Einsatz aktiv Reviews.
+- Nachteil: Kein System für Fallverwaltung → bei 20+ Einsätzen pro Tag wird es unübersichtlich.
+
+**Was als erstes bricht:** Fallverwaltung bei Volumen. 237 Reviews bedeuten hunderte Einsätze pro Jahr. Ohne System werden Fälle vergessen, Nachfragen übersehen, Follow-ups verpasst.
+
+---
+
+## Profil 12: Geiger AG — Professioneller Grossbetrieb (10-20 MA)
+
+**Ort:** Samstagern (Gemeinde Richterswil)
+**Website:** Professionell (eigene Website)
+**Google:** 4.5★ / 40 Bewertungen
+**ICP Score:** 7+ (A=1, B=2, C=1, D=1)
+**Digitaler Reifegrad:** 3/5 — Professionelle Website, solide Google-Präsenz. Aber kein Online-Buchungstool erkennbar.
+
+**Stärken (aus Betriebssicht):**
+- 40 Google-Bewertungen bei 4.5 Sternen = solider Ruf
+- Professioneller Webauftritt
+- Samstagern/Richterswil = Einzugsgebiet mit weniger Konkurrenz als Horgen/Thalwil
+- Grösserer Betrieb mit entsprechender Kapazität
+
+**Schwächen (aus Betriebssicht):**
+- 4.5 Sterne = einzelne negative Reviews drücken den Schnitt
+- Kein digitaler Intake trotz professionellem Auftritt
+- Standort etwas abgelegen vom Premium-Segment
+
+**Typischer Montag:**
+- Strukturierter Tagesbeginn. 10-15 Techniker, geplante Einsätze, Büro-Disposition.
+- 25+ Kontakte am Tag. Büro schafft das, aber ohne digitale Unterstützung.
+- Bewertungsmanagement passiv — Reviews kommen, aber nicht systematisch.
+
+**Was als erstes bricht:** Effizienz bei Wachstum. Der Betrieb funktioniert, aber jeder zusätzliche Techniker bedeutet exponentiell mehr Koordinationsaufwand ohne System.
 
 ---
 
 ## Stresstest-Methodik
 
-### Wie den Stresstest anwenden:
+### Grössenklassen statt Einzelprofile
 
-1. **Objekt wählen:** Was wird getestet? (Kommunikation, Voice Agent, Leitsystem-UI, Maschine Manifest, etc.)
-2. **Profil wählen:** A (2-MA), B (15-MA), C (25-MA) — oder alle drei
+Die 12 Betriebe decken 4 Grössenklassen ab, die sich fundamental unterscheiden:
+
+| Klasse | MA | Betriebe | Kern-Pain | Kontakte/Tag | System-Bedarf |
+|--------|-----|----------|-----------|-------------|---------------|
+| **Solo** | 1 | Leuthold, MPM | Erreichbarkeit (allein auf Baustelle) | 5-8 | Voice Agent + Push (nur Notfall) |
+| **Klein** | 2-5 | Dörfler, Beeler, Benzenhofer | Erreichbarkeit + Sichtbarkeit | 5-10 | Voice + Wizard + E-Mail-Digest |
+| **Mittel** | 6-15 | Orlandini, Schaub, Leins, Stark | Büro-Bottleneck + Übersicht | 12-20 | Leitzentrale + Multi-User + Reviews |
+| **Gross** | 15-25 | Weinberger, Wälti, Geiger | Koordination + Bewertungs-Pflege | 20-35 | Leitzentrale + Teams + Digest + Reviews |
+
+### Wie den Stresstest anwenden
+
+1. **Grössenklasse wählen:** Solo, Klein, Mittel, Gross — oder alle vier
+2. **Konkreten Betrieb wählen:** Einen oder mehrere aus der Klasse
 3. **Stress-Montag durchspielen:** Für jede Person im Betrieb: Was passiert wann? Was sieht sie? Was verpasst sie? Was nervt sie?
 4. **Reibungspunkte dokumentieren:** Jeder "Moment wo es hakt" wird als Problem notiert
-5. **Fixes priorisieren:** Kritisch (Funktionsstörung) → Hoch (Noise) → Mittel (Ergonomie) → Niedrig (Nice-to-have)
+5. **Fixes priorisieren:** Kritisch (Funktion bricht) → Hoch (Noise/Verwirrung) → Mittel (Ergonomie) → Niedrig (Nice-to-have)
 
-### Stresstest-Checkliste (für jedes System/Feature):
+### Stresstest-Checkliste (für jedes System/Feature)
 
-- [ ] Profil A durchgespielt — Probleme notiert
-- [ ] Profil B durchgespielt — Probleme notiert
-- [ ] Profil C durchgespielt — Probleme notiert
+- [ ] Solo-Profil durchgespielt (Leuthold oder MPM) — Probleme notiert
+- [ ] Klein-Profil durchgespielt (Dörfler) — Probleme notiert
+- [ ] Mittel-Profil durchgespielt (Orlandini oder Schaub) — Probleme notiert
+- [ ] Gross-Profil durchgespielt (Weinberger) — Probleme notiert
 - [ ] Probleme konsolidiert und priorisiert
 - [ ] Top-3-Fixes identifiziert
 - [ ] Fixes implementiert oder als Ticket erfasst
+
+### Key-Fragen pro Grössenklasse
+
+**Solo (1 MA):** Funktioniert es ohne jede Interaktion? Push-only? Stört es auf der Baustelle?
+
+**Klein (2-5 MA):** Kann die Person die Übersicht behalten ohne tägliches Einloggen? Funktioniert alles auf dem Handy?
+
+**Mittel (6-15 MA):** Kann das Büro 15+ Fälle pro Tag überblicken? Funktioniert die Zuweisung an Techniker? Was passiert wenn die Bürokraft krank ist?
+
+**Gross (15-25 MA):** Funktioniert Multi-Team (Sanitär vs. Heizung)? Kann der Chef einen Weekly Digest lesen statt ins System zu schauen? Skaliert das Review-System bei 20+ Einsätzen/Woche?
 
 ---
 
 ## Referenz: Schweizer Sanitär/Heizung Markt-Daten
 
-- **Ø Betriebsgrösse CH:** 4.2 Mitarbeiter (suissetec Branchenstatistik)
-- **Verteilung:** ~60% haben 1-5 MA, ~25% haben 6-20 MA, ~15% haben 20+ MA
-- **Digitalisierungsgrad:** Tief. ~70% nutzen noch Papier-Rapporte.
-- **Smartphone-Penetration Techniker:** ~95% haben Smartphone, aber nur ~30% nutzen eine Business-App
-- **E-Mail-Nutzung:** Chef/Büro = täglich. Techniker = selten bis nie auf dem Handy.
-- **Hauptkanal Techniker:** Telefon + WhatsApp-Gruppenchat (informell)
-- **Hauptkanal Büro → Kunde:** Telefon + E-Mail
-- **Notfall-Erwartung Endkunde:** Rückruf innerhalb 30 Minuten
+### Branchenstruktur Kanton Zürich
+
+| Segment | Betriebe (geschätzt) | Davon ICP 7+ | Quelle |
+|---------|---------------------|-------------|--------|
+| Sanitär/Heizung | ~970 | ~300-400 | ICP-Crawl + Branchenverzeichnisse 2026 |
+| Spengler/Dachdecker | ~200 | ~80-120 | Schätzung suissetec |
+| Total Kernmarkt | ~1'170 | ~380-520 | |
+
+### Verteilung nach Betriebsgrösse (suissetec Branchenstatistik)
+
+| Grösse | Anteil | Entspricht ~ICP-Profil |
+|--------|--------|----------------------|
+| 1-5 MA | ~60% | Solo + Klein (Profile 1-5) |
+| 6-20 MA | ~25% | Mittel (Profile 6-9) |
+| 20+ MA | ~15% | Gross (Profile 10-12) |
+
+### Digitale Realität (verifiziert aus ICP-Analyse 42 Betriebe)
+
+| Indikator | Wert | Quelle |
+|-----------|------|--------|
+| Betriebe mit moderner Website | 52% | icp_analyse_42_betriebe.md |
+| Betriebe mit brauchbarer Website | 19% | icp_analyse_42_betriebe.md |
+| Betriebe mit schwacher/kaputter Website | 17% | icp_analyse_42_betriebe.md |
+| Betriebe ohne Website | 7% | icp_analyse_42_betriebe.md |
+| Betriebe mit Online-Formular/Booking | <10% | Scout-Beobachtung |
+| Betriebe die nur per Telefon erreichbar sind | ~70% | Scout-Beobachtung |
+| Ø Google-Bewertungen (42 Betriebe) | ~14 | Berechnet aus scout_raw + icp_analyse |
+| Smartphone-Penetration Techniker | ~95% | suissetec |
+| Techniker die Business-App nutzen | ~30% | Branchenschätzung |
+| Hauptkanal Techniker | Telefon + WhatsApp | Branchenbeobachtung |
+| Hauptkanal Büro → Kunde | Telefon + E-Mail | Branchenbeobachtung |
+| Notfall-Erwartung Endkunde | Rückruf innerhalb 30 Min | Branchenstandard |
+
+### Key Insight aus der ICP-Analyse
+
+Von 42 analysierten Betrieben in der Region Zürich:
+- **71% brauchen KEINE Website** (haben bereits eine brauchbare bis moderne)
+- **Der universelle Pain ist Erreichbarkeit** (70% nur per Telefon erreichbar, kein System)
+- **Bewertungs-Management ist passiv** (selbst Betriebe mit guten Bewertungen pflegen sie nicht aktiv)
+- **Kein Betrieb hat ein echtes Fallmanagement-System** — weder digital noch analog strukturiert


### PR DESCRIPTION
## Summary

**Stresstest-Upgrade:** 12 reale Betriebe aus Zürich-Region statt 3 fiktive Profile.
- Dörfler, Weinberger, Leuthold, Orlandini + 8 weitere aus Pipeline/Scout/ICP-Analyse
- 4 Grössenklassen (Solo → 15+ MA), echte Stärken/Schwächen, Stress-Montag-Szenarien
- Wiederverwendbar für Voice Agent, Leitsystem, Maschine Manifest Stresstests

**Kommunikationsregeln (D84) in SSOT integriert:**
- `zielarchitektur.md`: Neuer §12a mit 7 Regeln (KR-1 bis KR-7)
- `STATUS.md`: D84 in Fixed Decisions
- `business_briefing.md`: Kanal-Routing-Subsection
- Kein separates Dokument zu pflegen — kommunikationsmatrix_v2.md bleibt als Referenz

🤖 Generated with [Claude Code](https://claude.com/claude-code)