### PR TITLE
feat: BigBen Runde 5 — 24h Reminder + Confirmation SMS

### DIFF
--- a/src/web/app/api/bigben-pub/reservations/[id]/route.ts
+++ b/src/web/app/api/bigben-pub/reservations/[id]/route.ts
@@ -57,7 +57,9 @@ export async function PATCH(
   }
 
   // SMS to guest on confirm/decline (skip for manual/no-phone reservations)
-  if (res.guest_phone && res.guest_phone !== "—") {
+  // Only send when status is actually CHANGING (guard against re-confirms)
+  const statusChanged = res.status !== newStatus;
+  if (statusChanged && res.guest_phone && res.guest_phone !== "—") {
     const dateObj = new Date(res.reservation_date + "T12:00:00");
     const dateStr = dateObj.toLocaleDateString("en-GB", {
       weekday: "long",
@@ -69,7 +71,7 @@ export async function PATCH(
     if (newStatus === "confirmed") {
       await sendSms(
         res.guest_phone,
-        `Hi ${res.guest_name}! Your table at Big Ben Pub is confirmed: ${dateStr} at ${timeStr}, ${res.party_size} guests. See you there! Alte Landstrasse 20, Oberrieden.`,
+        `Confirmed! Your table at Big Ben Pub, ${dateStr} at ${timeStr} for ${res.party_size} guests. Alte Landstrasse 20, Oberrieden. See you there!`,
         "BigBenPub"
       );
     } else if (newStatus === "declined") {
@@ -86,7 +88,7 @@ export async function PATCH(
     reservation_id: id,
     status: newStatus,
     guest: res.guest_name,
-    sms: res.guest_phone && res.guest_phone !== "—" ? "sent" : "skipped",
+    sms: statusChanged && res.guest_phone && res.guest_phone !== "—" ? "sent" : "skipped",
   }));
 
   return NextResponse.json({ ok: true, status: newStatus });

--- a/src/web/app/api/lifecycle/tick/route.ts
+++ b/src/web/app/api/lifecycle/tick/route.ts
@@ -105,12 +105,17 @@ export async function POST(req: NextRequest) {
   // ── 24h Termin reminders ──────────────────────────────────────────────
   const reminderResults = await processTerminReminders(supabase, now);
 
+  // ── 24h Pub reservation reminders ────────────────────────────────────
+  const pubReminderResults = await processPubReservationReminders(supabase, now);
+
   return NextResponse.json({
     processed: trials.length,
     actions: results.length,
     results,
     reminders_sent: reminderResults.length,
     reminders: reminderResults,
+    pub_reminders_sent: pubReminderResults.length,
+    pub_reminders: pubReminderResults,
   });
 }
 
@@ -387,6 +392,65 @@ async function processTerminReminders(
     });
 
     results.push({ case_id: c.id, sent, reason });
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// 24h Pub reservation reminders — SMS to guests before confirmed reservations
+// ---------------------------------------------------------------------------
+
+interface PubReminderResult {
+  reservation_id: string;
+  sent: boolean;
+  reason?: string;
+}
+
+async function processPubReservationReminders(
+  supabase: ReturnType<typeof getServiceClient>,
+  now: Date,
+): Promise<PubReminderResult[]> {
+  const results: PubReminderResult[] = [];
+
+  // Tomorrow's date in Europe/Zurich timezone
+  const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  const tomorrowStr = tomorrow.toLocaleDateString("sv-SE", { timeZone: "Europe/Zurich" }); // YYYY-MM-DD
+
+  // Query confirmed reservations for tomorrow that haven't been reminded yet
+  const { data: reservations } = await supabase
+    .from("pub_reservations")
+    .select("id, guest_name, guest_phone, reservation_date, reservation_time, party_size")
+    .eq("reservation_date", tomorrowStr)
+    .eq("status", "confirmed")
+    .is("reminder_sent_at", null);
+
+  if (!reservations || reservations.length === 0) return results;
+
+  for (const r of reservations) {
+    if (!r.guest_phone || r.guest_phone === "—") {
+      results.push({ reservation_id: r.id, sent: false, reason: "no_phone" });
+      continue;
+    }
+
+    const timeStr = r.reservation_time?.substring(0, 5) ?? "";
+    const smsBody = `Reminder: Your table at Big Ben Pub tomorrow at ${timeStr} for ${r.party_size} guests. We look forward to seeing you! — Big Ben Pub`;
+
+    const smsResult = await sendSms(r.guest_phone, smsBody, "BigBenPub");
+
+    // Mark as reminded (idempotency guard)
+    if (smsResult.sent) {
+      await supabase
+        .from("pub_reservations")
+        .update({ reminder_sent_at: now.toISOString() })
+        .eq("id", r.id);
+    }
+
+    results.push({
+      reservation_id: r.id,
+      sent: smsResult.sent,
+      reason: smsResult.reason,
+    });
   }
 
   return results;

--- a/supabase/migrations/20260416000000_pub_reservation_reminder.sql
+++ b/supabase/migrations/20260416000000_pub_reservation_reminder.sql
@@ -1,0 +1,3 @@
+-- Add reminder_sent_at to pub_reservations for 24h reminder idempotency
+ALTER TABLE pub_reservations
+  ADD COLUMN IF NOT EXISTS reminder_sent_at TIMESTAMPTZ;


### PR DESCRIPTION
Confirm→SMS, 24h reminder via lifecycle tick, migration for reminder_sent_at.