### PR TITLE
fix(push): iOS App-Icon-Badge + tenant-agnostic Service Worker

### DIFF
--- a/src/web/app/api/bigben-pub/reserve/route.ts
+++ b/src/web/app/api/bigben-pub/reserve/route.ts
@@ -80,8 +80,17 @@ export async function POST(req: Request) {
       month: "long",
     });
 
-    // Push notification to Paul (no guest SMS — that fires only on confirm)
+    // Push notification to Paul (no guest SMS — that fires only on confirm).
+    // Counts pending reservations AFTER insert so the iOS App-Icon-Badge
+    // reflects the real "you have N waiting" state, not just +1 per push.
     if (tenant) {
+      const { count: pendingCount } = await supabase
+        .from("pub_reservations")
+        .select("id", { count: "exact", head: true })
+        .eq("tenant_id", tenant.id)
+        .eq("status", "pending");
+      const badgeCount = pendingCount ?? 1;
+
       import("@/src/lib/push/sendOpsPush").then(({ sendOpsPush }) =>
         sendOpsPush({
           tenantId: tenant.id,
@@ -90,6 +99,7 @@ export async function POST(req: Request) {
           body: `${name} — ${dateStr} at ${time}, ${guests} ${Number(guests) === 1 ? "guest" : "guests"}`,
           url: "/ops/reservations",
           tag: `reservation-${date}-${name}`,
+          badgeCount,
         })
       ).catch(() => {});
     }

--- a/src/web/app/api/bigben-pub/sync-calls/route.ts
+++ b/src/web/app/api/bigben-pub/sync-calls/route.ts
@@ -110,6 +110,12 @@ export async function GET() {
         synced++;
         try {
           const { sendOpsPush } = await import("@/src/lib/push/sendOpsPush");
+          // Count pending after insert for accurate App-Icon-Badge
+          const { count: pendingCount } = await supabase
+            .from("pub_reservations")
+            .select("id", { count: "exact", head: true })
+            .eq("tenant_id", tenant.id)
+            .eq("status", "pending");
           await sendOpsPush({
             tenantId: tenant.id,
             eventType: "case",
@@ -117,6 +123,7 @@ export async function GET() {
             body: `${guestName} · ${partySize} guests · ${time}`,
             url: "/ops/reservations",
             tag: `res-voice-${call.call_id}`,
+            badgeCount: pendingCount ?? 1,
           });
         } catch { /* best effort */ }
       }

--- a/src/web/public/sw.js
+++ b/src/web/public/sw.js
@@ -53,6 +53,10 @@ self.addEventListener("message", (event) => {
 });
 
 // ── Push Notifications ─────────────────────────────────────────────────────
+// Tenant-agnostisch: title + url + tag kommen aus payload (gesetzt vom Caller
+// in sendOpsPush). Fallback auf generic FlowSight-Branding wenn payload fehlt.
+// iOS App-Icon-Badge (die Zahl rechts oben) wird via navigator.setAppBadge
+// gesetzt — Paul-Feedback 28.04. PM. Erfordert iOS 16.4+ und PWA-Install.
 self.addEventListener("push", (event) => {
   if (!event.data) return;
 
@@ -67,32 +71,70 @@ self.addEventListener("push", (event) => {
     body: payload.body ?? "",
     icon: "/api/ceo/pwa/icon?size=192",
     badge: "/api/ceo/pwa/icon?size=96",
-    tag: payload.tag ?? "flowsight-ceo",
-    data: { url: payload.url ?? "/ceo/pulse" },
+    tag: payload.tag ?? "flowsight",
+    data: { url: payload.url ?? "/" },
     vibrate: [100, 50, 100],
   };
 
-  event.waitUntil(self.registration.showNotification(payload.title ?? "FlowSight CEO", options));
+  // App-Icon-Badge (number on icon). Server can pass payload.badgeCount,
+  // otherwise we increment by 1 each push. iOS clears on click.
+  const setBadge = async () => {
+    try {
+      if ("setAppBadge" in self.navigator) {
+        const count = typeof payload.badgeCount === "number"
+          ? payload.badgeCount
+          : 1;
+        await self.navigator.setAppBadge(count);
+      }
+    } catch { /* badge API unavailable, ignore */ }
+  };
+
+  event.waitUntil(Promise.all([
+    self.registration.showNotification(payload.title ?? "FlowSight", options),
+    setBadge(),
+  ]));
 });
 
 // ── Notification Click ─────────────────────────────────────────────────────
+// URL-aware tab focus: match the payload URL's base path (/ops, /ceo, /kunden,
+// etc.) instead of hardcoding /ceo. Then clear the app-icon-badge — Paul
+// tapped, so the "you have new" signal can go away.
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
 
-  const url = event.notification.data?.url ?? "/ceo/pulse";
+  const url = event.notification.data?.url ?? "/";
+  const basePath = url.split("/")[1] || "";  // "/ops/reservations" → "ops"
+
+  const clearBadge = async () => {
+    try {
+      if ("clearAppBadge" in self.navigator) {
+        await self.navigator.clearAppBadge();
+      }
+    } catch { /* ignore */ }
+  };
 
   event.waitUntil(
-    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
-      // Focus existing CEO tab if open
-      for (const client of clients) {
-        if (client.url.includes("/ceo") && "focus" in client) {
-          client.navigate(url);
-          return client.focus();
+    Promise.all([
+      clearBadge(),
+      self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+        // Prefer existing tab on the same base path (e.g. another /ops/* tab)
+        for (const client of clients) {
+          if (basePath && client.url.includes("/" + basePath + "/") && "focus" in client) {
+            client.navigate(url);
+            return client.focus();
+          }
         }
-      }
-      // Open new tab
-      return self.clients.openWindow(url);
-    })
+        // Otherwise: any tab from same origin, navigate it
+        for (const client of clients) {
+          if ("focus" in client) {
+            client.navigate(url);
+            return client.focus();
+          }
+        }
+        // No open tab: open new
+        return self.clients.openWindow(url);
+      }),
+    ])
   );
 });
 

--- a/src/web/src/lib/push/sendOpsPush.ts
+++ b/src/web/src/lib/push/sendOpsPush.ts
@@ -15,6 +15,11 @@ export async function sendOpsPush(opts: {
   body: string;
   url?: string;
   tag?: string;
+  /** App-Icon-Badge count (iOS 16.4+, PWA installed). When set, the SW will
+   *  call navigator.setAppBadge(badgeCount) on receive. Caller should pass the
+   *  current count of pending items (e.g. pending_reservations) so the badge
+   *  reflects state, not a per-event +1. */
+  badgeCount?: number;
   targetUserId?: string;
 }): Promise<{ sent: number; failed: number }> {
   try {
@@ -61,6 +66,7 @@ export async function sendOpsPush(opts: {
       body: opts.body,
       url: opts.url ?? "/ops/cases",
       tag: opts.tag,
+      badgeCount: opts.badgeCount,
     });
 
     let sent = 0;


### PR DESCRIPTION
## Trigger
Pauls Feedback aus dem Termin: "Ich hätte gerne wirklich, dass wenn eine Reservierungsanfrage reinkommt, dass dann eine Zahl rechts oben im Icon steht, 1, 2, 5". Verified: \`navigator.setAppBadge()\` wurde nie gerufen.

## Was drin ist
- **Service Worker:** \`navigator.setAppBadge(badgeCount)\` on push, \`clearAppBadge()\` on click, URL-aware Tab-Focus, generic FlowSight-Fallback statt CEO-spezifisch
- **sendOpsPush:** neuer optionaler \`badgeCount\` Parameter
- **/api/bigben-pub/reserve + /sync-calls:** zählen pending nach Insert, übergeben als badgeCount

## iOS-Vorbedingungen für Badge
- iOS 16.4+ ist Pflicht
- App muss als PWA installiert sein (Home-Screen) — sonst no-op

Falls eine der Bedingungen fehlt: Badge wird ignoriert, normale Push-Notification (Swipe-Down) kommt weiterhin.

## Test plan
- [ ] Auf installierter PWA: neue Test-Reservation auslösen → App-Icon zeigt "1"
- [ ] Zweite Reservation → "2"
- [ ] Notification antippen → Badge weg
- [ ] Klick navigiert zur richtigen URL (\`/ops/reservations\`, nicht \`/ceo/pulse\`)
- [ ] Bestehender Tab wird gefocused statt neuer geöffnet (Same-base-path-Match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)