### PR TITLE
fix(bigben): FB22/23/24 — reservation forms EN+high-end, kill premature SMS, Linux path

### DIFF
--- a/scripts/_ops/bigben_voice_daily_refresh.mjs
+++ b/scripts/_ops/bigben_voice_daily_refresh.mjs
@@ -24,6 +24,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const require = createRequire(import.meta.url);
@@ -33,8 +34,10 @@ const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
 
 const SLUG = "bigben-pub";
-// scripts/_ops/<this file>  →  ../.. = repo root
-const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname).replace(/^\//, ""), "..", "..");
+// scripts/_ops/<this file>  →  ../.. = repo root.
+// Use fileURLToPath for cross-platform correctness (the regex hack to strip
+// a leading slash from URL pathnames silently broke on Linux runners).
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const AGENT_PATHS = {
   en: path.join(REPO_ROOT, "retell", "exports", "bigben-pub_agent.json"),
 };

--- a/src/web/app/(demos)/bigben-pub/ReservationForm.tsx
+++ b/src/web/app/(demos)/bigben-pub/ReservationForm.tsx
@@ -9,177 +9,267 @@ const TIME_SLOTS = [
 
 const PARTY_SIZES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 20];
 
+const DAY_NAMES_EN = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const DAY_NAMES_LONG_EN = [
+  "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+];
+const MONTH_NAMES_EN = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+interface DayOption {
+  value: string;          // ISO date YYYY-MM-DD (Zurich-aware)
+  label: string;          // "Tomorrow · Wed 29 Apr"
+  short: string;          // "Wed 29 Apr"
+  fullLabel: string;      // "Wednesday, 29 April"
+  isClosed: boolean;      // pub is closed on Mondays
+}
+
+/** Compute the next 21 days as date options in Zurich time. */
+function buildDayOptions(): DayOption[] {
+  const out: DayOption[] = [];
+  // Anchor on Zurich today by formatting and re-parsing
+  const todayIso = new Date().toLocaleDateString("sv-SE", { timeZone: "Europe/Zurich" });
+  const [ty, tm, td] = todayIso.split("-").map(Number);
+  for (let i = 1; i <= 21; i++) {
+    const d = new Date(Date.UTC(ty, tm - 1, td + i, 12, 0));
+    const iso = d.toISOString().split("T")[0];
+    const dow = d.getUTCDay();
+    const dayShort = DAY_NAMES_EN[dow];
+    const dayLong = DAY_NAMES_LONG_EN[dow];
+    const dayNum = d.getUTCDate();
+    const monthShort = MONTH_NAMES_EN[d.getUTCMonth()];
+    const monthLong = new Date(d).toLocaleDateString("en-GB", { month: "long", timeZone: "UTC" });
+    const short = `${dayShort} ${dayNum} ${monthShort}`;
+    let prefix = "";
+    if (i === 1) prefix = "Tomorrow · ";
+    else if (i <= 6) prefix = `This ${dayLong} · `;
+    out.push({
+      value: iso,
+      label: prefix + short,
+      short,
+      fullLabel: `${dayLong}, ${dayNum} ${monthLong}`,
+      isClosed: dow === 1, // Monday closed
+    });
+  }
+  return out;
+}
+
 export function ReservationForm() {
+  const [days] = useState(buildDayOptions);
+  const firstOpen = days.find((d) => !d.isClosed) ?? days[0];
+  const [date, setDate] = useState(firstOpen.value);
+  const [time, setTime] = useState("19:00");
+  const [guests, setGuests] = useState("2");
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [note, setNote] = useState("");
   const [submitted, setSubmitted] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selected = days.find((d) => d.value === date) ?? firstOpen;
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    setError(null);
+    if (selected.isClosed) {
+      setError("We're closed on Mondays — please pick another day.");
+      return;
+    }
     setLoading(true);
-
-    const form = new FormData(e.currentTarget);
     try {
       const res = await fetch("/api/bigben-pub/reserve", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: form.get("name"),
-          phone: form.get("phone"),
-          date: form.get("date"),
-          time: form.get("time"),
-          guests: form.get("guests"),
-          note: form.get("note"),
-        }),
+        body: JSON.stringify({ name, phone, date, time, guests, note }),
       });
-
       if (!res.ok) {
         const data = await res.json().catch(() => null);
-        alert(data?.error ?? "Something went wrong. Please try again.");
+        setError(data?.error ?? "Something went wrong. Please try again.");
         setLoading(false);
         return;
       }
     } catch {
-      alert("Connection error. Please try again.");
+      setError("Connection error. Please try again.");
       setLoading(false);
       return;
     }
-
     setSubmitted(true);
   }
-
-  // Min date = tomorrow
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  const minDate = tomorrow.toISOString().split("T")[0];
 
   if (submitted) {
     return (
       <div className="rounded-2xl border border-[#e8e0d5] bg-white p-10 text-center shadow-sm">
-        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-50">
-          <svg className="h-8 w-8 text-emerald-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-[#fdf6e7]">
+          <svg className="h-8 w-8 text-[#c0392b]" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
           </svg>
         </div>
-        <h3 className="mt-5 font-serif text-2xl font-bold text-[#1a1a1a]">Table reserved!</h3>
-        <p className="mt-2 text-sm text-[#888]">
-          You&apos;ll receive an SMS confirmation shortly.
-          <br />
-          We look forward to seeing you!
+        <h3 className="mt-5 font-serif text-2xl font-bold text-[#1a1a1a]">Thanks, {name.split(" ")[0]}!</h3>
+        <p className="mt-3 text-sm leading-relaxed text-[#666]">
+          Your request for <strong className="text-[#1a1a1a]">{selected.fullLabel}</strong> at{" "}
+          <strong className="text-[#1a1a1a]">{time}</strong> for{" "}
+          <strong className="text-[#1a1a1a]">{guests} {Number(guests) === 1 ? "guest" : "guests"}</strong> is in.
+        </p>
+        <p className="mt-3 text-sm text-[#888]">
+          Paul will confirm by SMS shortly. We&apos;re looking forward to seeing you.
         </p>
       </div>
     );
   }
 
   return (
-    <form onSubmit={handleSubmit} className="rounded-2xl border border-[#e8e0d5] bg-white p-8 shadow-sm">
-      <div className="grid gap-5 sm:grid-cols-2">
-        {/* Name */}
-        <div className="sm:col-span-2">
-          <label htmlFor="res-name" className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-[#999]">
-            Name
-          </label>
-          <input
-            id="res-name"
-            name="name"
-            type="text"
-            required
-            placeholder="John Smith"
-            className="w-full rounded-lg border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3 text-sm text-[#1a1a1a] placeholder:text-[#ccc] focus:border-[#c0392b] focus:outline-none focus:ring-1 focus:ring-[#c0392b]"
-          />
+    <form onSubmit={handleSubmit} className="rounded-2xl border border-[#e8e0d5] bg-white p-6 sm:p-9 shadow-sm">
+      {/* Date — horizontal pill scroller (English locale, controlled) */}
+      <div className="mb-6">
+        <div className="mb-2.5 flex items-baseline justify-between">
+          <label className="text-xs font-bold uppercase tracking-[0.18em] text-[#888]">Date</label>
+          <span className="text-xs text-[#999]">{selected.fullLabel}</span>
         </div>
-
-        {/* Phone */}
-        <div className="sm:col-span-2">
-          <label htmlFor="res-phone" className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-[#999]">
-            Phone (for SMS confirmation)
-          </label>
-          <input
-            id="res-phone"
-            name="phone"
-            type="tel"
-            required
-            placeholder="+41 79 ..."
-            className="w-full rounded-lg border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3 text-sm text-[#1a1a1a] placeholder:text-[#ccc] focus:border-[#c0392b] focus:outline-none focus:ring-1 focus:ring-[#c0392b]"
-          />
+        <div
+          className="-mx-1 flex gap-2 overflow-x-auto pb-1 px-1"
+          style={{ scrollbarWidth: "thin" }}
+        >
+          {days.map((d) => {
+            const active = d.value === date;
+            return (
+              <button
+                key={d.value}
+                type="button"
+                onClick={() => !d.isClosed && setDate(d.value)}
+                disabled={d.isClosed}
+                title={d.isClosed ? "Closed on Mondays" : d.fullLabel}
+                className={`flex-shrink-0 rounded-xl border px-3.5 py-2.5 text-center transition-all ${
+                  active
+                    ? "border-[#c0392b] bg-[#c0392b] text-white shadow-md"
+                    : d.isClosed
+                    ? "border-[#f0e8dc] bg-[#faf7f2] text-[#bbb] cursor-not-allowed"
+                    : "border-[#e8e0d5] bg-white text-[#1a1a1a] hover:border-[#c0392b]/60 hover:bg-[#fdf6e7]"
+                }`}
+              >
+                <div className={`text-[10px] font-semibold uppercase tracking-wider ${active ? "text-white/90" : "text-[#999]"}`}>
+                  {DAY_NAMES_EN[new Date(d.value + "T12:00:00Z").getUTCDay()]}
+                </div>
+                <div className="text-base font-bold leading-tight mt-0.5">
+                  {new Date(d.value + "T12:00:00Z").getUTCDate()}
+                </div>
+                <div className={`text-[10px] mt-0.5 ${active ? "text-white/90" : "text-[#999]"}`}>
+                  {MONTH_NAMES_EN[new Date(d.value + "T12:00:00Z").getUTCMonth()]}
+                </div>
+              </button>
+            );
+          })}
         </div>
+      </div>
 
-        {/* Date */}
+      {/* Time + Guests */}
+      <div className="mb-6 grid grid-cols-2 gap-4">
         <div>
-          <label htmlFor="res-date" className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-[#999]">
-            Date
-          </label>
-          <input
-            id="res-date"
-            name="date"
-            type="date"
-            required
-            min={minDate}
-            className="w-full rounded-lg border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3 text-sm text-[#1a1a1a] focus:border-[#c0392b] focus:outline-none focus:ring-1 focus:ring-[#c0392b]"
-          />
-        </div>
-
-        {/* Time */}
-        <div>
-          <label htmlFor="res-time" className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-[#999]">
+          <label htmlFor="res-time" className="mb-2.5 block text-xs font-bold uppercase tracking-[0.18em] text-[#888]">
             Time
           </label>
           <select
             id="res-time"
             name="time"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
             required
-            className="w-full rounded-lg border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3 text-sm text-[#1a1a1a] focus:border-[#c0392b] focus:outline-none focus:ring-1 focus:ring-[#c0392b]"
+            className="w-full rounded-xl border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3.5 text-[15px] font-medium text-[#1a1a1a] focus:border-[#c0392b] focus:bg-white focus:outline-none focus:ring-2 focus:ring-[#c0392b]/20 transition-all"
           >
-            <option value="">Select a time</option>
             {TIME_SLOTS.map((t) => (
               <option key={t} value={t}>{t}</option>
             ))}
           </select>
         </div>
-
-        {/* Guests */}
         <div>
-          <label htmlFor="res-guests" className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-[#999]">
+          <label htmlFor="res-guests" className="mb-2.5 block text-xs font-bold uppercase tracking-[0.18em] text-[#888]">
             Guests
           </label>
           <select
             id="res-guests"
             name="guests"
+            value={guests}
+            onChange={(e) => setGuests(e.target.value)}
             required
-            className="w-full rounded-lg border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3 text-sm text-[#1a1a1a] focus:border-[#c0392b] focus:outline-none focus:ring-1 focus:ring-[#c0392b]"
+            className="w-full rounded-xl border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3.5 text-[15px] font-medium text-[#1a1a1a] focus:border-[#c0392b] focus:bg-white focus:outline-none focus:ring-2 focus:ring-[#c0392b]/20 transition-all"
           >
-            <option value="">How many?</option>
             {PARTY_SIZES.map((n) => (
               <option key={n} value={n}>{n} {n === 1 ? "guest" : "guests"}</option>
             ))}
-            {/* All sizes available — no need to call */}
           </select>
         </div>
-
-        {/* Note */}
-        <div>
-          <label htmlFor="res-note" className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-[#999]">
-            Special requests
-          </label>
-          <input
-            id="res-note"
-            name="note"
-            type="text"
-            placeholder="e.g. birthday, outdoor seating"
-            className="w-full rounded-lg border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3 text-sm text-[#1a1a1a] placeholder:text-[#ccc] focus:border-[#c0392b] focus:outline-none focus:ring-1 focus:ring-[#c0392b]"
-          />
-        </div>
       </div>
+
+      {/* Name */}
+      <div className="mb-4">
+        <label htmlFor="res-name" className="mb-2.5 block text-xs font-bold uppercase tracking-[0.18em] text-[#888]">
+          Your name
+        </label>
+        <input
+          id="res-name"
+          name="name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          placeholder="John Smith"
+          className="w-full rounded-xl border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3.5 text-[15px] text-[#1a1a1a] placeholder:text-[#bbb] focus:border-[#c0392b] focus:bg-white focus:outline-none focus:ring-2 focus:ring-[#c0392b]/20 transition-all"
+        />
+      </div>
+
+      {/* Phone */}
+      <div className="mb-4">
+        <label htmlFor="res-phone" className="mb-2.5 block text-xs font-bold uppercase tracking-[0.18em] text-[#888]">
+          Phone <span className="font-normal normal-case tracking-normal text-[#bbb]">— for SMS confirmation</span>
+        </label>
+        <input
+          id="res-phone"
+          name="phone"
+          type="tel"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          required
+          placeholder="+41 79 ..."
+          className="w-full rounded-xl border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3.5 text-[15px] text-[#1a1a1a] placeholder:text-[#bbb] focus:border-[#c0392b] focus:bg-white focus:outline-none focus:ring-2 focus:ring-[#c0392b]/20 transition-all"
+        />
+      </div>
+
+      {/* Note */}
+      <div className="mb-6">
+        <label htmlFor="res-note" className="mb-2.5 block text-xs font-bold uppercase tracking-[0.18em] text-[#888]">
+          Special requests <span className="font-normal normal-case tracking-normal text-[#bbb]">— optional</span>
+        </label>
+        <input
+          id="res-note"
+          name="note"
+          type="text"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Birthday, outdoor seating, ..."
+          className="w-full rounded-xl border border-[#e0d9d0] bg-[#faf7f2] px-4 py-3.5 text-[15px] text-[#1a1a1a] placeholder:text-[#bbb] focus:border-[#c0392b] focus:bg-white focus:outline-none focus:ring-2 focus:ring-[#c0392b]/20 transition-all"
+        />
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
 
       <button
         type="submit"
         disabled={loading}
-        className="mt-6 w-full rounded-lg bg-[#c0392b] py-3.5 text-sm font-bold uppercase tracking-wider text-white transition-all hover:bg-[#e74c3c] hover:shadow-lg disabled:opacity-50"
+        className="w-full rounded-xl bg-[#c0392b] py-4 text-[13px] font-bold uppercase tracking-[0.2em] text-white transition-all hover:bg-[#a83020] hover:shadow-lg active:scale-[0.99] disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        {loading ? "Reserving..." : "Reserve Table"}
+        {loading ? "Sending request..." : "Request a Table"}
       </button>
 
-      <p className="mt-3 text-center text-xs text-[#ccc]">
-        You&apos;ll receive an SMS confirmation. No spam, no newsletter.
+      <p className="mt-4 text-center text-[11px] leading-relaxed text-[#999]">
+        Paul will confirm your reservation by SMS shortly after he sees the request.
+        <br />
+        No spam, no newsletter, no auto-replies.
       </p>
     </form>
   );

--- a/src/web/app/api/bigben-pub/reserve/route.ts
+++ b/src/web/app/api/bigben-pub/reserve/route.ts
@@ -1,17 +1,18 @@
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { getServiceClient } from "@/src/lib/supabase/server";
-import { sendSms } from "@/src/lib/sms/sendSms";
 
 /**
  * POST /api/bigben-pub/reserve — Table reservation for Big Ben Pub.
  *
  * 1. Saves to pub_reservations (status = pending)
- * 2. SMS notification to Paul (owner)
- * 3. SMS confirmation to guest ("received, we'll confirm shortly")
+ * 2. Push notification to Paul (owner) — he confirms in the app
+ *
+ * NO SMS to the guest at submit time. Guest only receives an SMS once
+ * Paul actually confirms in the app (via /api/bigben-pub/reservations/[id]
+ * PATCH). Sending a "request received" SMS at submit would be misread as
+ * confirmation and creates a confusing two-SMS flow.
  */
-
-const PAUL_PHONE = process.env.BIGBEN_OWNER_PHONE ?? "";
 
 export async function POST(req: Request) {
   const base = { _tag: "bigben_reservation", stage: "api" };
@@ -71,7 +72,7 @@ export async function POST(req: Request) {
       });
     }
 
-    // Format date for display
+    // Format date for display (used in push notification body)
     const dateObj = new Date(date + "T12:00:00");
     const dateStr = dateObj.toLocaleDateString("en-GB", {
       weekday: "long",
@@ -79,21 +80,7 @@ export async function POST(req: Request) {
       month: "long",
     });
 
-    // ── SMS to guest (received, not yet confirmed) ─────────────────
-    const guestSms = [
-      `Hi ${name}!`,
-      ``,
-      `Your reservation request at Big Ben Pub:`,
-      `${dateStr} at ${time}, ${guests} ${Number(guests) === 1 ? "guest" : "guests"}.`,
-      ``,
-      `Paul will confirm shortly.`,
-      `Alte Landstrasse 20, 8942 Oberrieden`,
-    ]
-      .join("\n");
-
-    const guestResult = await sendSms(phone, guestSms, "BigBenPub");
-
-    // Push notification to Paul (no SMS — he uses the app)
+    // Push notification to Paul (no guest SMS — that fires only on confirm)
     if (tenant) {
       import("@/src/lib/push/sendOpsPush").then(({ sendOpsPush }) =>
         sendOpsPush({
@@ -110,13 +97,12 @@ export async function POST(req: Request) {
     console.log(
       JSON.stringify({
         ...base,
-        decision: "sent",
+        decision: "saved_pending",
         name,
         date,
         time,
         guests,
         source,
-        sms_guest: guestResult.sent ? "sent" : guestResult.reason,
         db: tenant ? "saved" : "no_tenant",
       }),
     );

--- a/src/web/app/ops/(dashboard)/reservations/ReservationManager.tsx
+++ b/src/web/app/ops/(dashboard)/reservations/ReservationManager.tsx
@@ -63,6 +63,45 @@ function NoShowBadge({ count }: { count: number }) {
   );
 }
 
+const DAY_NAMES_EN = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const DAY_NAMES_LONG_EN = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const MONTH_NAMES_EN = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+interface ManualDayOption {
+  value: string;
+  short: string;
+  long: string;
+  isClosed: boolean;
+  prefix: string;
+}
+
+/** Today + next 14 days as English-locale options for Paul's walk-in form. */
+function buildManualDayOptions(): ManualDayOption[] {
+  const out: ManualDayOption[] = [];
+  const todayIso = new Date().toLocaleDateString("sv-SE", { timeZone: "Europe/Zurich" });
+  const [ty, tm, td] = todayIso.split("-").map(Number);
+  for (let i = 0; i <= 14; i++) {
+    const d = new Date(Date.UTC(ty, tm - 1, td + i, 12, 0));
+    const iso = d.toISOString().split("T")[0];
+    const dow = d.getUTCDay();
+    const dayShort = DAY_NAMES_EN[dow];
+    const dayLong = DAY_NAMES_LONG_EN[dow];
+    const dayNum = d.getUTCDate();
+    const monthShort = MONTH_NAMES_EN[d.getUTCMonth()];
+    let prefix = "";
+    if (i === 0) prefix = "Today";
+    else if (i === 1) prefix = "Tomorrow";
+    out.push({
+      value: iso,
+      short: `${dayShort} ${dayNum} ${monthShort}`,
+      long: `${dayLong}, ${dayNum} ${monthShort}`,
+      isClosed: dow === 1,
+      prefix,
+    });
+  }
+  return out;
+}
+
 /** Return today's date as YYYY-MM-DD in Zurich timezone */
 function todayISO(): string {
   return new Date().toLocaleDateString("sv-SE", { timeZone: "Europe/Zurich" });
@@ -220,86 +259,153 @@ export function ReservationManager({ reservations, noShowMap }: { reservations: 
         </button>
       </div>
 
-      {/* Manual reservation button — for walk-in / bar reservations */}
+      {/* Add reservation — for walk-ins and phone bookings */}
       <button
         onClick={() => {
           if (!showForm) {
-            // Re-compute date/time each time the form opens for accurate walk-in defaults
             setDate(todayISO());
             setTime(nowRounded15());
           }
           setShowForm(!showForm);
         }}
-        className="w-full rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
+        className="w-full rounded-xl bg-gray-900 py-3.5 text-sm font-semibold text-white transition-all hover:bg-gray-800 active:scale-[0.99]"
       >
-        {showForm ? "Cancel" : "+ Add Reservation"}
+        {showForm ? "Cancel" : "+ Add reservation"}
       </button>
 
-      {/* Manual form — quick entry for bar reservations */}
-      {showForm && (
-        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm space-y-3">
-          <p className="text-xs text-gray-400 font-medium">Walk-in / Phone</p>
-          <input
-            type="text"
-            placeholder="Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:outline-none"
-            autoFocus
-          />
-          <input
-            type="tel"
-            placeholder="Phone (optional)"
-            value={phone}
-            onChange={(e) => setPhone(e.target.value)}
-            className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:outline-none"
-          />
-          <div className="flex gap-2">
-            <input
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              className="flex-1 rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-gray-400 focus:outline-none"
-            />
-            <select
-              value={time}
-              onChange={(e) => setTime(e.target.value)}
-              className="w-24 rounded-lg border border-gray-200 px-2 py-2.5 text-sm focus:border-gray-400 focus:outline-none"
-            >
-              {Array.from({ length: 40 }, (_, i) => {
-                const h = Math.floor(i / 4) + 14; // 14:00 to 23:45
-                const m = (i % 4) * 15;
-                if (h >= 24) return null;
-                const val = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
-                return <option key={val} value={val}>{val}</option>;
-              })}
-            </select>
-            <select
-              value={guests}
-              onChange={(e) => setGuests(e.target.value)}
-              className="w-16 rounded-lg border border-gray-200 px-2 py-2.5 text-sm focus:border-gray-400 focus:outline-none"
-            >
-              {[1,2,3,4,5,6,7,8,10,12,15,20].map((n) => (
-                <option key={n} value={n}>{n}</option>
-              ))}
-            </select>
+      {/* Manual form — modern, English-only locale */}
+      {showForm && (() => {
+        const days = buildManualDayOptions();
+        const selected = days.find((d) => d.value === date) ?? days[0];
+        return (
+        <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm space-y-5">
+          <div className="flex items-baseline justify-between">
+            <p className="text-xs font-bold uppercase tracking-[0.18em] text-gray-400">Walk-in / phone</p>
+            <p className="text-[11px] text-gray-400">No SMS sent at save</p>
           </div>
-          <input
-            type="text"
-            placeholder="Note (optional)"
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:outline-none"
-          />
+
+          {/* Date — horizontal pill scroller, English locale */}
+          <div>
+            <div className="mb-2 flex items-baseline justify-between">
+              <label className="text-[11px] font-bold uppercase tracking-[0.16em] text-gray-500">Date</label>
+              <span className="text-[11px] text-gray-400">{selected.long}</span>
+            </div>
+            <div className="-mx-1 flex gap-1.5 overflow-x-auto pb-1 px-1" style={{ scrollbarWidth: "thin" }}>
+              {days.map((d) => {
+                const active = d.value === date;
+                return (
+                  <button
+                    key={d.value}
+                    type="button"
+                    onClick={() => !d.isClosed && setDate(d.value)}
+                    disabled={d.isClosed}
+                    title={d.isClosed ? "Closed on Mondays" : d.long}
+                    className={`flex-shrink-0 rounded-lg border px-3 py-2 text-center transition-all min-w-[58px] ${
+                      active
+                        ? "border-gray-900 bg-gray-900 text-white shadow-sm"
+                        : d.isClosed
+                        ? "border-gray-100 bg-gray-50 text-gray-300 cursor-not-allowed"
+                        : "border-gray-200 bg-white text-gray-700 hover:border-gray-400 hover:bg-gray-50"
+                    }`}
+                  >
+                    <div className={`text-[9px] font-semibold uppercase tracking-wider ${active ? "text-white/80" : "text-gray-400"}`}>
+                      {d.prefix || DAY_NAMES_EN[new Date(d.value + "T12:00:00Z").getUTCDay()]}
+                    </div>
+                    <div className="text-sm font-bold leading-tight mt-0.5">
+                      {new Date(d.value + "T12:00:00Z").getUTCDate()}
+                    </div>
+                    <div className={`text-[9px] mt-0.5 ${active ? "text-white/80" : "text-gray-400"}`}>
+                      {MONTH_NAMES_EN[new Date(d.value + "T12:00:00Z").getUTCMonth()]}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Time + Guests */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-2 block text-[11px] font-bold uppercase tracking-[0.16em] text-gray-500">Time</label>
+              <select
+                value={time}
+                onChange={(e) => setTime(e.target.value)}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm font-medium focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+              >
+                {Array.from({ length: 40 }, (_, i) => {
+                  const h = Math.floor(i / 4) + 14;
+                  const m = (i % 4) * 15;
+                  if (h >= 24) return null;
+                  const val = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+                  return <option key={val} value={val}>{val}</option>;
+                })}
+              </select>
+            </div>
+            <div>
+              <label className="mb-2 block text-[11px] font-bold uppercase tracking-[0.16em] text-gray-500">Guests</label>
+              <select
+                value={guests}
+                onChange={(e) => setGuests(e.target.value)}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm font-medium focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+              >
+                {[1,2,3,4,5,6,7,8,10,12,15,20].map((n) => (
+                  <option key={n} value={n}>{n} {n === 1 ? "guest" : "guests"}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Name */}
+          <div>
+            <label className="mb-2 block text-[11px] font-bold uppercase tracking-[0.16em] text-gray-500">Name</label>
+            <input
+              type="text"
+              placeholder="Guest name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/10 placeholder:text-gray-400"
+              autoFocus
+            />
+          </div>
+
+          {/* Phone (optional) */}
+          <div>
+            <label className="mb-2 block text-[11px] font-bold uppercase tracking-[0.16em] text-gray-500">
+              Phone <span className="font-normal normal-case tracking-normal text-gray-400">— optional</span>
+            </label>
+            <input
+              type="tel"
+              placeholder="+41 79 ..."
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/10 placeholder:text-gray-400"
+            />
+          </div>
+
+          {/* Note (optional) */}
+          <div>
+            <label className="mb-2 block text-[11px] font-bold uppercase tracking-[0.16em] text-gray-500">
+              Note <span className="font-normal normal-case tracking-normal text-gray-400">— optional</span>
+            </label>
+            <input
+              type="text"
+              placeholder="Birthday, outdoor seating, ..."
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/10 placeholder:text-gray-400"
+            />
+          </div>
+
           <button
             onClick={handleManualSave}
-            disabled={saving || !name.trim() || !date}
-            className="w-full rounded-lg bg-gray-900 py-2.5 text-sm font-semibold text-white disabled:opacity-40 transition-colors hover:bg-gray-800"
+            disabled={saving || !name.trim() || !date || selected.isClosed}
+            className="w-full rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white transition-all hover:bg-gray-800 active:scale-[0.99] disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            {saving ? "Saving..." : "Save"}
+            {saving ? "Saving..." : selected.isClosed ? "Closed on Mondays" : `Save reservation · ${selected.short} ${time}`}
           </button>
         </div>
-      )}
+        );
+      })()}
 
       {/* Reservations grouped by day */}
       {reservations.length === 0 && (


### PR DESCRIPTION
## Summary
Three founder-feedback fixes from live BigBen testing on 28.04. + a CI fix discovered via the post-merge smoke test.

**FB24 — premature confirmation SMS (critical)**
Submit was firing an SMS \"Paul will confirm shortly\" before Paul actually saw the request. Guests read it as confirmation, then got a second SMS when Paul tapped confirm. SMS at submit removed — only PATCH /reservations/[id] with status=confirmed fires the SMS now.

**FB22 — website reservation form**
Native \`<input type=\"date\">\` showed German weekday/month names regardless of site language (Swiss browser locale). Replaced with a horizontal English date-pill scroller (next 21 days, Mondays disabled). Typography + spacing pass.

**FB23 — Paul's walk-in form**
Same native-date issue inside the operator app. Same fix. Plus form fully in English, modern fields, button shows selected date+time inline.

**CI fix — Linux path**
\`bigben_voice_daily_refresh.mjs\` REPO_ROOT computation was Windows-only. Smoke test on main runner failed at \`ENOENT: src/web/.env.local\`. Switched to \`fileURLToPath\`.

## Test plan
- [ ] Website /bigben-pub reservation form: pill scroller in English, no submit-time SMS
- [ ] App /ops/reservations \`+ Add reservation\`: pill scroller in English, modern look
- [ ] Submit website reservation → no SMS arrives at guest until Paul confirms in app
- [ ] After merge: \`gh workflow run \"BigBen Voice Daily Refresh\"\` → green + Telegram success

🤖 Generated with [Claude Code](https://claude.com/claude-code)