### PR TITLE
fix(bigben): FB28 — kill banner after push activation, move status to header

### DIFF
--- a/src/web/app/ops/(dashboard)/help/page.tsx
+++ b/src/web/app/ops/(dashboard)/help/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { PushTestCard } from "@/src/components/ops/PushTestCard";
 
 const FAQ_ITEMS = [
   {
@@ -77,6 +78,11 @@ export default function HelpPage() {
           </a>
         </div>
       </div>
+
+      {/* Notifications — moved here from the dashboard banner so the dashboard
+          stays clean once activation is done. The "Send test" path lives here
+          for onboarding diagnostics. */}
+      <PushTestCard />
 
       {/* FAQ */}
       <div className="bg-white border border-gray-200 rounded-2xl shadow-sm divide-y divide-gray-100">

--- a/src/web/app/ops/(dashboard)/pub-dashboard/PubDashboard.tsx
+++ b/src/web/app/ops/(dashboard)/pub-dashboard/PubDashboard.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { PushEnableCard } from "@/src/components/ops/PushEnableCard";
+import { PushStatusIndicator } from "@/src/components/ops/PushStatusIndicator";
 
 interface TodayEvent {
   id: string;
@@ -95,13 +96,17 @@ export function PubDashboard({
       {/* Header */}
       <div>
         <h1 className="text-lg font-bold text-gray-900">{tenantName}</h1>
-        <p className="text-xs text-gray-400">
-          {new Date().toLocaleDateString("en-GB", { weekday: "long", day: "numeric", month: "long", year: "numeric", timeZone: "Europe/Zurich" })}
-        </p>
+        <div className="mt-0.5 flex items-center gap-2">
+          <p className="text-xs text-gray-400">
+            {new Date().toLocaleDateString("en-GB", { weekday: "long", day: "numeric", month: "long", year: "numeric", timeZone: "Europe/Zurich" })}
+          </p>
+          <PushStatusIndicator />
+        </div>
       </div>
 
-      {/* Push enable card — visible until user has subscribed. Once active,
-          shows a "Send test" link so we can verify end-to-end during onboarding. */}
+      {/* Push enable card — only visible while NOT subscribed. Once active
+          the card returns null; status moves to PushStatusIndicator above
+          and the test path lives on /ops/help (FB28). */}
       <PushEnableCard />
 
       {/* ── PENDING RESERVATIONS (compact alert) ──────── */}

--- a/src/web/src/components/ops/PushEnableCard.tsx
+++ b/src/web/src/components/ops/PushEnableCard.tsx
@@ -3,11 +3,11 @@
 import { useEffect, useState } from "react";
 
 /**
- * Persistent Push-Activation card for the Pub-Dashboard. Replaces reliance
- * on the one-shot PushOnboardingBanner — this card is ALWAYS visible until
- * the user has actually subscribed. Lets Paul (or founder) enable push at
- * any time, and offers a "Send test" so we can verify end-to-end during
- * onboarding.
+ * Activation card for the Pub-Dashboard. Renders ONLY while push has not been
+ * subscribed yet (or was denied / unsupported). Once active, returns null —
+ * no permanent banner above the dashboard. Status feedback moves into the
+ * header (PushStatusIndicator), and the "Send test" path lives on /ops/help
+ * (PushTestCard) so the founder can still verify delivery end-to-end.
  *
  * iOS quirk: Web Push only works on iOS 16.4+ AND the app must be installed
  * to the home screen (PWA). We surface that hint inline.
@@ -17,7 +17,6 @@ export function PushEnableCard() {
     "loading",
   );
   const [busy, setBusy] = useState(false);
-  const [testStatus, setTestStatus] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -27,12 +26,11 @@ export function PushEnableCard() {
     }
     const perm = Notification.permission;
     if (perm === "denied") { setState("denied"); return; }
-    // Check if we already have an active subscription
     (async () => {
       try {
         const reg = await navigator.serviceWorker.ready;
         const sub = await reg.pushManager.getSubscription();
-        setState(sub ? "subscribed" : (perm === "granted" ? "prompt" : "prompt"));
+        setState(sub ? "subscribed" : "prompt");
       } catch {
         setState("prompt");
       }
@@ -72,26 +70,8 @@ export function PushEnableCard() {
     }
   }
 
-  async function sendTest() {
-    setBusy(true);
-    setTestStatus(null);
-    try {
-      const res = await fetch("/api/ops/push/send-test", { method: "POST" });
-      const data = await res.json().catch(() => ({}));
-      if (res.ok) {
-        setTestStatus(`✓ Sent — check your phone (${data.sent ?? 0} delivered)`);
-      } else {
-        setTestStatus(`Failed: ${data.error ?? res.status}`);
-      }
-    } catch (err) {
-      setTestStatus(`Failed: ${(err as Error).message}`);
-    } finally {
-      setBusy(false);
-      setTimeout(() => setTestStatus(null), 8000);
-    }
-  }
-
   if (state === "loading") return null;
+  if (state === "subscribed") return null;
   if (state === "unsupported") {
     return (
       <div className="rounded-2xl border border-gray-100 bg-white p-4 shadow-sm">
@@ -109,31 +89,6 @@ export function PushEnableCard() {
         <p className="mt-2 text-sm text-amber-700">
           Push permission was denied. Open your browser/system settings and enable notifications for this app, then reload.
         </p>
-      </div>
-    );
-  }
-  if (state === "subscribed") {
-    return (
-      <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4 shadow-sm">
-        <div className="flex items-start gap-3">
-          <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100">
-            <svg className="h-5 w-5 text-emerald-600" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
-            </svg>
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-semibold text-emerald-900">Notifications active</p>
-            <p className="text-xs text-emerald-700 mt-0.5">You&apos;ll get a push when a new reservation comes in.</p>
-            <button
-              onClick={sendTest}
-              disabled={busy}
-              className="mt-2 text-xs font-medium text-emerald-700 hover:text-emerald-900 underline disabled:opacity-50"
-            >
-              {busy ? "Sending…" : "Send test notification"}
-            </button>
-            {testStatus && <p className="mt-1 text-[11px] text-emerald-700">{testStatus}</p>}
-          </div>
-        </div>
       </div>
     );
   }

--- a/src/web/src/components/ops/PushStatusIndicator.tsx
+++ b/src/web/src/components/ops/PushStatusIndicator.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Tiny inline bell-with-check that renders ONLY when push is subscribed.
+ * Sits next to the dashboard date so Paul sees at a glance that pushes
+ * are active — without a permanent banner stealing vertical space (FB28).
+ *
+ * Renders nothing (null) in any other state. The full activation card lives
+ * on the dashboard (PushEnableCard, prompt-state) until subscribed.
+ */
+export function PushStatusIndicator() {
+  const [subscribed, setSubscribed] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator) || !("PushManager" in window)) return;
+    if (Notification.permission !== "granted") return;
+    (async () => {
+      try {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        setSubscribed(Boolean(sub));
+      } catch {
+        /* keep false */
+      }
+    })();
+  }, []);
+
+  if (!subscribed) return null;
+
+  return (
+    <span
+      title="Notifications active"
+      className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700"
+    >
+      <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
+      </svg>
+      <span className="leading-none">on</span>
+    </span>
+  );
+}

--- a/src/web/src/components/ops/PushTestCard.tsx
+++ b/src/web/src/components/ops/PushTestCard.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Notifications section on the help page. Shows current subscription state
+ * and a "Send test notification" button (founder/onboarding diagnostic path).
+ * Lives on /ops/help — never on the main dashboard, where it stole vertical
+ * space as a permanent green banner (FB28).
+ */
+export function PushTestCard() {
+  const [state, setState] = useState<"loading" | "unsupported" | "denied" | "prompt" | "subscribed">("loading");
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+      setState("unsupported");
+      return;
+    }
+    const perm = Notification.permission;
+    if (perm === "denied") { setState("denied"); return; }
+    (async () => {
+      try {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        setState(sub ? "subscribed" : "prompt");
+      } catch {
+        setState("prompt");
+      }
+    })();
+  }, []);
+
+  async function sendTest() {
+    setBusy(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/api/ops/push/send-test", { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        setStatus(`Sent — check your phone (${data.sent ?? 0} delivered)`);
+      } else {
+        setStatus(`Failed: ${data.error ?? res.status}`);
+      }
+    } catch (err) {
+      setStatus(`Failed: ${(err as Error).message}`);
+    } finally {
+      setBusy(false);
+      setTimeout(() => setStatus(null), 8000);
+    }
+  }
+
+  if (state === "loading") return null;
+
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <h2 className="text-base font-bold text-gray-900">Notifications</h2>
+
+      {state === "subscribed" && (
+        <>
+          <p className="mt-2 text-sm text-gray-600">
+            Push notifications are active. You&apos;ll get an alert when a new reservation comes in.
+          </p>
+          <button
+            onClick={sendTest}
+            disabled={busy}
+            className="mt-4 rounded-lg bg-gray-900 px-4 py-2 text-xs font-semibold text-white hover:bg-gray-800 disabled:opacity-50 transition-colors"
+          >
+            {busy ? "Sending…" : "Send test notification"}
+          </button>
+          {status && <p className="mt-2 text-xs text-gray-600">{status}</p>}
+        </>
+      )}
+
+      {state === "prompt" && (
+        <p className="mt-2 text-sm text-gray-600">
+          Notifications are not enabled yet. Open the dashboard and tap “Enable notifications”.
+        </p>
+      )}
+
+      {state === "denied" && (
+        <p className="mt-2 text-sm text-amber-700">
+          Push permission was denied. Open your browser or system settings, allow notifications for this app, and reload.
+        </p>
+      )}
+
+      {state === "unsupported" && (
+        <p className="mt-2 text-sm text-gray-600">
+          Push is not supported in this browser. On iPhone: install the app to your home screen first.
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Banner weg:** PushEnableCard subscribed-State → \`return null\`. Pauls Dashboard ist nach Aktivierung sauber — keine permanente Card mehr über den 6 KPI-Cards.
- **Status im Header:** Mini Bell-✓ Pill (\`PushStatusIndicator\`) inline neben dem Datum — rendert nur bei subscribed, sonst null.
- **Test-Pfad in /ops/help:** \`PushTestCard\` mit Send-Test-Button bleibt für Onboarding/Diagnose erhalten, nur woanders (nicht mehr Hauptscreen).

## Test plan
- [ ] Pub-Dashboard mit Paul-Account (subscribed) öffnen → kein Banner mehr, stattdessen kleine "🔔 on" Pill neben dem Datum
- [ ] Pub-Dashboard ohne Push-Subscription → existierende Activation-Card sichtbar (prompt-state)
- [ ] /ops/help öffnen → "Notifications" Section mit Status + "Send test notification" Button
- [ ] Test-Button → Push landet auf Pauls iPhone
- [ ] Notifications denied/unsupported States rendern korrekte Hinweise (nicht null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)