### PR TITLE
fix(bigben): FB29 — PWA module-aware start_url + cases guard

### DIFF
--- a/src/web/app/api/ops/pwa/manifest/route.ts
+++ b/src/web/app/api/ops/pwa/manifest/route.ts
@@ -1,4 +1,5 @@
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
+import { getServiceClient } from "@/src/lib/supabase/server";
 import { resolveTenantIdentity } from "@/src/lib/tenants/resolveTenantIdentity";
 
 /**
@@ -9,10 +10,16 @@ import { resolveTenantIdentity } from "@/src/lib/tenants/resolveTenantIdentity";
  * not "FlowSight". Identity Contract R4 compliance.
  *
  * Fallback for unauthenticated: generic "Leitsystem".
+ *
+ * start_url is tenant-module-aware: Pub tenants land on /ops/pub-dashboard,
+ * not the Sanitär /ops/cases surface (FB29 — Paul opened the PWA from the
+ * home screen and saw the Sanitär Leitsystem with "Guten Abend, Big" header).
  */
 export async function GET(request: Request) {
   let name = "Leitsystem";
   let shortName = "Leitsystem";
+  let startUrl = "/ops/cases";
+  let description = "Fälle, Termine und Team auf einen Blick.";
 
   // Support ?tenant=UUID for per-tenant PWA installation (from /ops/app/[slug])
   const { searchParams } = new URL(request.url);
@@ -26,6 +33,21 @@ export async function GET(request: Request) {
       if (identity) {
         shortName = identity.leitsystemName;
         name = `${identity.leitsystemName} Leitsystem`;
+      }
+
+      // Module-aware start_url: pubs go to /ops/pub-dashboard so the home-screen
+      // icon never opens the Sanitär Leitsystem (FB29).
+      const supabase = getServiceClient();
+      const { data: tenant } = await supabase
+        .from("tenants")
+        .select("modules")
+        .eq("id", tenantIdParam)
+        .single();
+      const modules = (tenant?.modules ?? {}) as Record<string, unknown>;
+      const isPub = Boolean(modules.events) || Boolean(modules.reservations);
+      if (isPub) {
+        startUrl = "/ops/pub-dashboard";
+        description = "Reservierungen, Events und Gäste auf einen Blick.";
       }
     } else {
       // Default: resolve from auth session
@@ -49,8 +71,8 @@ export async function GET(request: Request) {
   const manifest = {
     name,
     short_name: shortName,
-    description: "Fälle, Termine und Team auf einen Blick.",
-    start_url: "/ops/cases",
+    description,
+    start_url: startUrl,
     scope: "/ops",
     display: "standalone" as const,
     display_override: ["standalone"],

--- a/src/web/app/ops/(dashboard)/cases/page.tsx
+++ b/src/web/app/ops/(dashboard)/cases/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { getServiceClient } from "@/src/lib/supabase/server";
 import { resolveTenantScope } from "@/src/lib/supabase/resolveTenantScope";
 import { getAuthClient } from "@/src/lib/supabase/server-auth";
@@ -22,6 +23,22 @@ export default async function OpsCasesPage({
 
   const supabase = getServiceClient();
   const scope = await resolveTenantScope();
+
+  // FB29 defensive guard: if the active tenant is a Pub (events/reservations
+  // module), bounce to /ops/pub-dashboard. This catches stale browser cache,
+  // shared links, and any path that bypasses the manifest start_url change.
+  // Without this, Paul could still see "Guten Abend, Big" + Sanitär KPIs.
+  if (scope?.tenantId) {
+    const { data: tenantModuleCheck } = await supabase
+      .from("tenants")
+      .select("modules")
+      .eq("id", scope.tenantId)
+      .single();
+    const mods = (tenantModuleCheck?.modules ?? {}) as Record<string, unknown>;
+    if (Boolean(mods.events) || Boolean(mods.reservations)) {
+      redirect("/ops/pub-dashboard");
+    }
+  }
 
   // ── Tenant scope (ALWAYS filter when tenantId present — even for admins)
   // Prevents tenant identity leak: Weinberger Leitstand must never show Brunner cases.


### PR DESCRIPTION
## Summary
- Manifest's start_url now resolves per tenant-module: Pub-Tenants (events/reservations) → \`/ops/pub-dashboard\`, Sanitär bleibt \`/ops/cases\`. Beim PWA-Launch vom Home-Screen landet Paul direkt auf der richtigen Surface.
- Defensive Guard in \`/ops/cases\`: Cookie zeigt auf Pub-Tenant → Server-Redirect zu \`/ops/pub-dashboard\` bevor Daten geladen werden. Schutz gegen stale Cache, geteilte Links, getippte URLs.

## Test plan
- [ ] Paul installiert PWA neu via \`/ops/app/bigben-pub\` → Home-Screen-Icon antippen → erwartet: pub-dashboard mit 6 Cards (NICHT "Guten Abend, Big" + NEU/BEI UNS)
- [ ] Direkt \`/ops/cases\` aufrufen mit BigBen-Cookie → Redirect zu \`/ops/pub-dashboard\`
- [ ] Sanitär-Tenant (Dörfler) /ops/cases → Sanitär-Leitsystem (kein Redirect)
- [ ] Manifest debug: \`curl https://flowsight.ch/api/ops/pwa/manifest?tenant=<bigben-id>\` → \`start_url: /ops/pub-dashboard\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)